### PR TITLE
Allow wider range of Vue versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "bulma": "0.7.2"
   },
   "peerDependencies": {
-    "vue": "2.5.x"
+    "vue": "^2.5.13"
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "5.3.1",


### PR DESCRIPTION
Restrict Vue peer dependency to `^2.5.13` (equivalent to `>= 2.5.13 < 3.0.0`), allowing a much
wider range of Vue versions.

Closes #1218