### PR TITLE
Add text-color property to BInput component

### DIFF
--- a/docs/pages/components/input/api/input.js
+++ b/docs/pages/components/input/api/input.js
@@ -72,6 +72,13 @@ export default [
                 default: '<code>true</code>'
             },
             {
+                name: '<code>text-color</code>',
+                description: 'Color to be used in input text, optional',
+                type: 'String',
+                values: 'Any Bulma text color class, or custom text color class',
+                default: '—'
+            },
+            {
                 name: 'Any native attribute',
                 description: '—',
                 type: '—',

--- a/src/components/input/Input.vue
+++ b/src/components/input/Input.vue
@@ -75,6 +75,10 @@
             hasCounter: {
                 type: Boolean,
                 default: () => config.defaultInputHasCounter
+            },
+            textColor: {
+                type: String,
+                default: ''
             }
         },
         data() {
@@ -104,6 +108,7 @@
                 return [
                     this.statusType,
                     this.size,
+                    this.textColor,
                     { 'is-rounded': this.rounded }
                 ]
             },


### PR DESCRIPTION
Adding a text-color property to the BInput component enable the use of any Bulma text color class or custom class to change the color of text within an input field.
