### PR TITLE
TagInput | fix onblur event if tag is added onblur

### DIFF
--- a/src/components/taginput/Taginput.vue
+++ b/src/components/taginput/Taginput.vue
@@ -173,10 +173,10 @@
             },
 
             customOnBlur($event) {
-                this.onBlur($event)
-
                 // Add tag on-blur if not select only
                 if (!this.autocomplete) this.addTag()
+
+                this.onBlur($event)
             },
 
             onSelect(option) {


### PR DESCRIPTION
When leaving input not empty, it adds automatically a tag. However, the `onblur` event is emitted before adding this tag hence it doesn't have all the tags.