### PR TITLE
Fix hidden overflow inside tab

### DIFF
--- a/src/components/tabs/TabItem.vue
+++ b/src/components/tabs/TabItem.vue
@@ -1,5 +1,8 @@
 <template>
-    <transition :name="transitionName">
+    <transition
+        :name="transitionName"
+        @before-enter="$parent.isTransitioning = true"
+        @after-enter="$parent.isTransitioning = false">
         <div v-show="isActive && visible" class="tab-item">
             <slot/>
         </div>

--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -26,7 +26,7 @@
                 </li>
             </ul>
         </nav>
-        <section class="tab-content">
+        <section class="tab-content" :class="{'is-transitioning': isTransitioning}">
             <slot/>
         </section>
     </div>
@@ -58,7 +58,8 @@
                 activeTab: this.value || 0,
                 tabItems: [],
                 contentHeight: 0,
-                _isTabs: true // Used internally by TabItem
+                _isTabs: true, // Used internally by TabItem
+                isTransitioning: false
             }
         },
         computed: {

--- a/src/scss/components/_tabs.scss
+++ b/src/scss/components/_tabs.scss
@@ -10,7 +10,7 @@
     }
     .tab-content {
         position: relative;
-        overflow: hidden;
+        overflow: visible;
         display: flex;
         flex-direction: column;
         padding: 1rem;
@@ -18,6 +18,9 @@
             flex-shrink: 0;
             flex-basis: auto;
         }
+    }
+    .is-transitioning {
+        overflow: hidden;
     }
     &:not(:last-child) {
         margin-bottom: 1.5rem;


### PR DESCRIPTION
I have created improved version of #811 PR

Before:
![image](https://user-images.githubusercontent.com/477677/44518910-d8c28a00-a6cb-11e8-9db3-3270841bf0bd.png)
After:
![image](https://user-images.githubusercontent.com/477677/44518977-04457480-a6cc-11e8-8d73-69c66fb99905.png)

overflow:hidden is applied to tab-content only during animated tab transition to avoid below problem (it was noticed in #811 comments)

![image](https://user-images.githubusercontent.com/477677/44519219-b41ae200-a6cc-11e8-8f14-c8520db07e0b.png)

In my PR it looks like that:
![image](https://user-images.githubusercontent.com/477677/44520199-84b9a480-a6cf-11e8-9db5-877c49154c07.png)

I am sorry for creating another PR but I don't know if it's possible to amend someone else's PR.

closes #808 
closes #468 