### PR TITLE
Fix #1269 Switch captures focus twice

### DIFF
--- a/src/components/switch/Switch.vue
+++ b/src/components/switch/Switch.vue
@@ -13,6 +13,7 @@
         <input
             v-model="computedValue"
             type="checkbox"
+            tabindex="-1"
             @click.stop
             :disabled="disabled"
             :name="name"


### PR DESCRIPTION
Fix #1269. The hidden input checkbox captures the second focus when tabbing, which is disabled here. The focus on label is needed for visual effects, like glowing.