### PR TITLE
Add aria attributes to Tabs and TabItems components

### DIFF
--- a/docs/pages/components/tabs/api/tabs.js
+++ b/docs/pages/components/tabs/api/tabs.js
@@ -90,6 +90,13 @@ export default [
                 type: 'Boolean',
                 values: '-',
                 default: 'true'
+            },
+            {
+                name: '<code>id</code>',
+                description: 'Optional id for <i>aria-control</i>',
+                type: 'String',
+                values: '-',
+                default: '-'
             }
         ]
     }

--- a/src/components/tabs/TabItem.vue
+++ b/src/components/tabs/TabItem.vue
@@ -1,6 +1,11 @@
 <template>
     <transition :name="transitionName">
-        <div v-show="isActive && visible" class="tab-item">
+        <div
+            v-show="isActive && visible"
+            class="tab-item"
+            role="tabpanel"
+            :id="id"
+            :aria-hidden="!isActive || !visible">
             <slot/>
         </div>
     </transition>
@@ -17,7 +22,8 @@
             visible: {
                 type: Boolean,
                 default: true
-            }
+            },
+            id: ''
         },
         data() {
             return {

--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -4,6 +4,7 @@
             <ul role="tablist">
                 <li
                     role="presentation"
+                    :tabindex="tabItem.visible && !tabItem.disabled ? 0 : -1"
                     v-for="(tabItem, index) in tabItems"
                     :key="index"
                     v-show="tabItem.visible"

--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -1,13 +1,18 @@
 <template>
     <div class="b-tabs" :class="{ 'is-fullwidth': expanded }">
         <nav class="tabs" :class="navClasses">
-            <ul>
+            <ul role="tablist">
                 <li
+                    role="presentation"
                     v-for="(tabItem, index) in tabItems"
                     :key="index"
                     v-show="tabItem.visible"
                     :class="{ 'is-active': newValue === index, 'is-disabled': tabItem.disabled }">
-                    <a @click="tabClick(index)">
+                    <a
+                        @click="tabClick(index)"
+                        role="tab"
+                        :aria-controls="tabItem.id"
+                        :aria-selected="tabItem.visible">
                         <b-icon
                             v-if="tabItem.icon"
                             :icon="tabItem.icon"


### PR DESCRIPTION
Hi there!

Continuing the discussion in Ref. #576 and Ref. #608, I'm planning to help a bit with Aria attributes and keyboards navigation. Here, as a _first-try_, I add `role`, `aria-controls`, `aria-selected` and  `tabindex` to allow proper navigation and feedback for Tabs; and `role`, `aria-hidden` and an `id` for TabItem.

The `id` is the tricky part, I'm not sure if it goes well with the way you're planning your library. As I described in the docs, it would be an optional `props` for TabItem. Maybe we can be more specific labeling it `ariaId`? I'm not sure. Fact is, if you do plan on providing accessibility for other components, we would need to offer this ID solution in other components, as it is the way ARIA navigates through the accessibility tree.

I'm not an expert in the accessibility issue, but I'm planning on studying and implementing other cases if you're interested, as I'm using Buefy in a big project and this is a key feature for us. Thanks in anyways for all you've being doing here, it's great!