### PR TITLE
Fix dropdown menu overflow and add line truncate

### DIFF
--- a/src/scss/components/_autocomplete.scss
+++ b/src/scss/components/_autocomplete.scss
@@ -3,6 +3,7 @@
     .dropdown-menu {
         display: block;
         min-width: 100%;
+        max-width: 100%;
         &.is-opened-top {
             top: auto;
             bottom: 100%;
@@ -13,6 +14,9 @@
         max-height: 200px;
     }
     .dropdown-item {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
         &.is-hovered {
             background: $dropdown-item-hover-background-color;
             color: $dropdown-item-hover-color;


### PR DESCRIPTION
Got a weird overflow when I'm using autocomplete input. Because my dropdown-item were too long and made the dropdown-menu have to expand to contain the item. I don't think it's necessary in this case (because this is autocomplete input). So I have to write some css to fix that.