### PR TITLE
Add "parent" prop for Snackbar

### DIFF
--- a/src/components/snackbar/index.js
+++ b/src/components/snackbar/index.js
@@ -6,6 +6,7 @@ import { use, registerComponentProgrammatic } from '../../utils/plugins'
 const SnackbarProgrammatic = {
     open(params) {
         let message
+        let parent
         if (typeof params === 'string') message = params
 
         const defaultParam = {
@@ -13,11 +14,16 @@ const SnackbarProgrammatic = {
             position: 'is-bottom-right',
             message
         }
+        if (params.parent) {
+            parent = params.parent
+            delete params.parent
+        }
         const propsData = Object.assign(defaultParam, params)
 
         const vm = typeof window !== 'undefined' && window.Vue ? window.Vue : Vue
         const SnackbarComponent = vm.extend(Snackbar)
         return new SnackbarComponent({
+            parent,
             el: document.createElement('div'),
             propsData
         })


### PR DESCRIPTION
This PR to make **snackbar** component work like modal component

# Description:
We are using **buefy** with **nuxt** which uses **vue-meta** which depends on `$parent` prop to setup meta tags on HTML head section.

# Problem:
Currently as soon as **snackbar** is created, nuxt checks for `$parent` prop then populate another prop (`$metaInfo`) then update the HTML head section accordingly. Because there's no parent prop passed in, `$metaInfo` prop is empty, nuxt remove some existing meta tags which causes broken page.

 