### PR TITLE
Fix for duplicated visible days names

### DIFF
--- a/src/components/datepicker/DatepickerTable.vue
+++ b/src/components/datepicker/DatepickerTable.vue
@@ -2,8 +2,8 @@
     <section class="datepicker-table">
         <header class="datepicker-header">
             <div
-                v-for="day in visibleDayNames"
-                :key="day"
+                v-for="(day, index) in visibleDayNames"
+                :key="index"
                 class="datepicker-cell">
                 {{ day }}
             </div>


### PR DESCRIPTION
Sometimes people like me use the same name for displaying custom days names, when 2 has the same key vue.js throws a warning for duplicated keys, the example calendar correspond to a Spanish one in which **Tuesday** is represented with a 'M' _(Martes)_ and **Wednesday** with a same 'M' _(Miércoles)_

<img width="421" alt="screen shot 2018-03-22 at 4 53 12 pm" src="https://user-images.githubusercontent.com/514985/37803005-5d15859e-2df2-11e8-8d48-2a7d5ffe0400.png">
