### PR TITLE
Table/disabled detailed

### DIFF
--- a/docs/pages/components/table/api/table.js
+++ b/docs/pages/components/table/api/table.js
@@ -171,6 +171,13 @@ export default [
                 default: '<code>[]</code>'
             },
             {
+              name: '<code>disabled-detailed</code>',
+              description: 'Controls the visibility of the trigger that toggles the detailed rows.',
+              type: 'Function',
+              values: '—',
+              default: '<code>true</code>'
+            },
+            {
                 name: '<code>detail-key</code>',
                 description: 'Use an unique key of your data Object when use detailed or opened detailed. (id recommended)',
                 type: 'String',

--- a/docs/pages/components/table/api/table.js
+++ b/docs/pages/components/table/api/table.js
@@ -171,7 +171,7 @@ export default [
                 default: '<code>[]</code>'
             },
             {
-              name: '<code>has-visible-detailed</code>',
+              name: '<code>has-detailed-visible</code>',
               description: 'Controls the visibility of the trigger that toggles the detailed rows.',
               type: 'Function',
               values: '—',

--- a/docs/pages/components/table/api/table.js
+++ b/docs/pages/components/table/api/table.js
@@ -171,7 +171,7 @@ export default [
                 default: '<code>[]</code>'
             },
             {
-              name: '<code>disabled-detailed</code>',
+              name: '<code>has-visible-detailed</code>',
               description: 'Controls the visibility of the trigger that toggles the detailed rows.',
               type: 'Function',
               values: '—',

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -68,7 +68,7 @@
 
                             <td v-if="detailed">
                                 <a
-                                    v-if="!disabledDetailed(row)"
+                                    v-if="!hasVisibleDetailed(row)"
                                     role="button"
                                     @click.stop="toggleDetails(row)">
                                     <b-icon
@@ -236,7 +236,7 @@
                 type: Array,
                 default: () => []
             },
-            disabledDetailed: {
+            hasVisibleDetailed: {
                 type: Function,
                 default: () => true
             },

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -68,7 +68,7 @@
 
                             <td v-if="detailed">
                                 <a
-                                    v-if="!hasVisibleDetailed(row)"
+                                    v-if="!hasDetailedVisible(row)"
                                     role="button"
                                     @click.stop="toggleDetails(row)">
                                     <b-icon
@@ -236,7 +236,7 @@
                 type: Array,
                 default: () => []
             },
-            hasVisibleDetailed: {
+            hasDetailedVisible: {
                 type: Function,
                 default: () => true
             },

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -67,7 +67,10 @@
                             @dblclick="$emit('dblclick', row)">
 
                             <td v-if="detailed">
-                                <a role="button" @click.stop="toggleDetails(row)">
+                                <a
+                                    v-if="!disabledDetailed(row)"
+                                    role="button"
+                                    @click.stop="toggleDetails(row)">
                                     <b-icon
                                         icon="chevron-right"
                                         both
@@ -232,6 +235,10 @@
             openedDetailed: {
                 type: Array,
                 default: () => []
+            },
+            disabledDetailed: {
+                type: Function,
+                default: () => true
             },
             detailKey: {
                 type: String,


### PR DESCRIPTION
 The `disabled-detailed` prop controls the visibility of the trigger that toggles the detailed rows.

- The prop supports an function to evaluate the visibility: 
By example: `
	disabledDetails: (row) => {
 		return [3, 5].includes(row['id'])
	}
`