### PR TITLE
updated material design icons package

### DIFF
--- a/docs/assets/scss/main.scss
+++ b/docs/assets/scss/main.scss
@@ -26,8 +26,8 @@
 @import "~highlight.js/styles/atelier-cave-light.css";
 
 // MDI
-$mdi-font-path: "~mdi/fonts";
-@import "~mdi/scss/materialdesignicons";
+$mdi-font-path: "~@mdi/font/fonts";
+@import "~@mdi/font/scss/materialdesignicons";
 
 // FontAwesome
 // $fa-font-path: "~font-awesome/fonts";

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,12 @@
       "integrity": "sha512-uYd3d748klO7/+0N2F0JFYO1JeSR8/VF50S2+anI3/tG56GDAaT7fwTwlhv3N+C023f4vw3z7IPRc9ixstaAcw==",
       "dev": true
     },
+    "@mdi/font": {
+      "version": "2.4.85",
+      "resolved": "https://registry.npmjs.org/@mdi/font/-/font-2.4.85.tgz",
+      "integrity": "sha512-+I9MI1tk2ONx/Z+qBoyubNKBVMu2Tn1MWvCIvO7enGfE10d+VPeHMFxgbWNAK8ff8lLjAwhJuE3n1bKHVDz+dQ==",
+      "dev": true
+    },
     "@types/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -56,9 +62,9 @@
       "dev": true
     },
     "@vue/test-utils": {
-      "version": "1.0.0-beta.12",
-      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.12.tgz",
-      "integrity": "sha512-457S/w+VuHnh4jw03ingrVAx8jMbxRz+jGGjoTeEFPZzv20GDzPUauQQqDy71EYw6BiNscC0RGOaLvAcS6BZ9Q==",
+      "version": "1.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.16.tgz",
+      "integrity": "sha512-TF9ae3zhs8qBN98Bix2Bh3IrwkhscEV3HRthPgtzJPNG0YHUyNTlZNXH36vbP0nuSAs9Om8XjVd8/MDj8ehpEA==",
       "dev": true,
       "requires": {
         "lodash": "4.17.5"
@@ -8483,12 +8489,6 @@
         }
       }
     },
-    "mdi": {
-      "version": "2.1.99",
-      "resolved": "https://registry.npmjs.org/mdi/-/mdi-2.1.99.tgz",
-      "integrity": "sha512-s0NN21D+r6pOgU0UmrsbNs+lrdKG6xFq4BvJF6ivJlI5ki6KfWMO8kQsIpYxYiM177rad0cY3nOWVXotyyoyeg==",
-      "dev": true
-    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -13473,15 +13473,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -13500,6 +13491,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringify-object": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free-webfonts": "^1.0.3",
+    "@mdi/font": "^2.4.85",
     "@vue/test-utils": "^1.0.0-beta.15",
     "autoprefixer": "^7.1.1",
     "axios": "^0.16.2",
@@ -89,7 +90,6 @@
     "jest": "^22.1.4",
     "jest-serializer-vue": "^0.3.0",
     "lint-staged": "^6.1.1",
-    "mdi": "^2.0.46",
     "node-sass": "^4.5.3",
     "opn": "^4.0.2",
     "optimize-css-assets-webpack-plugin": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,6 +20,10 @@
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free-webfonts/-/fontawesome-free-webfonts-1.0.6.tgz#3dd13aa1a7466bff8fb0a401e1771c011ef2ca14"
 
+"@mdi/font@^2.4.85":
+  version "2.4.85"
+  resolved "https://registry.yarnpkg.com/@mdi/font/-/font-2.4.85.tgz#f257a2c3ed1dec3023f2dc12cd9210fab572ab42"
+
 "@types/strip-bom@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/strip-bom/-/strip-bom-3.0.0.tgz#14a8ec3956c2e81edb7520790aecf21c290aebd2"
@@ -5486,10 +5490,6 @@ md5.js@^1.3.4:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
-
-mdi@^2.0.46:
-  version "2.2.43"
-  resolved "https://registry.yarnpkg.com/mdi/-/mdi-2.2.43.tgz#c5e419a6e5f48c82c7109328f52530fd187a0ec0"
 
 media-typer@0.3.0:
   version "0.3.0"


### PR DESCRIPTION
Currently, we cannot use all the materials icons, due to lack of update of the material icons dependency. The icons currently available are from [mdi 2.0.46](https://materialdesignicons.com/cdn/2.0.46/) whereas there are a lot more available in the last version: [mdi 2.2.43](https://materialdesignicons.com/cdn/2.2.43/). I propose to update this dependency.

The package has changed name on npm, it is now called `@mdi/font` so I changed paths accordingly.

It seems to build properly when I do `npm install` then `npm run build`, but I have not tested my PR more than that.

> Note: I'm a total noob using node & javascript so I might have missed something. 