### PR TITLE
Change left margin to right margin when spacing nested fields

### DIFF
--- a/src/scss/components/_form.scss
+++ b/src/scss/components/_form.scss
@@ -6,8 +6,8 @@
     &.is-grouped {
         .field {
             flex-shrink: 0;
-            &+.field {
-                margin-left: 0.75rem;
+            &:not(:last-child) {
+                margin-right: 0.75rem;
             }
             &.is-expanded {
                 flex-grow: 1;


### PR DESCRIPTION
Change to use right margins to space nested fields, which is then consistent with grouped controls in Bulma. It will solve the problem of a left margin in wrapped lines when group-multiline is applied in #1228 . 