### PR TITLE
use meaningful link text instead of "here"

### DIFF
--- a/docs/pages/installation/Customization.vue
+++ b/docs/pages/installation/Customization.vue
@@ -19,7 +19,7 @@
                 <h3 class="subtitle">Set your variables with Sass</h3>
                 <b-message type="is-info">
                     <div class="content">
-                        <p><b>Tip:</b> You can see all Bulma's variables <a href="http://bulma.io/documentation/overview/variables/" target="_blank">here</a>.</p>
+                        <p><b>Tip:</b> You can see <a href="http://bulma.io/documentation/overview/variables/" target="_blank">all of Bulma's variables</a>.</p>
                         <p>There's also two other variables created by Buefy:</p>
                         <ol>
                             <li><code>$speed-slow: 150ms !default</code></li>


### PR DESCRIPTION
I know this link is on the page but it always takes me a few extra seconds to find it. Plus, accessibility win. 

aside: Loving Buefy!