### PR TITLE
Config for individual use of components

### DIFF
--- a/docs/pages/installation/ConstructorOptions.vue
+++ b/docs/pages/installation/ConstructorOptions.vue
@@ -3,6 +3,12 @@
         <div class="example is-paddingless">
             <CodeView :code="usage | pre" lang="javascript" expanded/>
         </div>
+        
+        <b-message type="is-warning">
+            If using components individually, set global options like this:<br>
+            <code>import config from 'buefy/src/utils/config';</code><br>
+            <code>config.defaultIconPack = 'fas'; // or any other constructor option</code>
+        </b-message>
 
         <ApiView :data="api"/>
     </div>


### PR DESCRIPTION
When using components individually, one must first import the config object to set global options. Thought that info would be useful here.