### PR TITLE
missing default for `$info` color

### DIFF
--- a/src/scss/utils/_variables.scss
+++ b/src/scss/utils/_variables.scss
@@ -4,7 +4,7 @@ $speed-slower: 250ms !default;
 $primary: #7957d5 !default;
 $primary-invert: $white !default;
 
-$info: #167df0;
+$info: #167df0 !default;
 
 $link: $primary !default;
 $link-invert: $primary-invert !default;


### PR DESCRIPTION
I'm not too sure about this `!default` keyword, I though it was here to allow override the value if it was set before... but it looks like i'm already able to override it right now...

besides, could someone tell me why we don't set `$info-invert` as well?
