### PR TITLE
add option to use v-if in b-tab-item

### DIFF
--- a/src/components/tabs/TabItem.vue
+++ b/src/components/tabs/TabItem.vue
@@ -1,6 +1,6 @@
 <template>
     <transition :name="transitionName">
-        <div v-show="isActive && visible" class="tab-item">
+        <div v-show="isActive && visible" class="tab-item" v-if="!useIf || (isActive && visible)">
             <slot/>
         </div>
     </transition>
@@ -17,6 +17,10 @@
             visible: {
                 type: Boolean,
                 default: true
+            },
+            useIf: {
+                type: Boolean,
+                default: false
             }
         },
         data() {

--- a/src/components/tabs/TabItem.vue
+++ b/src/components/tabs/TabItem.vue
@@ -1,6 +1,7 @@
 <template>
     <transition :name="transitionName">
-        <div v-show="isActive && visible" class="tab-item" v-if="!useIf || (isActive && visible)">
+        <div v-show="isActive && visible" class="tab-item" 
+             v-if="!useIf || (isActive && visible)">
             <slot/>
         </div>
     </transition>


### PR DESCRIPTION
Conditional rendering is a pretty common use case when employing tabs. The current way of achieving this is to keep a track of `$index` and `activeTab`.  Will add documentation and coverage code if you could let me know that this is not an undesirable change.