### PR TITLE
Required is optional for Prompt

### DIFF
--- a/src/components/dialog/Dialog.vue
+++ b/src/components/dialog/Dialog.vue
@@ -31,7 +31,6 @@
                                         v-model="prompt"
                                         class="input"
                                         ref="input"
-                                        required
                                         :class="{ 'is-danger': validationMessage }"
                                         v-bind="inputAttrs"
                                         @keyup.enter="confirm">
@@ -105,7 +104,7 @@
             hasInput: Boolean, // Used internally to know if it's prompt
             inputAttrs: {
                 type: Object,
-                default: () => {}
+                default: () => ({})
             },
             onConfirm: {
                 type: Function,
@@ -183,6 +182,10 @@
         },
         mounted() {
             this.isActive = true
+
+            if (typeof this.inputAttrs.required === 'undefined') {
+                this.$set(this.inputAttrs, 'required', true);
+            }
 
             this.$nextTick(() => {
                 // Handle which element receives focus


### PR DESCRIPTION
This makes the "required" attribute on a prompt input overridable through the inputAttrs object.

Our use case is that on a user action we want to prompt the user to input an optional comment.

Also, for what it's worth, according to [the arrow function docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#Returning_object_literals), using `() => {}` actually returns undefined. I believe the intention is to have `inputAttrs` default to an empty object, so you need to wrap the object literal in parenthesis `() => ({})`. There are a few other instances of `() => {}` being used within the project but I'm not sure what their intention is.