### PR TITLE
Prevent a switch with multi-line text from shrinking

### DIFF
--- a/src/scss/components/_switch.scss
+++ b/src/scss/components/_switch.scss
@@ -17,6 +17,7 @@ $switch-active-background-color: $primary !default;
         + .check {
             display: flex;
             align-items: center;
+            flex-shrink: 0;
             width: $switch-width;
             height: #{$switch-width / 2 + $switch-padding};
             padding: $switch-padding;


### PR DESCRIPTION
If a switch has a long label and the text wraps to the next line, the background for the switch will start to shrink.
![image](https://user-images.githubusercontent.com/4346833/44269618-623e0c00-a235-11e8-9127-1aa3af4b6527.png)

This PR will prevent this by adding a `flex-shrink: 0;`
![image](https://user-images.githubusercontent.com/4346833/44269727-b77a1d80-a235-11e8-9291-4790f5fda09a.png)
