### PR TITLE
Fix visibility inside tab (#808)

### DIFF
--- a/src/scss/components/_tabs.scss
+++ b/src/scss/components/_tabs.scss
@@ -10,7 +10,7 @@
     }
     .tab-content {
         position: relative;
-        overflow: hidden;
+        overflow: visible;
         display: flex;
         flex-direction: column;
         padding: 1rem;


### PR DESCRIPTION
Before fix:
![screenshot from 2018-05-12 22-46-15](https://user-images.githubusercontent.com/9641784/39961021-670aef28-5636-11e8-8bec-26630a5ddcc6.png)

After:
![screenshot from 2018-05-12 22-46-35](https://user-images.githubusercontent.com/9641784/39961022-6c2c7738-5636-11e8-8ff7-a86046a858bd.png)

Closes #808