### PR TITLE
Accessibility for Collapse component. 

### DIFF
--- a/docs/pages/components/collapse/api/collapse.js
+++ b/docs/pages/components/collapse/api/collapse.js
@@ -14,6 +14,13 @@ export default [
                 type: 'String',
                 values: '—',
                 default: '<code>fade</code>'
+            },
+            {
+                name: '<code>a11y-id</code>',
+                description: 'Id for the container div. Should be used with aria-controls on trigger for better accessibility.',
+                type: 'String',
+                values: '—',
+                default: ''
             }
         ],
         slots: [

--- a/docs/pages/components/collapse/api/collapse.js
+++ b/docs/pages/components/collapse/api/collapse.js
@@ -16,7 +16,7 @@ export default [
                 default: '<code>fade</code>'
             },
             {
-                name: '<code>a11y-id</code>',
+                name: '<code>aria-id</code>',
                 description: 'Id for the container div. Should be used with aria-controls on trigger for better accessibility.',
                 type: 'String',
                 values: '—',

--- a/docs/pages/components/collapse/examples/ExCardTemplate.vue
+++ b/docs/pages/components/collapse/examples/ExCardTemplate.vue
@@ -1,7 +1,7 @@
 <template>
     <section>
 
-        <b-collapse class="card" a11y-id="contentIdForA11y3">
+        <b-collapse class="card" aria-id="contentIdForA11y3">
             <div
                 slot="trigger" 
                 slot-scope="props"

--- a/docs/pages/components/collapse/examples/ExCardTemplate.vue
+++ b/docs/pages/components/collapse/examples/ExCardTemplate.vue
@@ -1,8 +1,13 @@
 <template>
     <section>
 
-        <b-collapse class="card">
-            <div slot="trigger" slot-scope="props" class="card-header">
+        <b-collapse class="card" a11y-id="contentIdForA11y3">
+            <div
+                slot="trigger" 
+                slot-scope="props"
+                class="card-header"
+                role="button"
+                aria-controls="contentIdForA11y3">
                 <p class="card-header-title">
                     Component
                 </p>

--- a/docs/pages/components/collapse/examples/ExPanelTemplate.vue
+++ b/docs/pages/components/collapse/examples/ExPanelTemplate.vue
@@ -11,7 +11,7 @@
         </div>
 
         <b-collapse
-                a11y-id="contentIdForA11y2"
+                aria-id="contentIdForA11y2"
                 class="panel"
                 :open.sync="isOpen">
             <div

--- a/docs/pages/components/collapse/examples/ExPanelTemplate.vue
+++ b/docs/pages/components/collapse/examples/ExPanelTemplate.vue
@@ -2,14 +2,23 @@
     <section>
 
         <div class="block">
-            <button class="button is-medium is-primary"
-                @click="isOpen = !isOpen">
+            <button
+                class="button is-medium is-primary"
+                @click="isOpen = !isOpen"
+                aria-controls="contentIdForA11y2">
                 Toggle
             </button>
         </div>
 
-        <b-collapse class="panel" :open.sync="isOpen">
-            <div slot="trigger" class="panel-heading">
+        <b-collapse
+                a11y-id="contentIdForA11y2"
+                class="panel"
+                :open.sync="isOpen">
+            <div
+                slot="trigger"
+                class="panel-heading"
+                role="button"
+                aria-controls="contentIdForA11y2">
                 <strong>Title</strong>
             </div>
             <p class="panel-tabs">

--- a/docs/pages/components/collapse/examples/ExSimple.vue
+++ b/docs/pages/components/collapse/examples/ExSimple.vue
@@ -1,7 +1,7 @@
 <template>
     <section>
 
-        <b-collapse :open="false" a11y-id="contentIdForA11y1">
+        <b-collapse :open="false" aria-id="contentIdForA11y1">
             <button
                 class="button is-primary"
                 slot="trigger"

--- a/docs/pages/components/collapse/examples/ExSimple.vue
+++ b/docs/pages/components/collapse/examples/ExSimple.vue
@@ -1,8 +1,11 @@
 <template>
     <section>
 
-        <b-collapse :open="false">
-            <button class="button is-primary" slot="trigger">Click me!</button>
+        <b-collapse :open="false" a11y-id="contentIdForA11y1">
+            <button
+                class="button is-primary"
+                slot="trigger"
+                aria-controls="contentIdForA11y1">Click me!</button>
             <div class="notification">
                 <div class="content">
                     <h3>

--- a/src/components/collapse/Collapse.vue
+++ b/src/components/collapse/Collapse.vue
@@ -5,7 +5,7 @@
         </div>
         <transition :name="animation">
             <div
-                :id="a11yId"
+                :id="ariaId"
                 :aria-expanded="isOpen"
                 class="collapse-content"
                 v-show="isOpen">
@@ -27,7 +27,7 @@
                 type: String,
                 default: 'fade'
             },
-            a11yId: {
+            ariaId: {
                 type: String,
                 default: ''
             }

--- a/src/components/collapse/Collapse.vue
+++ b/src/components/collapse/Collapse.vue
@@ -4,7 +4,11 @@
             <slot name="trigger" :open="isOpen" />
         </div>
         <transition :name="animation">
-            <div class="collapse-content" v-show="isOpen">
+            <div
+                :id="a11yId"
+                :aria-expanded="isOpen"
+                class="collapse-content"
+                v-show="isOpen">
                 <slot/>
             </div>
         </transition>
@@ -22,6 +26,10 @@
             animation: {
                 type: String,
                 default: 'fade'
+            },
+            a11yId: {
+                type: String,
+                default: ''
             }
         },
         data() {


### PR DESCRIPTION
Puts aria-expanded. Creates a11y-id props to bused on div content. Adds aria-controls and role to triggers on documentation.

This is the first commit of a serious of upcoming related to accessibility. Naming conventions,such as the a11y for the special id prop are still being discussed.