### PR TITLE
Edit Upload documentation

### DIFF
--- a/docs/pages/components/upload/api/upload.js
+++ b/docs/pages/components/upload/api/upload.js
@@ -79,7 +79,7 @@ export default [
             {
                 name: '<code>input</code>',
                 description: 'Triggers when the file list is changed',
-                parameters: '<code>value: Array</code>'
+                parameters: '<code>value: File</code> or <code>File[]</code>'
             }
         ],
         methods: [


### PR DESCRIPTION
Curarent description for upload component event (`value: Array`) is insufficient.

Proposal:

`value: File` or `File[]`