### PR TITLE
Add value attribute to switch

### DIFF
--- a/src/components/switch/Switch.vue
+++ b/src/components/switch/Switch.vue
@@ -14,6 +14,7 @@
             v-model="newValue"
             type="checkbox"
             :name="name"
+            :value="nativeValue"
             :disabled="disabled"
             :true-value="trueValue"
             :false-value="falseValue">


### PR DESCRIPTION
Add a `value` attribute that binds `nativeValue` to switch. The document has a `native-value` property, but it was not used in the switch component.