### PR TITLE
Fix table mobile card view for IE11

### DIFF
--- a/src/scss/components/_table.scss
+++ b/src/scss/components/_table.scss
@@ -158,13 +158,12 @@
                     td {
                         display: flex;
                         width: auto;
-                        justify-content: flex-end;
+                        justify-content: space-between;
                         text-align: right;
                         border-bottom: 1px solid $background;
                         &:before {
                             content: attr(data-label);
                             font-weight: $weight-semibold;
-                            margin-right: auto;
                             padding-right: 0.5em;
                             text-align: left;
                         }


### PR DESCRIPTION
margin-right: auto; does not work in IE11 (see [https://stackoverflow.com/questions/37534254/flex-auto-margin-not-working-in-ie10-11/37535548](url) and [https://stackoverflow.com/questions/31903734/ie11-flexbox-max-width-and-marginauto](url)) without width: 100%. Adding "width: 100%;" causes wrapping on long data though so instead using "justify-content: space-between;" gives the desired effect (left-justifying the label and right-justifying the data) without the quirks of margin*: auto;.

Screenshot before (IE 11):
![image](https://user-images.githubusercontent.com/2299536/39319073-956ad32c-4945-11e8-9bf6-a4c703cc1f95.png)

Screenshot adding width: 100% (IE 11):
![image](https://user-images.githubusercontent.com/2299536/39319187-f70a0274-4945-11e8-99a6-bc9df68e3f28.png)

Screenshot removing margin-right: auto; and changing justify-content: space-between (IE 11):
![image](https://user-images.githubusercontent.com/2299536/39321630-278041c8-494d-11e8-8a9e-4cd67489265b.png)

Screenshot before (Chrome 65):
![image](https://user-images.githubusercontent.com/2299536/39322275-f306e67a-494e-11e8-9a58-104c9784bf85.png)

Screenshot removing margin-right: auto; and changing justify-content: space-between (Chrome 65):
![image](https://user-images.githubusercontent.com/2299536/39322239-d0ecff3e-494e-11e8-8f4f-fe27c5f6c84a.png)
