### PR TITLE
doc added Object as parameter in tagsinput events

### DIFF
--- a/docs/pages/components/taginput/api/taginput.js
+++ b/docs/pages/components/taginput/api/taginput.js
@@ -122,12 +122,12 @@ export default [
             {
                 name: '<code>add</code>',
                 description: 'Triggers when a tag has been added',
-                parameters: '<code>value: String</code>'
+                parameters: '<code>value: String|Object</code>'
             },
             {
                 name: '<code>remove</code>',
                 description: 'Triggers when a tag has been removed',
-                parameters: '<code>value: String</code>'
+                parameters: '<code>value: String|Object</code>'
             }
         ]
     }


### PR DESCRIPTION
Parameter for add, remove events, a ream can be not only String, but also an Object, if the v-model was an Array of Objects type