### PR TITLE
Prevent a radio with multi-line text from shrinking

### DIFF
--- a/src/scss/components/_radio.scss
+++ b/src/scss/components/_radio.scss
@@ -19,6 +19,7 @@ $radio-active-background-color: $primary !default;
                 display: flex;
                 align-items: center;
                 justify-content: center;
+                flex-shrink: 0;
                 width: 1.25em;
                 height: 1.25em;
                 border: 2px solid $grey;


### PR DESCRIPTION
If a radio has a long label and the text wraps to the next line, the radio will start to shrink.
![image](https://user-images.githubusercontent.com/4346833/47433132-101ee700-d7a0-11e8-8f6e-5845e563c18e.png)

This PR will prevent this by adding a `flex-shrink: 0;`
![image](https://user-images.githubusercontent.com/4346833/47433178-2331b700-d7a0-11e8-9002-241beefa1630.png)