### PR TITLE
Improve datepicker accessibility

### DIFF
--- a/docs/pages/components/datepicker/api/datepicker.js
+++ b/docs/pages/components/datepicker/api/datepicker.js
@@ -163,6 +163,13 @@ export default [
                 default: 'Bottom right'
             },
             {
+                name: '<code>open-on-focus</code>',
+                description: 'Open datepicker on input focus',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
                 name: 'Any native attribute',
                 description: '—',
                 type: '—',

--- a/src/components/datepicker/Datepicker.spec.js
+++ b/src/components/datepicker/Datepicker.spec.js
@@ -1,10 +1,92 @@
-import { shallowMount } from '@vue/test-utils'
+import {
+    mount
+} from '@vue/test-utils'
 import BDatepicker from '@components/datepicker/Datepicker'
 
+const dropdownMenu = '.dropdown-menu'
+let wrapper, $dropdown, $input
+
 describe('BDatepicker', () => {
+    beforeEach(() => {
+        wrapper = mount(BDatepicker, {
+            stubs: {
+                transition: false
+            }
+        })
+        $dropdown = wrapper.find(dropdownMenu)
+        $input = wrapper.find('input')
+    })
+
     it('is called', () => {
-        const wrapper = shallowMount(BDatepicker)
         expect(wrapper.name()).toBe('BDatepicker')
         expect(wrapper.isVueInstance()).toBeTruthy()
+    })
+
+    it('has an input type', () => {
+        expect(wrapper.contains('.control .input[type=text]')).toBeTruthy()
+    })
+
+    it('has a dropdown menu hidden by default', () => {
+        expect(wrapper.contains(dropdownMenu)).toBeTruthy()
+        expect($dropdown.isVisible()).toBeFalsy()
+    })
+
+    it('has no input type when inline', () => {
+        wrapper.setProps({
+            inline: 'true'
+        })
+        expect(wrapper.contains('.control .input[type=text]')).toBeFalsy()
+    })
+
+    it('has a dropdown menu visible when inline', () => {
+        wrapper.setProps({
+            inline: 'true'
+        })
+        expect(wrapper.contains(dropdownMenu)).toBeTruthy()
+        expect($dropdown.isVisible()).toBeTruthy()
+    })
+
+    it('call toggle method', () => {
+        wrapper.vm.$refs.dropdown.isActive = false
+        wrapper.vm.toggle()
+        expect(wrapper.vm.$refs.dropdown.isActive).toBeTruthy()
+        expect($dropdown.isVisible()).toBeTruthy()
+
+        wrapper.vm.toggle(false)
+        expect(wrapper.vm.$refs.dropdown.isActive).toBeFalsy()
+    })
+
+    it('can emit input, focus and blur events', () => {
+        $input.trigger('focus')
+        expect(wrapper.emitted()['focus']).toBeTruthy()
+        $input.trigger('blur')
+        expect(wrapper.emitted()['blur']).toBeTruthy()
+    })
+
+    it('can open datepicker on openOnfocus', () => {
+        wrapper.setProps({
+            openOnFocus: true
+        })
+        $input.trigger('focus')
+        expect(wrapper.vm.$refs.dropdown.isActive).toBeTruthy()
+        expect($dropdown.isVisible()).toBeTruthy()
+    })
+
+    it('can open datepicker on enter', () => {
+        wrapper.setProps({
+            openOnFocus: false
+        })
+        $input.trigger('focus')
+        $input.trigger('keyup.enter')
+        expect(wrapper.vm.$refs.dropdown.isActive).toBeTruthy()
+        expect($dropdown.isVisible()).toBeTruthy()
+    })
+
+    it('can close datepicker on esc', () => {
+        wrapper.vm.$refs.dropdown.isActive = true
+        const keyupEvent = new Event('keyup')
+        keyupEvent.keyCode = 27
+        window.document.dispatchEvent(keyupEvent)
+        wrapper.vm.$nextTick(() => expect($dropdown.isVisible()).toBeFalsy())
     })
 })

--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -113,9 +113,7 @@
                         :events="events"
                         :indicators="indicators"
                         :date-creator="dateCreator"
-                        @keyup.native.enter="toggle(true)"
-                        @click.native.stop
-                        @close="$refs.dropdown.isActive = false"/>
+                        @close="toggle(false)"/>
                 </div>
 
                 <footer
@@ -144,6 +142,7 @@
             v-bind="$attrs"
             @change.native="onChangeNativePicker"
             @click.native.stop="toggle(true)"
+            @keyup.native.enter="toggle(true)"
             @focus="handleOnFocus"
             @blur="onBlur"/>
     </div>
@@ -483,15 +482,6 @@
                     this.$refs.dropdown.isActive = typeof active === 'boolean'
                         ? active
                         : !this.$refs.dropdown.isActive
-                }
-            },
-
-            /*
-            * Close datepicker
-            */
-            close() {
-                if (this.$refs.dropdown) {
-                    this.$refs.dropdown.isActive = false
                 }
             },
 


### PR DESCRIPTION
Make datepicker accessible through keyboard only navigation (#1237 ).

**New behaviour**
- Tab into a datepicker field.
- Press `Enter` to open datepicker
- Use `Tab` + `Enter` to select a date or press `Esc` to close it

A new prop called `open-on-focus` has been added.
If true, the datepicker is open when the input field gets the focus (no need to press `Enter`). 