### PR TITLE
Field | fix rounded with dynamic addons

### DIFF
--- a/src/components/field/Field.vue
+++ b/src/components/field/Field.vue
@@ -101,9 +101,13 @@
             fieldType() {
                 if (this.grouped) return 'is-grouped'
 
+                let renderedNode = 0
+                if (this.$slots.default) {
+                    renderedNode = this.$slots.default
+                                        .reduce((i, node) => node.tag ? i + 1 : i, 0)
+                }
                 if (
-                    this.$slots.default !== undefined &&
-                    this.$slots.default.length > 1 &&
+                    renderedNode > 1 &&
                     this.addons &&
                     !this.horizontal
                 ) {


### PR DESCRIPTION
When having addons dynamically displayed, rounded field behavior isn't correct.

Example : https://jsfiddle.net/j9jp0kq0/1/