### PR TITLE
Add clearOnSelect prop to Autocomplete.vue

### DIFF
--- a/docs/pages/components/autocomplete/api/autocomplete.js
+++ b/docs/pages/components/autocomplete/api/autocomplete.js
@@ -23,6 +23,13 @@ export default [
                 default: '<code>value</code>'
             },
             {
+                name: '<code>clear-on-select</code>',
+                description: 'Clear input text on select',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
                 name: '<code>open-on-focus</code>',
                 description: 'Open dropdown list on focus',
                 type: 'Boolean',

--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -75,6 +75,7 @@
                 default: 'value'
             },
             keepFirst: Boolean,
+            clearOnSelect: Boolean,
             openOnFocus: Boolean
         },
         data() {
@@ -198,7 +199,7 @@
                 this.selected = option
                 this.$emit('select', this.selected)
                 if (this.selected !== null) {
-                    this.newValue = this.getValue(this.selected)
+                    this.newValue = this.clearOnSelect ? '' : this.getValue(this.selected)
                 }
                 closeDropdown && this.$nextTick(() => { this.isActive = false })
             },


### PR DESCRIPTION
**REASON TO ADD THIS:**

In my project I have a search bar to find users where I use `b-autocomplete`.

In this case, autocomplete handles an array of user **objects**.

When the `select` event is triggered, the page goes directly to the profile of the selected user.

**Preserving/completing the input value is unnecessary in this situation, I just want to reset it to '' (empty string).** Also I think this is a fairly common use-case.

If I don't specify a `field` to be displayed from the object, autocomplete emits (input event) `undefined` as the new value.

*This causes errors in my code because I expect my search value to always be a string.*