### PR TITLE
Fix Modal width limit set by Bulma

### DIFF
--- a/docs/pages/components/modal/api/modal.js
+++ b/docs/pages/components/modal/api/modal.js
@@ -46,7 +46,7 @@ export default [
             },
             {
                 name: '<code>width</code>',
-                description: 'Width of the Modal, maximum of <code>960</code>',
+                description: 'Width of the Modal',
                 type: 'Number, String',
                 values: '—',
                 default: '<code>960</code>'

--- a/src/scss/components/_modal.scss
+++ b/src/scss/components/_modal.scss
@@ -8,4 +8,7 @@
             width: 100%;
         }
     }
+    .modal-content {
+        width: 100%;
+    }
 }


### PR DESCRIPTION
This fixes the problem that setting the `width` prop of Modal over 640px does not take effect.

Bulma has a fixed variable defining the width of `modal-content` class, which defaults to 640px. Currently, setting `width` of Modal larger than 640px is not working (see "Launch image modal" in documentation).

By setting style of width 100% on `modal-content` also keeps modal component in card with `has-modal-card` prop working as before.

closes #905 #1135 