### PR TITLE
Add indeterminate state to checkbox.

### DIFF
--- a/docs/pages/components/checkbox/examples/ExSimple.vue
+++ b/docs/pages/components/checkbox/examples/ExSimple.vue
@@ -16,6 +16,11 @@
             </b-checkbox>
         </div>
         <div class="field">
+            <b-checkbox :indeterminate="true">
+                Indeterminate
+            </b-checkbox>
+        </div>
+        <div class="field">
             <b-checkbox disabled>Disabled</b-checkbox>
         </div>
     </section>

--- a/src/components/checkbox/Checkbox.vue
+++ b/src/components/checkbox/Checkbox.vue
@@ -8,6 +8,7 @@
         @keydown.prevent.enter.space="$refs.label.click()">
         <input
             v-model="newValue"
+            :indeterminate.prop="indeterminate"
             type="checkbox"
             :disabled="disabled"
             :required="required"
@@ -26,6 +27,7 @@
         props: {
             value: [String, Number, Boolean, Function, Object, Array, Symbol],
             nativeValue: [String, Number, Boolean, Function, Object, Array, Symbol],
+            indeterminate: Boolean,
             type: String,
             disabled: Boolean,
             required: Boolean,

--- a/src/scss/components/_checkbox.scss
+++ b/src/scss/components/_checkbox.scss
@@ -36,6 +36,18 @@ $checkbox-checkmark-color: $primary-invert !default;
                     }
                 }
             }
+            &:indeterminate + .check {
+                background: $checkbox-active-background-color url(indeterminate($checkbox-checkmark-color)) no-repeat center center;
+                border-color: $checkbox-active-background-color;
+                @each $name, $pair in $colors {
+                    $color: nth($pair, 1);
+                    $color-invert: nth($pair, 2);
+                    &.is-#{$name} {
+                        background: $color url(indeterminate($color-invert)) no-repeat center center;
+                        border-color: $color;
+                    }
+                }
+            }
         }
         .control-label {
             padding-left: 0.5em;

--- a/src/scss/utils/_functions.scss
+++ b/src/scss/utils/_functions.scss
@@ -39,3 +39,11 @@
 
     @return svg-encode("#{$start}#{$content}#{$end}");
 }
+
+@function indeterminate($color) {
+    $start: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1">';
+    $content: '<rect style="fill:#{$color}" width="0.7" height="0.2" x=".15" y=".4"></rect>';
+    $end: '</svg>';
+
+    @return svg-encode("#{$start}#{$content}#{$end}");
+}


### PR DESCRIPTION
First draft of the indeterminate checkbox state. The implementation is simple and makes no assumptions on how the `indeterminate` prop should be set. The user is responsible for managing the state of the prop.

![image](https://i.gyazo.com/dfb3455c12e43f8bfb388a7aaca1ec63.png)

Reason for this feature:

It's a native browser feature and should be implemented imo. The main use case is to have a checkbox whose state is determined by other checkboxes. Here's an example from one of my projects.

![example](https://i.gyazo.com/bc498cd4425504691275cc9c328540b1.png)