### PR TITLE
Add support for classes is-* in tables

### DIFF
--- a/src/scss/components/_table.scss
+++ b/src/scss/components/_table.scss
@@ -140,8 +140,8 @@
                     &:not(:last-child) {
                         margin-bottom: 1rem;
                     }
-                    // Disables is-striped
-                    &:not(.is-selected) {
+                    // Disables is-*
+                    &:not([class*="is-"]) {
                         background: inherit;
                         &:hover {
                             background-color: inherit;


### PR DESCRIPTION
Look this the problem: https://codepen.io/brunoosilva/pen/LQBwex

Only `table` have the class `is-striped`