### PR TITLE
Add code to set activeTab on created

### DIFF
--- a/src/components/tabs/TabItem.vue
+++ b/src/components/tabs/TabItem.vue
@@ -60,6 +60,9 @@
                 throw new Error('You should wrap bTabItem on a bTabs')
             }
             this.$parent.tabItems.push(this)
+            if (this.$parent.tabItems.indexOf(this) === this.$parent.activeTab) {
+                this.isActive = true
+            }
         },
         beforeDestroy() {
             const index = this.$parent.tabItems.indexOf(this)


### PR DESCRIPTION
Currently, tab item is only rendered on mounted.

It can be a long wait before user sees anything if a lot of things need to be loaded.

This patch allows active tab to be rendered on created first.