### PR TITLE
Docs | Add example of loading inside router hook

### DIFF
--- a/docs/pages/components/loading/Loading.vue
+++ b/docs/pages/components/loading/Loading.vue
@@ -12,6 +12,10 @@
             <p>When you want to close the Loading, call the <code>close()</code> method from the component.</p>
         </Example>
 
+        <Example :component="ExRouterHook" :code="ExRouterHookCode" title="Using inside router hooks">
+            <p>If you want to use the loading component in a component's navigation guard.</p>
+        </Example>
+
         <ApiView :data="api"/>
     </div>
 </template>
@@ -25,6 +29,9 @@
     import ExProgrammatically from './examples/ExProgrammatically'
     import ExProgrammaticallyCode from '!!raw-loader!./examples/ExProgrammatically'
 
+    import ExRouterHook from './examples/ExRouterHook'
+    import ExRouterHookCode from '!!raw-loader!./examples/ExRouterHook'
+
     export default {
         data() {
             return {
@@ -32,7 +39,9 @@
                 ExSimple,
                 ExProgrammatically,
                 ExSimpleCode,
-                ExProgrammaticallyCode
+                ExProgrammaticallyCode,
+                ExRouterHook,
+                ExRouterHookCode
             }
         }
     }

--- a/docs/pages/components/loading/examples/ExRouterHook.vue
+++ b/docs/pages/components/loading/examples/ExRouterHook.vue
@@ -1,0 +1,40 @@
+<template>
+    <div>
+        <b-field>
+            <button class="button is-primary is-medium">
+                Launch loading
+            </button>
+        </b-field>
+        <b-field>
+            <b-switch>Display loader over full page</b-switch>
+        </b-field>
+        <b-notification :closable="false">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id fermentum quam. Proin sagittis, nibh id hendrerit imperdiet, elit sapien laoreet elit
+        </b-notification>
+    </div>
+</template>
+
+<script>
+    function fetchData(id) {
+        return {
+            id: 1,
+            firstName: 'John',
+            lastName: 'Doe'
+        }
+    }
+
+    export default {
+        beforeRouteEnter(to, from, next) {
+            const loading = Vue.prototype.$loading.open();
+
+            fetchData(to.params.id).then(() => {
+                next(() => loading.close())
+            });
+        },
+        data() {
+            return {
+                isFullPage: true,
+            }
+        }
+    }
+</script>


### PR DESCRIPTION
It is a common use case to use the `bloading `component inside a component navigation guard.

Fixes #312 