### PR TITLE
Buefy 0.6.6 -> 0.6.7 is broken. Upgrade semantic version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buefy",
-  "version": "0.6.7-beta.1",
+  "version": "0.7.0-beta.1",
   "homepage": "https://buefy.github.io",
   "description": "Lightweight UI components for Vue.js based on Bulma",
   "author": "Rafael Beraldo <rafael.pimpa@gmail.com>",


### PR DESCRIPTION
Upgrading from Buefy 0.6.6 to 0.6.7 is broken. Please update the minor/major version since they are not backwards compatible.

The main problem is that old code may reference `buefy.css` from `buefy/lib/` whereas in `0.6.7`, it is actually in `buefy/dist/`. This breaks builds and produces the following error output:

```
ERROR in ./src/main.js
Module not found: Error: Can't resolve 'buefy/lib/buefy.css' in 'C:\Users\Peter\project\src'
 @ ./src/main.js 10:0-29
```

using code:
```
import 'buefy/lib/buefy.css'
```
with `package.json`
```
...
    "buefy": "^0.6.6",
...
```
and running `npm update`.


A workaround is to refer to the new location:
```
import 'buefy/dist/buefy.css'
```

Another alternative is to output the css file to the `buefy/lib/` directory until ready to bump up the minor/major version numbers. Please refer to https://docs.npmjs.com/getting-started/semantic-versioning