### PR TITLE
Fixed typo "Nop" -> "Nope" in Radio Button Documentation

### DIFF
--- a/docs/pages/components/radio/examples/ExRadioButton.vue
+++ b/docs/pages/components/radio/examples/ExRadioButton.vue
@@ -2,10 +2,10 @@
     <section>
         <b-field>
             <b-radio-button v-model="radioButton"
-                native-value="Nop"
+                native-value="Nope"
                 type="is-danger">
                 <b-icon icon="close"></b-icon>
-                <span>Nop</span>
+                <span>Nope</span>
             </b-radio-button>
 
             <b-radio-button v-model="radioButton"


### PR DESCRIPTION
Minor change to docs, adding `'e'` to the end of `'Nop'`