### PR TITLE
Loading: onCancel should not be called on ESC key when inactive

### DIFF
--- a/src/components/loading/Loading.vue
+++ b/src/components/loading/Loading.vue
@@ -52,7 +52,7 @@
              * Close the Modal if canCancel.
              */
             cancel() {
-                if (!this.canCancel) return
+                if (!this.canCancel || !this.isActive) return
 
                 this.close()
             },


### PR DESCRIPTION
Hi,

I found that `onCancel` callback is being called whenever user press ESC key even if loading is not active.

See this example -
```html
<b-loading :active="false" :on-cancel="onCancel"  :can-cancel="true"></b-loading>
```
```js
methods : {
 onCancel() {
        alert("User cancelled the operation by pressing ESC key")
 },
}
```
I can setup a full JSFiddle if you want.