### PR TITLE
Fix CodePen links in doc

### DIFF
--- a/docs/components/CodepenEdit.vue
+++ b/docs/components/CodepenEdit.vue
@@ -55,8 +55,8 @@
                     css_external: this.externalStyles.join(';'),
                     js_external: this.externalScripts.join(';')
                 })
-                    .replace(/"/g, '&​quot;')
-                    .replace(/'/g, '&apos;')
+                    .replace(/"/g, '\u0022')
+                    .replace(/'/g, '\u0027')
             }
         },
         methods: {


### PR DESCRIPTION
Fix #1232 

Vue re-escapes html attributes. Use unicode as workaround (from  https://github.com/vuejs/vue/issues/7994). Before `&quot;` was escaped again to `&amp;&#8203;quot;`. Maybe CodePen changes and does not like it now. 