### PR TITLE
Add 'todayInstantiator' property to allow custom today's Date creation

### DIFF
--- a/docs/pages/components/datepicker/api/datepicker.js
+++ b/docs/pages/components/datepicker/api/datepicker.js
@@ -23,6 +23,13 @@ export default [
                 default: '<code>(date) => new Date(Date.parse(date))</code>'
             },
             {
+                name: '<code>date-instantiator</code>',
+                description: 'Function used internally to create a new Date instance',
+                type: 'Function',
+                values: '—',
+                default: '<code>() => new Date()</code>'
+            },
+            {
                 name: '<code>min-date</code>',
                 description: 'Earliest date available for selection',
                 type: 'Date',

--- a/docs/pages/components/datepicker/api/datepicker.js
+++ b/docs/pages/components/datepicker/api/datepicker.js
@@ -23,7 +23,7 @@ export default [
                 default: '<code>(date) => new Date(Date.parse(date))</code>'
             },
             {
-                name: '<code>date-instantiator</code>',
+                name: '<code>date-creator</code>',
                 description: 'Function used internally to create a new Date instance',
                 type: 'Function',
                 values: '—',

--- a/docs/pages/installation/api/constructor-options.js
+++ b/docs/pages/installation/api/constructor-options.js
@@ -87,6 +87,13 @@ export default [
                 default: '<code>Date.parse(date)</code>'
             },
             {
+                name: '<code>defaultTodayInstantiator</code>',
+                description: `Default datepicker <code>today-instantiator</code> attribute`,
+                type: 'Function',
+                values: '—',
+                default: '<code>new Date()</code>'
+            },
+            {
                 name: '<code>defaultDayNames</code>',
                 description: `Default datepicker <code>day-names</code> attribute`,
                 type: 'Array',

--- a/docs/pages/installation/api/constructor-options.js
+++ b/docs/pages/installation/api/constructor-options.js
@@ -87,8 +87,8 @@ export default [
                 default: '<code>Date.parse(date)</code>'
             },
             {
-                name: '<code>defaultTodayInstantiator</code>',
-                description: `Default datepicker <code>today-instantiator</code> attribute`,
+                name: '<code>defaultDateCreator</code>',
+                description: `Default datepicker <code>date-creator</code> attribute`,
                 type: 'Function',
                 values: '—',
                 default: '<code>new Date()</code>'

--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -109,7 +109,7 @@
                     :selectable-dates="selectableDates"
                     :events="events"
                     :indicators="indicators"
-                    :today-instantiator="todayInstantiator"
+                    :date-creator="dateCreator"
                     @close="$refs.dropdown.isActive = false"/>
 
                 <footer
@@ -258,11 +258,11 @@
                     }
                 }
             },
-            todayInstantiator: {
+            dateCreator: {
                 type: Function,
                 default: () => {
-                    if (typeof config.defaultTodayInstantiator === 'function') {
-                        return config.defaultTodayInstantiator()
+                    if (typeof config.defaultDateCreator === 'function') {
+                        return config.defaultDateCreator()
                     } else {
                         return new Date()
                     }
@@ -282,7 +282,7 @@
             }
         },
         data() {
-            const focusedDate = this.value || this.focusedDate || this.todayInstantiator()
+            const focusedDate = this.value || this.focusedDate || this.dateCreator()
 
             return {
                 dateSelected: this.value,
@@ -303,7 +303,7 @@
                 const latestYear = this.maxDate
                 ? this.maxDate.getFullYear()
                     : (Math.max(
-                        this.todayInstantiator().getFullYear(),
+                        this.dateCreator().getFullYear(),
                         this.focusedDateData.year) + 3)
 
                 const earliestYear = this.minDate
@@ -341,7 +341,7 @@
             * Update internal focusedDateData
             */
             dateSelected(value) {
-                const currentDate = !value ? this.todayInstantiator() : value
+                const currentDate = !value ? this.dateCreator() : value
                 this.focusedDateData = {
                     month: currentDate.getMonth(),
                     year: currentDate.getFullYear()

--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -109,6 +109,7 @@
                     :selectable-dates="selectableDates"
                     :events="events"
                     :indicators="indicators"
+                    :today-instantiator="todayInstantiator"
                     @close="$refs.dropdown.isActive = false"/>
 
                 <footer
@@ -257,6 +258,16 @@
                     }
                 }
             },
+            todayInstantiator: {
+                type: Function,
+                default: () => {
+                    if (typeof config.defaultTodayInstantiator === 'function') {
+                        return config.defaultTodayInstantiator()
+                    } else {
+                        return new Date()
+                    }
+                }
+            },
             mobileNative: {
                 type: Boolean,
                 default: () => {
@@ -271,7 +282,7 @@
             }
         },
         data() {
-            const focusedDate = this.value || this.focusedDate || new Date()
+            const focusedDate = this.value || this.focusedDate || this.todayInstantiator()
 
             return {
                 dateSelected: this.value,
@@ -291,7 +302,9 @@
             listOfYears() {
                 const latestYear = this.maxDate
                 ? this.maxDate.getFullYear()
-                    : (Math.max(new Date().getFullYear(), this.focusedDateData.year) + 3)
+                    : (Math.max(
+                        this.todayInstantiator().getFullYear(),
+                        this.focusedDateData.year) + 3)
 
                 const earliestYear = this.minDate
                 ? this.minDate.getFullYear() : 1900
@@ -328,7 +341,7 @@
             * Update internal focusedDateData
             */
             dateSelected(value) {
-                const currentDate = !value ? new Date() : value
+                const currentDate = !value ? this.todayInstantiator() : value
                 this.focusedDateData = {
                     month: currentDate.getMonth(),
                     year: currentDate.getFullYear()

--- a/src/components/datepicker/DatepickerTable.vue
+++ b/src/components/datepicker/DatepickerTable.vue
@@ -23,7 +23,7 @@
                 :selectable-dates="selectableDates"
                 :events="eventsInThisWeek(week, index)"
                 :indicators="indicators"
-                :today-instantiator="todayInstantiator"
+                :date-creator="dateCreator"
                 @select="updateSelectedDate"/>
         </div>
     </section>
@@ -48,7 +48,7 @@
             maxDate: Date,
             focused: Object,
             disabled: Boolean,
-            todayInstantiator: Function,
+            dateCreator: Function,
             unselectableDates: Array,
             unselectableDaysOfWeek: Array,
             selectableDates: Array

--- a/src/components/datepicker/DatepickerTable.vue
+++ b/src/components/datepicker/DatepickerTable.vue
@@ -23,6 +23,7 @@
                 :selectable-dates="selectableDates"
                 :events="eventsInThisWeek(week, index)"
                 :indicators="indicators"
+                :today-instantiator="todayInstantiator"
                 @select="updateSelectedDate"/>
         </div>
     </section>
@@ -47,6 +48,7 @@
             maxDate: Date,
             focused: Object,
             disabled: Boolean,
+            todayInstantiator: Function,
             unselectableDates: Array,
             unselectableDaysOfWeek: Array,
             selectableDates: Array

--- a/src/components/datepicker/DatepickerTableRow.spec.js
+++ b/src/components/datepicker/DatepickerTableRow.spec.js
@@ -15,7 +15,7 @@ describe('BDatepickerTableRow', () => {
                     new Date('Sat Jan 06 2018 00:00:00 GMT-0200 (-02)')
                 ],
                 month: 12,
-                todayInstantiator: function () {
+                dateCreator: function () {
                     return new Date()
                 }
             }

--- a/src/components/datepicker/DatepickerTableRow.spec.js
+++ b/src/components/datepicker/DatepickerTableRow.spec.js
@@ -14,7 +14,10 @@ describe('BDatepickerTableRow', () => {
                     new Date('Fri Jan 05 2018 00:00:00 GMT-0200 (-02)'),
                     new Date('Sat Jan 06 2018 00:00:00 GMT-0200 (-02)')
                 ],
-                month: 12
+                month: 12,
+                todayInstantiator: function () {
+                    return new Date()
+                }
             }
         })
         expect(wrapper.name()).toBe('BDatepickerTableRow')

--- a/src/components/datepicker/DatepickerTableRow.vue
+++ b/src/components/datepicker/DatepickerTableRow.vue
@@ -55,7 +55,7 @@
             selectableDates: Array,
             events: Array,
             indicators: String,
-            todayInstantiator: Function
+            dateCreator: Function
         },
         methods: {
             /*
@@ -155,7 +155,7 @@
 
                 return {
                     'is-selected': dateMatch(day, this.selectedDate),
-                    'is-today': dateMatch(day, this.todayInstantiator()),
+                    'is-today': dateMatch(day, this.dateCreator()),
                     'is-selectable': this.selectableDate(day) && !this.disabled,
                     'is-unselectable': !this.selectableDate(day) || this.disabled
                 }

--- a/src/components/datepicker/DatepickerTableRow.vue
+++ b/src/components/datepicker/DatepickerTableRow.vue
@@ -54,7 +54,8 @@
             unselectableDaysOfWeek: Array,
             selectableDates: Array,
             events: Array,
-            indicators: String
+            indicators: String,
+            todayInstantiator: Function
         },
         methods: {
             /*
@@ -154,7 +155,7 @@
 
                 return {
                     'is-selected': dateMatch(day, this.selectedDate),
-                    'is-today': dateMatch(day, new Date()),
+                    'is-today': dateMatch(day, this.todayInstantiator()),
                     'is-selectable': this.selectableDate(day) && !this.disabled,
                     'is-unselectable': !this.selectableDate(day) || this.disabled
                 }

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -10,6 +10,7 @@ let config = {
     defaultInputAutocomplete: 'on',
     defaultDateFormatter: null,
     defaultDateParser: null,
+    defaultTodayInstantiator: null,
     defaultDayNames: null,
     defaultMonthNames: null,
     defaultFirstDayOfWeek: null,

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -10,7 +10,7 @@ let config = {
     defaultInputAutocomplete: 'on',
     defaultDateFormatter: null,
     defaultDateParser: null,
-    defaultTodayInstantiator: null,
+    defaultDateCreator: null,
     defaultDayNames: null,
     defaultMonthNames: null,
     defaultFirstDayOfWeek: null,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -26,7 +26,7 @@ export declare type BuefyConfig = {
     defaultInputAutocomplete: 'on' | 'off';
     defaultDateFormatter?: string;
     defaultDateParser?: string;
-    defaultTodayInstantiator?: string;
+    defaultDateCreator?: string;
     defaultDayNames?: string;
     defaultMonthNames?: string;
     defaultFirstDayOfWeek?: string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -26,6 +26,7 @@ export declare type BuefyConfig = {
     defaultInputAutocomplete: 'on' | 'off';
     defaultDateFormatter?: string;
     defaultDateParser?: string;
+    defaultTodayInstantiator?: string;
     defaultDayNames?: string;
     defaultMonthNames?: string;
     defaultFirstDayOfWeek?: string;


### PR DESCRIPTION
Fixes https://github.com/buefy/buefy/issues/1080 by adding a new `todayInstantiator` property.

This allows to pass a function like this:

```html
<b-datepicker :today-instantiator="todayInstantiator"></b-datepicker>
```

```js
todayInstantiator() {
    return new Date()
},
```

This fixes some issues when the browser default new Date() instantiation used inside the component does not match the way each application works with dates.

For example, in an app that uses Moment or Luxon to set a timezone, the today's date set by the app can be different from the today's date used inside the component.

With this property I have the freedom to do something like this:

```js
todayInstantiator() {
    return moment().tz('Australia/Sydney').toDate()
},
```

The `todayInstantiator` property is a function that must always return a regular JS Date object representing today's date.

**Please note** this function only applies when the component wants to get the today's date using `new Date()` and does not change anything else, ensuring that nothing breaks.