### PR TITLE
Show loading spinner on confirm button of dialog when callback returns a Promise

### DIFF
--- a/docs/pages/components/dialog/api/dialog.js
+++ b/docs/pages/components/dialog/api/dialog.js
@@ -91,7 +91,7 @@ export default [
             {
                 name: '<code>onConfirm</code>',
                 description: 'Callback function when the confirm button is clicked',
-                type: 'Function (value: String)',
+                type: 'Function (value: String): void, Promise',
                 values: '—',
                 default: '—'
             },

--- a/src/components/dialog/Dialog.vue
+++ b/src/components/dialog/Dialog.vue
@@ -51,7 +51,7 @@
                     </button>
                     <button
                         class="button"
-                        :class="type"
+                        :class="confirmButtonClass"
                         ref="confirmButton"
                         @click="confirm">
                         {{ confirmText }}
@@ -123,7 +123,8 @@
             return {
                 prompt,
                 isActive: false,
-                validationMessage: ''
+                validationMessage: '',
+                isConfirming: false
             }
         },
         computed: {
@@ -146,6 +147,12 @@
             },
             showCancel() {
                 return this.cancelOptions.indexOf('button') >= 0
+            },
+            confirmButtonClass() {
+                return {
+                    [this.type]: true,
+                    'is-loading': this.isConfirming
+                }
             }
         },
         methods: {
@@ -162,8 +169,20 @@
                     }
                 }
 
-                this.onConfirm(this.prompt)
-                this.close()
+                this.isConfirming = true
+                const confirmationResult = this.onConfirm(this.prompt)
+
+                Promise.resolve(confirmationResult)
+                    .then(() => {
+                        this.isConfirming = false
+
+                        this.close()
+                    })
+                    .catch((error) => {
+                        this.isConfirming = false
+
+                        throw error
+                    })
             },
 
             /**


### PR DESCRIPTION
This PR would add Bulma's `is-loading` class to the confirm button of a Dialog when its callback returns a Promise. The spinner will be visible until the confirm Promise resolves.
The usage of the Dialog doesn't change as any result of the confirmation callback is "promisified" using `Promise.resolve()`. This means that any normal or void function will resolve immediately whereas an async function returns a Promise which will be awaited.

![image](https://user-images.githubusercontent.com/678686/53244535-76166f00-36ab-11e9-9a24-6929eb68a917.png)
