### PR TITLE
Added an option to enable the use of the fontawesome 5 svg component

### DIFF
--- a/docs/pages/components/icon/Icon.vue
+++ b/docs/pages/components/icon/Icon.vue
@@ -12,6 +12,10 @@
         <b-message type="is-info">
             Using <code>far</code> or <code>fad</code> while having FontAwesome free tier might have missing icons.
         </b-message>
+        <b-message type="is-info">
+            You can set the <code>defaultIconComponent</code> constructor option to render icons with the
+            <a href="https://www.npmjs.com/package/@fortawesome/vue-fontawesome" target="_blank">vue-fontawesome</a> component.
+        </b-message>
         <Example :component="ExFa" :code="ExFaCode" title="FontAwesome" vertical/>
 
         <Example :component="ExObjectSyntax" :code="ExObjectSyntaxCode" title="Object syntax" vertical>

--- a/docs/pages/installation/api/constructor-options.js
+++ b/docs/pages/installation/api/constructor-options.js
@@ -12,6 +12,15 @@ export default [
                 default: '<code>mdi</code>'
             },
             {
+                name: '<code>defaultIconComponent</code>',
+                description: `Component used to render the Icon.
+                    Can be used to render FontAwesome 5 icons with the
+                    <a href="https://www.npmjs.com/package/@fortawesome/vue-fontawesome" target="_blank">vue-fontawesome</a> component`,
+                type: 'Component',
+                values: '<code>vue-fontawesome</code>',
+                default: '<code>null</code>'
+            },
+            {
                 name: '<code>defaultContainerElement</code>',
                 description: `Default container attribute for floating Notices (Toasts & Snackbars). Note that this also
                     changes the <code>position</code> of the Notices from <code>fixed</code> to <code>absolute</code>.

--- a/src/components/icon/Icon.vue
+++ b/src/components/icon/Icon.vue
@@ -5,7 +5,7 @@
             :class="[newPack, newIcon, newCustomSize, customClass]"/>
 
         <component
-            v-if="useIconComponent"
+            v-else
             :is="useIconComponent"
             :icon="[newPack, newIcon]"
             :size="newCustomSize"

--- a/src/components/icon/Icon.vue
+++ b/src/components/icon/Icon.vue
@@ -1,6 +1,13 @@
 <template>
     <span class="icon" :class="[newType, size]">
-        <i :class="[newPack, newIcon, newCustomSize, customClass]"/>
+        <i
+            v-if="!useIconComponent"
+            :class="[newPack, newIcon, newCustomSize, customClass]"/>
+
+         <component
+            v-if="useIconComponent"
+            :is="useIconComponent"
+            :icon="[newPack, newIcon]"/>
     </span>
 </template>
 
@@ -25,17 +32,9 @@
              * internal icons are always MDI.
              */
             newIcon() {
-                if (!this.both) {
-                    if (this.newPack === 'mdi') {
-                        return `${this.newPack}-${this.icon}`
-                    } else {
-                        return `fa-${this.icon}`
-                    }
-                }
-
                 return this.newPack === 'mdi'
                     ? `${this.newPack}-${this.icon}`
-                    : `fa-${this.getEquivalentIconOf(this.icon)}`
+                    : this.getFAIconOf(this.icon)
             },
             newPack() {
                 return this.pack || config.defaultIconPack
@@ -77,9 +76,19 @@
                     case 'is-large': return largeSize
                     default: return defaultSize
                 }
+            },
+            useIconComponent() {
+                return config.defaultIconComponent
             }
         },
         methods: {
+            getFAIconOf(value) {
+                if (this.useIconComponent) {
+                    return this.getEquivalentIconOf(this.icon)
+                }
+                return `fa-${this.getEquivalentIconOf(this.icon)}`
+            },
+
             /**
              * Equivalent FA icon name of the MDI.
              */

--- a/src/components/icon/Icon.vue
+++ b/src/components/icon/Icon.vue
@@ -95,6 +95,11 @@
              * Equivalent FA icon name of the MDI.
              */
             getEquivalentIconOf(value) {
+                // Only transform the class if the both prop is set to true
+                if (!this.both) {
+                    return value
+                }
+
                 switch (value) {
                     case 'check': return 'check'
                     case 'information': return 'info-circle'

--- a/src/components/icon/Icon.vue
+++ b/src/components/icon/Icon.vue
@@ -4,7 +4,7 @@
             v-if="!useIconComponent"
             :class="[newPack, newIcon, newCustomSize, customClass]"/>
 
-         <component
+        <component
             v-if="useIconComponent"
             :is="useIconComponent"
             :icon="[newPack, newIcon]"

--- a/src/components/icon/Icon.vue
+++ b/src/components/icon/Icon.vue
@@ -7,7 +7,9 @@
          <component
             v-if="useIconComponent"
             :is="useIconComponent"
-            :icon="[newPack, newIcon]"/>
+            :icon="[newPack, newIcon]"
+            :size="newCustomSize"
+            :class="[customClass]"/>
     </span>
 </template>
 
@@ -34,7 +36,7 @@
             newIcon() {
                 return this.newPack === 'mdi'
                     ? `${this.newPack}-${this.icon}`
-                    : this.getFAIconOf(this.icon)
+                    : this.addFAPrefix(this.getEquivalentIconOf(this.icon))
             },
             newPack() {
                 return this.pack || config.defaultIconPack
@@ -63,13 +65,13 @@
             customSizeByPack() {
                 const defaultSize = this.newPack === 'mdi'
                     ? 'mdi-24px'
-                    : 'fa-lg'
+                    : this.addFAPrefix('lg')
                 const mediumSize = this.newPack === 'mdi'
                     ? 'mdi-36px'
-                    : 'fa-2x'
+                    : this.addFAPrefix('2x')
                 const largeSize = this.newPack === 'mdi'
                     ? 'mdi-48px'
-                    : 'fa-3x'
+                    : this.addFAPrefix('3x')
                 switch (this.size) {
                     case 'is-small': return
                     case 'is-medium': return mediumSize
@@ -82,11 +84,11 @@
             }
         },
         methods: {
-            getFAIconOf(value) {
+            addFAPrefix(value) {
                 if (this.useIconComponent) {
-                    return this.getEquivalentIconOf(this.icon)
+                    return value
                 }
-                return `fa-${this.getEquivalentIconOf(this.icon)}`
+                return `fa-${value}`
             },
 
             /**

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -1,6 +1,7 @@
 let config = {
     defaultContainerElement: null,
     defaultIconPack: 'mdi',
+    defaultIconComponent: null,
     defaultDialogConfirmText: null,
     defaultDialogCancelText: null,
     defaultSnackbarDuration: 3500,


### PR DESCRIPTION
This PR adds support for the [Font Awesome svg component](
https://www.npmjs.com/package/@fortawesome/vue-fontawesome).

With Font Awesome 5 they provide a vue component to render icons as svg. This allows us to only import the icons we need ans use tree shaking to reduce the bundle size.  

With this PR, I added a `defaultIconComponent` config that is used to render the icon, instead of the `<i>` tag.

```js
import Vue from 'vue'
import Buefy from 'buefy'
import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'

Vue.use(Buefy, {
  defaultIconPack: 'fas',
  defaultIconComponent: FontAwesomeIcon
})
```
