### PR TITLE
Implemented indeterminate state for checkable table

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -21,6 +21,7 @@
                         <th class="checkbox-cell" v-if="checkable">
                             <b-checkbox
                                 :value="isAllChecked"
+                                :indeterminate="isSomeChecked"
                                 :disabled="isAllUncheckable"
                                 @change.native="checkAll"/>
                         </th>
@@ -319,6 +320,20 @@
                     return indexOf(this.newCheckedRows, currentVisibleRow, this.customIsChecked) < 0
                 })
                 return !isAllChecked
+            },
+
+            /**
+             * Check if some rows in the page are checked.
+             */
+            isSomeChecked() {
+                const validVisibleData = this.visibleData.filter(
+                        (row) => this.isRowCheckable(row))
+                if (validVisibleData.length === 0) return false
+                const isSomeChecked = validVisibleData.some((currentVisibleRow) => {
+                    return indexOf(this.newCheckedRows,
+                    currentVisibleRow, this.customIsChecked) >= 0
+                })
+                return isSomeChecked && !this.isAllChecked
             },
 
             /**


### PR DESCRIPTION
Set the header checkbox on a checkable table to indeterminate state if some (but not all) checkable rows have been selected.

![buefy-table-checkbox-indeterminate](https://user-images.githubusercontent.com/11631108/47609956-767a6280-da49-11e8-9630-ff7e4c7ef108.gif)
