### PR TITLE
Feature: Adds autocomplete slot support to taginput

### DIFF
--- a/docs/pages/components/taginput/Taginput.vue
+++ b/docs/pages/components/taginput/Taginput.vue
@@ -13,6 +13,12 @@
             </p>
         </Example>
 
+        <Example :component="ExTemplatedAutocomplete" :code="ExTemplatedAutocompleteCode" title="Templated Autocomplete" vertical>
+            <p>
+                Slots are available for autocomplete items and the empty message, like with the <router-link to="/documentation/autocomplete">Autocomplete</router-link> control.
+            </p>
+        </Example>
+
         <Example :component="ExLimit" :code="ExLimitCode" title="Limits" vertical>
             <p>
                 You can limit the length and number of tags with the <code>maxlength</code> and <code>maxtags</code> props.
@@ -45,6 +51,9 @@
     import ExAutocomplete from './examples/ExAutocomplete'
     import ExAutocompleteCode from '!!raw-loader!./examples/ExAutocomplete'
 
+    import ExTemplatedAutocomplete from './examples/ExTemplatedAutocomplete'
+    import ExTemplatedAutocompleteCode from '!!raw-loader!./examples/ExTemplatedAutocomplete'
+
     import ExLimit from './examples/ExLimit'
     import ExLimitCode from '!!raw-loader!./examples/ExLimit'
 
@@ -66,6 +75,7 @@
                 api,
                 ExSimple,
                 ExAutocomplete,
+                ExTemplatedAutocomplete,
                 ExLimit,
                 ExState,
                 ExType,
@@ -73,6 +83,7 @@
                 ExModifier,
                 ExSimpleCode,
                 ExAutocompleteCode,
+                ExTemplatedAutocompleteCode,
                 ExLimitCode,
                 ExStateCode,
                 ExTypeCode,

--- a/docs/pages/components/taginput/api/taginput.js
+++ b/docs/pages/components/taginput/api/taginput.js
@@ -75,6 +75,18 @@ export default [
                 default: '—'
             }
         ],
+        slots: [
+            {
+                name: 'default',
+                description: '',
+                props: '<code>option: String|Object</code>, <code>index: Number</code>'
+            },
+            {
+                name: '<code>empty</code>',
+                description: 'Show like an option if <code>data</code> array prop is empty',
+                props: '—'
+            }
+        ],
         events: [
             {
                 name: '<code>input</code>',

--- a/docs/pages/components/taginput/examples/ExTemplatedAutocomplete.vue
+++ b/docs/pages/components/taginput/examples/ExTemplatedAutocomplete.vue
@@ -1,0 +1,47 @@
+<template>
+    <section>
+        <b-field label="Enter some tags">
+            <b-taginput
+                v-model="tags"
+                :data="filteredTags"
+                autocomplete
+                field="user.first_name"
+                icon="label"
+                placeholder="Add a tag"
+                @typing="getFilteredTags">
+                <template slot-scope="props">
+                    <strong>{{props.option.id}}</strong>: {{props.option.user.first_name}}
+                </template>
+                <template slot="empty">
+                    There are no items
+                </template>
+            </b-taginput>
+        </b-field>
+        <pre style="max-height: 400px"><b>Tags:</b>{{ tags }}</pre>
+    </section>
+</template>
+
+<script>
+    const data = require('@/assets/data_test.json')
+
+    export default {
+        data() {
+            return {
+                filteredTags: data,
+                isSelectOnly: false,
+                tags: []
+            }
+        },
+        methods: {
+            getFilteredTags(text) {
+                this.filteredTags = data.filter((option) => {
+                    return option.user.first_name
+                        .toString()
+                        .toLowerCase()
+                        .indexOf(text.toLowerCase()) >= 0
+                })
+            }
+        }
+    }
+</script>
+

--- a/src/components/taginput/Taginput.vue
+++ b/src/components/taginput/Taginput.vue
@@ -37,7 +37,18 @@
                 @focus="onFocus"
                 @blur="customOnBlur"
                 @keydown.native="keydown"
-                @select="onSelect"/>
+                @select="onSelect">
+                <template
+                    :slot="defaultSlotName"
+                    slot-scope="props">
+                    <slot
+                        :option="props.option"
+                        :index="props.index" />
+                </template>
+                <template :slot="emptySlotName">
+                    <slot name="empty" />
+                </template>
+            </b-autocomplete>
         </div>
 
         <p v-if="maxtags || maxlength" class="help counter">
@@ -116,6 +127,22 @@
 
             valueLength() {
                 return this.newTag.trim().length
+            },
+
+            defaultSlotName() {
+                return this.hasDefaultSlot ? 'default' : 'dontrender'
+            },
+
+            emptySlotName() {
+                return this.hasEmptySlot ? 'empty' : 'dontrender'
+            },
+
+            hasDefaultSlot() {
+                return !!this.$scopedSlots.default
+            },
+
+            hasEmptySlot() {
+                return !!this.$slots.empty
             },
 
             /**


### PR DESCRIPTION
Brings feature parity between taginput and autocomplete by passing taginput's slots through to the underlying autocomplete.

![image](https://user-images.githubusercontent.com/130231/34505887-e74d9f9c-f073-11e7-8ccd-b7bf8b9532c6.png)

![image](https://user-images.githubusercontent.com/130231/34505883-e3b3ea6c-f073-11e7-937d-697d0ad4522b.png)
