### PR TITLE
Added preventDefault on mousedown when selecting an option

### DIFF
--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -38,7 +38,8 @@
                         :key="index"
                         class="dropdown-item"
                         :class="{ 'is-hovered': option === hovered }"
-                        @click="setSelected(option)">
+                        @click="setSelected(option)"
+                        @mousedown.prevent>
 
                         <slot
                             v-if="hasDefaultSlot"


### PR DESCRIPTION
Adding this switches the order of the events when clicking/selecting an option. This is useful for when you auto-select an item on blur, etc.

**Before**
1. mousedown
2. blur (from input)
3. mouseup
4. click

**After**
1. mousedown
2. mouseup
3. click
4. blur