### PR TITLE
[RANGE-DATE] Add functionality to select range of dates to DatePicker.

### DIFF
--- a/docs/pages/components/datepicker/Datepicker.vue
+++ b/docs/pages/components/datepicker/Datepicker.vue
@@ -46,6 +46,13 @@
             <p>Dates can be passed to the datepicker with the <code>events</code> prop and shown with indicators.</p>
         </Example>
 
+        <Example :component="ExRangeInput" :code="ExRangeInputCode" title="Select a range of dates" vertical>
+            <div class="tags has-addons">
+                <span class="tag is-success">New!</span>
+            </div>
+            <p>Dates selected can be within a range.</p>
+        </Example>
+
         <ApiView :data="api"/>
     </div>
 </template>
@@ -80,6 +87,9 @@
     import ExEvents from './examples/ExEvents'
     import ExEventsCode from '!!raw-loader!./examples/ExEvents'
 
+    import ExRangeInput from './examples/ExRangeInput'
+    import ExRangeInputCode from '!!raw-loader!./examples/ExRangeInput'
+
     export default {
         data() {
             return {
@@ -101,7 +111,9 @@
                 ExEvents,
                 ExEventsCode,
                 ExMonth,
-                ExMonthCode
+                ExMonthCode,
+                ExRangeInput,
+                ExRangeInputCode
             }
         }
     }

--- a/docs/pages/components/datepicker/api/datepicker.js
+++ b/docs/pages/components/datepicker/api/datepicker.js
@@ -212,6 +212,13 @@ export default [
                 default: '<code>4</code>'
             },
             {
+                name: '<code>range</code>',
+                description: 'Flag to allow choosing a range of date',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
                 name: 'Any native attribute',
                 description: '—',
                 type: '—',

--- a/docs/pages/components/datepicker/examples/ExRangeInput.vue
+++ b/docs/pages/components/datepicker/examples/ExRangeInput.vue
@@ -1,0 +1,23 @@
+<template>
+    <b-field label="Select a date">
+        <b-datepicker
+            placeholder="Click to select..."
+            v-model="dates"
+            range>
+        </b-datepicker>
+    </b-field>
+</template>
+
+<script>
+export default {
+    data() {
+        const today = new Date()
+        return {
+            dates: [
+                today,
+                new Date(today.getFullYear(), today.getMonth(), today.getDate() + 2)
+            ]
+        }
+    }
+}
+</script>

--- a/src/components/datepicker/Datepicker.spec.js
+++ b/src/components/datepicker/Datepicker.spec.js
@@ -90,4 +90,64 @@ describe('BDatepicker', () => {
         window.document.dispatchEvent(keyupEvent)
         wrapper.vm.$nextTick(() => expect($dropdown.isVisible()).toBeFalsy())
     })
+
+    describe('#dateFormatter', () => {
+        it('should add one to month since month in dates starts from 0', () => {
+            const dateToFormat = new Date(2019, 3, 1)
+            const formattedDate = wrapper.vm.dateFormatter(dateToFormat, wrapper.vm)
+            expect(formattedDate).toEqual('2019-4-1')
+        })
+
+        it('should format based on 2-digit numeric locale date with type === month', () => {
+            wrapper.setProps({
+                type: 'month'
+            })
+            const dateToFormat = new Date(2019, 3, 1)
+            const formattedDate = wrapper.vm.dateFormatter(dateToFormat, wrapper.vm)
+            expect(formattedDate).toEqual('2019-04')
+        })
+
+        it('should format a range of dates passed via array', () => {
+            const dateToFormat = [
+                new Date(2019, 3, 1),
+                new Date(2019, 3, 3)
+            ]
+            const formattedDate = wrapper.vm.dateFormatter(dateToFormat, wrapper.vm)
+            expect(formattedDate).toEqual('2019-4-1 - 2019-4-3')
+        })
+    })
+
+    describe('#formatValue', () => {
+        it('should call dateFormatter, passing the date', () => {
+            const mockDateFormatter = jest.fn()
+            wrapper.setProps({
+                dateFormatter: mockDateFormatter
+            })
+            const date = new Date()
+            wrapper.vm.formatValue(date)
+            expect(mockDateFormatter.mock.calls[0][0]).toEqual(date)
+        })
+
+        it('should not call dateFormatter when value is undefined or NaN', () => {
+            const mockDateFormatter = jest.fn()
+            wrapper.setProps({
+                dateFormatter: mockDateFormatter
+            })
+            wrapper.vm.formatValue(undefined)
+            expect(mockDateFormatter.mock.calls.length).toEqual(0)
+            wrapper.vm.formatValue('buefy')
+            expect(mockDateFormatter.mock.calls.length).toEqual(0)
+        })
+
+        it('should not call dateFormatter when value is an array with undefined or NaN elements', () => {
+            const mockDateFormatter = jest.fn()
+            wrapper.setProps({
+                dateFormatter: mockDateFormatter
+            })
+            wrapper.vm.formatValue([new Date(), undefined])
+            expect(mockDateFormatter.mock.calls.length).toEqual(0)
+            wrapper.vm.formatValue([new Date(), 'buefy'])
+            expect(mockDateFormatter.mock.calls.length).toEqual(0)
+        })
+    })
 })

--- a/src/components/datepicker/DatepickerTable.spec.js
+++ b/src/components/datepicker/DatepickerTable.spec.js
@@ -1,6 +1,5 @@
 import { shallowMount } from '@vue/test-utils'
 import BDatepickerTable from '@components/datepicker/DatepickerTable'
-
 import config, {setOptions} from '@utils/config'
 
 describe('BDatepickerTable', () => {
@@ -60,5 +59,94 @@ describe('BDatepickerTable', () => {
         wrapper.vm.updateSelectedDate(newDate)
         const valueEmitted = wrapper.emitted()['input'][0]
         expect(valueEmitted).toContainEqual(newDate)
+    })
+
+    describe('#hoveredDateRange', () => {
+        const selectedBeginDate = new Date(2019, 3, 10)
+        const threeDaysAfterBeginDate = new Date(2019, 3, 13)
+        const threeDaysBeforeBeginDate = new Date(2019, 3, 7)
+
+        const defaultProps = () => ({
+            dayNames: config.defaultDayNames,
+            monthNames: config.defaultMonthNames,
+            focused: {
+                month: config.focusedDate.getMonth(),
+                year: config.focusedDate.getFullYear()
+            }
+        })
+
+        it('should return an empty array when props range is false', () => {
+            const wrapper = shallowMount(BDatepickerTable, {
+                propsData: {
+                    ...defaultProps(),
+                    range: false
+                }
+            })
+            expect(wrapper.vm.hoveredDateRange).toEqual([])
+        })
+
+        it('should return an empty array when selectedEndDate exists', () => {
+            const wrapper = shallowMount(BDatepickerTable, {
+                propsData: {
+                    ...defaultProps(),
+                    range: true
+                }
+            })
+            wrapper.setData({
+                selectedBeginDate,
+                selectedEndDate: threeDaysAfterBeginDate
+            })
+            expect(wrapper.vm.hoveredDateRange).toEqual([])
+        })
+
+        it('should return an array of two dates', () => {
+            const wrapper = shallowMount(BDatepickerTable, {
+                propsData: {
+                    ...defaultProps(),
+                    range: true
+                }
+            })
+            wrapper.setData({
+                selectedBeginDate,
+                hoveredEndDate: threeDaysAfterBeginDate
+            })
+            expect(wrapper.vm.hoveredDateRange).toEqual([
+                selectedBeginDate,
+                threeDaysAfterBeginDate
+            ])
+        })
+
+        it('should return the earlier date as the first element', () => {
+            const wrapper = shallowMount(BDatepickerTable, {
+                propsData: {
+                    ...defaultProps(),
+                    range: true
+                }
+            })
+            wrapper.setData({
+                selectedBeginDate,
+                hoveredEndDate: threeDaysBeforeBeginDate
+            })
+            expect(wrapper.vm.hoveredDateRange).toEqual([
+                threeDaysBeforeBeginDate,
+                selectedBeginDate
+            ])
+        })
+
+        it('should filter only defined values', () => {
+            const wrapper = shallowMount(BDatepickerTable, {
+                propsData: {
+                    ...defaultProps(),
+                    range: true
+                }
+            })
+            wrapper.setData({
+                selectedBeginDate,
+                hoveredEndDate: undefined
+            })
+            expect(wrapper.vm.hoveredDateRange).toEqual([
+                selectedBeginDate
+            ])
+        })
     })
 })

--- a/src/components/datepicker/DatepickerTable.vue
+++ b/src/components/datepicker/DatepickerTable.vue
@@ -29,7 +29,10 @@
                 :show-week-number="showWeekNumber"
                 :first-day-of-week="firstDayOfWeek"
                 :rules-for-first-week="rulesForFirstWeek"
-                @select="updateSelectedDate"/>
+                :range="range"
+                :hovered-date-range="hoveredDateRange"
+                @select="updateSelectedDate"
+                @rangeHoverEndDate="setRangeHoverEndDate"/>
         </div>
     </section>
 </template>
@@ -37,13 +40,17 @@
 <script>
 import DatepickerTableRow from './DatepickerTableRow'
 
+const isDefined = (d) => d !== undefined
+
 export default {
     name: 'BDatepickerTable',
     components: {
         [DatepickerTableRow.name]: DatepickerTableRow
     },
     props: {
-        value: Date,
+        value: {
+            type: [Date, Array]
+        },
         dayNames: Array,
         monthNames: Array,
         firstDayOfWeek: Number,
@@ -66,6 +73,14 @@ export default {
         rulesForFirstWeek: {
             type: Number,
             default: () => 4
+        },
+        range: Boolean
+    },
+    data() {
+        return {
+            selectedBeginDate: undefined,
+            selectedEndDate: undefined,
+            hoveredEndDate: undefined
         }
     },
     computed: {
@@ -141,6 +156,18 @@ export default {
             }
 
             return weeksInThisMonth
+        },
+        hoveredDateRange() {
+            if (!this.range) {
+                return []
+            }
+            if (!isNaN(this.selectedEndDate)) {
+                return []
+            }
+            if (this.hoveredEndDate < this.selectedBeginDate) {
+                return [this.hoveredEndDate, this.selectedBeginDate].filter(isDefined)
+            }
+            return [this.selectedBeginDate, this.hoveredEndDate].filter(isDefined)
         }
     },
     methods: {
@@ -148,7 +175,33 @@ export default {
         * Emit input event with selected date as payload for v-model in parent
         */
         updateSelectedDate(date) {
-            this.$emit('input', date)
+            if (!this.range) {
+                this.$emit('input', date)
+            } else {
+                this.handleSelectRangeDate(date)
+            }
+        },
+
+        /*
+        * If both begin and end dates are set, reset the end date and set the begin date.
+        * If only begin date is selected, emit an array of the begin date and the new date.
+        * If not set, only set the begin date.
+        */
+        handleSelectRangeDate(date) {
+            if (this.selectedBeginDate && this.selectedEndDate) {
+                this.selectedBeginDate = date
+                this.selectedEndDate = undefined
+            } else if (this.selectedBeginDate && !this.selectedEndDate) {
+                if (this.selectedBeginDate > date) {
+                    this.selectedEndDate = this.selectedBeginDate
+                    this.selectedBeginDate = date
+                } else {
+                    this.selectedEndDate = date
+                }
+                this.$emit('input', [this.selectedBeginDate, this.selectedEndDate])
+            } else {
+                this.selectedBeginDate = date
+            }
         },
 
         /*
@@ -197,6 +250,10 @@ export default {
 
                 return week.some((weekDate) => weekDate.getTime() === timed)
             })
+        },
+
+        setRangeHoverEndDate(day) {
+            this.hoveredEndDate = day
         }
     }
 }

--- a/src/components/datepicker/DatepickerTableRow.spec.js
+++ b/src/components/datepicker/DatepickerTableRow.spec.js
@@ -1,26 +1,136 @@
 import { shallowMount } from '@vue/test-utils'
 import BDatepickerTableRow from '@components/datepicker/DatepickerTableRow'
 
+const propsData = {
+    week: [
+        new Date('Sun Dec 31 2017 00:00:00 GMT-0200 (-02)'),
+        new Date('Mon Jan 01 2018 00:00:00 GMT-0200 (-02)'),
+        new Date('Tue Jan 02 2018 00:00:00 GMT-0200 (-02)'),
+        new Date('Wed Jan 03 2018 00:00:00 GMT-0200 (-02)'),
+        new Date('Thu Jan 04 2018 00:00:00 GMT-0200 (-02)'),
+        new Date('Fri Jan 05 2018 00:00:00 GMT-0200 (-02)'),
+        new Date('Sat Jan 06 2018 00:00:00 GMT-0200 (-02)')
+    ],
+    month: 12,
+    dateCreator: function () {
+        return new Date()
+    }
+}
+
 describe('BDatepickerTableRow', () => {
     it('is called', () => {
-        const wrapper = shallowMount(BDatepickerTableRow, {
-            propsData: {
-                week: [
-                    new Date('Sun Dec 31 2017 00:00:00 GMT-0200 (-02)'),
-                    new Date('Mon Jan 01 2018 00:00:00 GMT-0200 (-02)'),
-                    new Date('Tue Jan 02 2018 00:00:00 GMT-0200 (-02)'),
-                    new Date('Wed Jan 03 2018 00:00:00 GMT-0200 (-02)'),
-                    new Date('Thu Jan 04 2018 00:00:00 GMT-0200 (-02)'),
-                    new Date('Fri Jan 05 2018 00:00:00 GMT-0200 (-02)'),
-                    new Date('Sat Jan 06 2018 00:00:00 GMT-0200 (-02)')
-                ],
-                month: 12,
-                dateCreator: function () {
-                    return new Date()
-                }
-            }
-        })
+        const wrapper = shallowMount(BDatepickerTableRow, { propsData })
         expect(wrapper.name()).toBe('BDatepickerTableRow')
         expect(wrapper.isVueInstance()).toBeTruthy()
+    })
+
+    describe('classObject', function () {
+        it('should have is-selected class for all range of dates selected', function () {
+            const wrapper = shallowMount(BDatepickerTableRow, {
+                propsData: {
+                    ...propsData,
+                    selectedDate: [propsData.week[1], propsData.week[5]]
+                }
+            })
+            expect(wrapper.findAll('.is-selected').length).toBe(5)
+        })
+
+        it('should have is-first-selected class for the first date selected within the range', function () {
+            const wrapper = shallowMount(BDatepickerTableRow, {
+                propsData: {
+                    ...propsData,
+                    selectedDate: [propsData.week[1], propsData.week[5]]
+                }
+            })
+            const {wrappers: [firstSelectedCell]} = wrapper.findAll('.is-selected')
+            expect(firstSelectedCell.classes()).toContain('is-first-selected')
+        })
+
+        it('should have is-within-selected class for the dates selected within the range', function () {
+            const wrapper = shallowMount(BDatepickerTableRow, {
+                propsData: {
+                    ...propsData,
+                    selectedDate: [propsData.week[1], propsData.week[5]]
+                }
+            })
+            const withinSelectedRangeCells = wrapper.findAll('.is-selected.is-within-selected')
+            expect(withinSelectedRangeCells.length).toBe(3)
+        })
+
+        it('should have is-last-selected class for the last date selected within the range', function () {
+            const wrapper = shallowMount(BDatepickerTableRow, {
+                propsData: {
+                    ...propsData,
+                    selectedDate: [propsData.week[1], propsData.week[5]]
+                }
+            })
+            // wrappers should return 5 elements. Destructure to get the last one
+            const {wrappers: [, , , , lastSelectedCell]} = wrapper.findAll('.is-selected')
+            expect(lastSelectedCell.classes()).toContain('is-last-selected')
+        })
+
+        it('should has is-selected class for all range of dates selected', function () {
+            const wrapper = shallowMount(BDatepickerTableRow, {
+                propsData: {
+                    ...propsData,
+                    selectedDate: [propsData.week[1], propsData.week[5]]
+                }
+            })
+            expect(wrapper.findAll('.is-selected').length).toBe(5)
+        })
+
+        it('should have is-within-hovered-range class for all range of dates hovered', function () {
+            const wrapper = shallowMount(BDatepickerTableRow, {
+                propsData: {
+                    ...propsData,
+                    selectedDate: [propsData.week[1], propsData.week[5]]
+                }
+            })
+            expect(wrapper.findAll('.is-selected').length).toBe(5)
+        })
+
+        it('should have is-first-hovered class for the first date hovered within the range', function () {
+            const wrapper = shallowMount(BDatepickerTableRow, {
+                propsData: {
+                    ...propsData,
+                    hoveredDateRange: [propsData.week[1], propsData.week[2]]
+                }
+            })
+            const {wrappers: [firstHoveredCell]} = wrapper.findAll('.is-within-hovered-range')
+            expect(firstHoveredCell.classes()).toContain('is-first-hovered')
+        })
+
+        it('should have is-within-hovered class for the dates hovered within the range', function () {
+            const wrapper = shallowMount(BDatepickerTableRow, {
+                propsData: {
+                    ...propsData,
+                    hoveredDateRange: [propsData.week[1], propsData.week[5]]
+                }
+            })
+            const withinHoveredRangeCells = wrapper.findAll('.is-within-hovered-range.is-within-hovered')
+            expect(withinHoveredRangeCells.length).toBe(3)
+        })
+
+        it('should have is-last-hovered class for the last date hovered within the range', function () {
+            const wrapper = shallowMount(BDatepickerTableRow, {
+                propsData: {
+                    ...propsData,
+                    hoveredDateRange: [propsData.week[1], propsData.week[5]]
+                }
+            })
+            // wrappers should return 5 elements. Destructure to get the last one
+            const {wrappers: [, , , , lastHoveredCell]} = wrapper.findAll('.is-within-hovered-range')
+            expect(lastHoveredCell.classes()).toContain('is-last-hovered')
+        })
+
+        it('should has is-within-hovered-range class for all range of dates hovered', function () {
+            const wrapper = shallowMount(BDatepickerTableRow, {
+                propsData: {
+                    ...propsData,
+                    hoveredDateRange: [propsData.week[1], propsData.week[5]]
+                }
+            })
+            expect(wrapper.findAll('.is-within-hovered-range').length).toBe(5)
+        })
     })
 })

--- a/src/scss/components/_datepicker.scss
+++ b/src/scss/components/_datepicker.scss
@@ -13,7 +13,7 @@
         border-bottom: 1px solid $grey-lighter;
     }
     .datepicker-content {
-        height: 16.25rem;   
+        height: 16.25rem;
     }
     .datepicker-footer {
         margin-top: 0.875rem;
@@ -70,10 +70,46 @@
                         color: $black;
                         cursor: pointer;
                     }
+                    &.is-within-hovered-range {
+                        &.is-first-hovered {
+                            background-color: $grey;
+                            color: $grey-lighter;
+                            border-bottom-right-radius: 0;
+                            border-top-right-radius: 0;
+                        }
+                        &.is-within-hovered {
+                            background-color: $background;
+                            color: $black;
+                            border-radius: 0;
+                        }
+                        &.is-last-hovered {
+                            background-color: $grey;
+                            color: $grey-lighter;
+                            border-bottom-left-radius: 0;
+                            border-top-left-radius: 0;
+                        }
+                    }
                 }
                 &.is-selected {
                     background-color: $primary;
                     color: $primary-invert;
+
+                    &.is-first-selected {
+                        background-color: $primary;
+                        color: $primary-invert;
+                        border-bottom-right-radius: 0;
+                        border-top-right-radius: 0;
+                    }
+                    &.is-within-selected {
+                        background-color: rgba($primary, 0.5);
+                        border-radius: 0;
+                    }
+                    &.is-last-selected {
+                        background-color: $primary;
+                        color: $primary-invert;
+                        border-bottom-left-radius: 0;
+                        border-top-left-radius: 0;
+                    }
                 }
                 &.is-nearby:not(.is-selected) {
                     color: $grey-light;


### PR DESCRIPTION
Addresses #932.

* To maintain backward compatibility, the component still accepts Date,
  but checks are performed to differentiate if users passed an Array of
  Date.
* Turn off border-radius for is-within selected cells.
* Turn off right border-radiuses for is-first selected and left
  border-radiuses for is-last selected cells.
* Add specs for DatePicker's dateformatter.
* Add specs for classObject in DatepickerTableRow.

p.s. I'm not sure what's up with the `yarn.lock`. It could be due to the different `yarn` version. I'm using `v1.10.1`

![datepicker](https://user-images.githubusercontent.com/8052933/46485665-b5dcd700-c82e-11e8-8691-7d0ea3435c64.gif)

**UPDATED**

![buefy](https://user-images.githubusercontent.com/8052933/62290380-d64be100-b493-11e9-889e-eda2d799ae92.gif)
