### PR TITLE
Snackbar - bind class type to main div to be able to customize styles

### DIFF
--- a/docs/pages/components/snackbar/api/snackbar.js
+++ b/docs/pages/components/snackbar/api/snackbar.js
@@ -3,7 +3,7 @@ export default [
         props: [
             {
                 name: '<code>type</code>',
-                description: 'Type (color) of the action button',
+                description: 'Type (color) of the action button but also the name of the parent class',
                 type: 'String',
                 values: `<code>is-white</code>, <code>is-black</code>, <code>is-light</code>,
                     <code>is-dark</code>, <code>is-primary</code>, <code>is-info</code>, <code>is-success</code>,

--- a/docs/pages/components/snackbar/api/snackbar.js
+++ b/docs/pages/components/snackbar/api/snackbar.js
@@ -3,7 +3,7 @@ export default [
         props: [
             {
                 name: '<code>type</code>',
-                description: 'Type (color) of the action button but also the name of the parent class',
+                description: 'Type (color) of the action button. Please notice that it is the name of the parent class also',
                 type: 'String',
                 values: `<code>is-white</code>, <code>is-black</code>, <code>is-light</code>,
                     <code>is-dark</code>, <code>is-primary</code>, <code>is-info</code>, <code>is-success</code>,

--- a/src/components/snackbar/Snackbar.vue
+++ b/src/components/snackbar/Snackbar.vue
@@ -5,7 +5,7 @@
         <div
             v-show="isActive"
             class="snackbar"
-            :class="position">
+            :class="[position,type]">
             <p class="text">{{ message }}</p>
             <div
                 v-if="actionText"

--- a/src/components/snackbar/Snackbar.vue
+++ b/src/components/snackbar/Snackbar.vue
@@ -5,7 +5,7 @@
         <div
             v-show="isActive"
             class="snackbar"
-            :class="[position,type]">
+            :class="[type,position]">
             <p class="text">{{ message }}</p>
             <div
                 v-if="actionText"


### PR DESCRIPTION
Bind `type` as the class in `Snackbar.vue` to main div to be able to customize styles of different level snackbars (ex. `is-warning`, `is-success`)

Currently I didn't found solution to customize snackbar styles depends on type (like `is-warning `, `is-success`. 

Dialog seems a bit overkill for the task and toast doesn't have button action ( but have the same changes in `Toast.vue` component what I propose).  

