### PR TITLE
Convert a value to string before getting its length

### DIFF
--- a/src/components/input/Input.vue
+++ b/src/components/input/Input.vue
@@ -153,7 +153,7 @@
              * Get value length
              */
             valueLength() {
-                return this.newValue ? this.newValue.length : 0
+                return this.newValue ? ('' + this.newValue).length : 0
             }
         },
         watch: {


### PR DESCRIPTION
The `maxlength` property (character counter) is not working correctly when you add the number modifier to your `v-model` managed input. Effect:

```
<b-input type="number" v-model.number="age" maxlength="2"></b-input>
```
![zrzut ekranu z 2018-03-04 13-37-37](https://user-images.githubusercontent.com/11018286/36945635-a0687f62-1fb1-11e8-8357-188fa699a0da.png)
