### PR TITLE
add docs for the table `striped` prop

### DIFF
--- a/docs/pages/components/table/api/table.js
+++ b/docs/pages/components/table/api/table.js
@@ -38,6 +38,13 @@ export default [
                 default: '<code>false</code>'
             },
             {
+                name: '<code>striped</code>',
+                description: 'Whether table is striped',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
                 name: '<code>narrowed</code>',
                 description: 'Makes the cells narrower',
                 type: 'Boolean',


### PR DESCRIPTION
`striped` is documented via an example, but is missing in the API table