### PR TITLE
Fire modal cancel on escape only when modal is active

### DIFF
--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -158,7 +158,7 @@
              */
             keyPress(event) {
                 // Esc key
-                if (event.keyCode === 27) this.cancel('escape')
+                if (this.isActive && event.keyCode === 27) this.cancel('escape')
             }
         },
         created() {


### PR DESCRIPTION
Right now the cancel method of a modal is called every time the user presses escape somewhere in the application. Even when the modal isn't even visible. Furthermore the onCancel callback function of the modal will be called, which is unnecessary and might lead to unexpected side effects. This PR makes sure the modal is active before if decides to cancel.