### PR TITLE
table: add multicolumn sort support

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "build:lib": "node build/build-lib.js",
     "build:docs": "node build/build.js",
     "build": "npm run build:lib && npm run build:docs",
+    "prepare": "npm run build",
     "cov": "./node_modules/codcov/bin/codcov"
   },
   "keywords": [

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -362,6 +362,7 @@
              */
             data(value) {
                 // Save newColumns before resetting
+                const currentSortColumns = this.currentSortColumns
                 const newColumns = this.newColumns
 
                 this.newColumns = []
@@ -370,6 +371,9 @@
                 // Prevent table from being headless, data could change and created hook
                 // on column might not trigger
                 this.$nextTick(() => {
+                    // The column's v-for causes newColumns array to increment which
+                    // will clear currentSortColumns, restore them...
+                    this.currentSortColumns = currentSortColumns
                     if (!this.newColumns.length) this.newColumns = newColumns
                 })
 


### PR DESCRIPTION
Hey, totally understand if you don't want to merge this but I have added multicolumn support to the table component as it was a requirement for what I needed. It works the same way as datatables where you hold shift to select multiple columns. The only breaking change I believe is that it now accepts a list of sortfields so this: `[field1, field2, field3]` or this `[[field1, desc], [field2, asc]]`. Hopefully it is bug free too, been testing it for the last week in backend mode.