### PR TITLE
Do not parse value with type number in helper escapeRegExpChars

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -83,6 +83,7 @@ export function removeElement(el) {
  */
 export function escapeRegExpChars(value) {
     if (!value) return value
+    if (typeof(value) === 'number') return value
 
     // eslint-disable-next-line
     return value.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&')

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -83,7 +83,7 @@ export function removeElement(el) {
  */
 export function escapeRegExpChars(value) {
     if (!value) return value
-    if (typeof(value) === 'number') return value
+    if (typeof value === 'number') return value
 
     // eslint-disable-next-line
     return value.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&')


### PR DESCRIPTION
Method .replace() does not exist of type number.
https://github.com/buefy/buefy/issues/656