### PR TITLE
Fix space keydown prevent not working on Firefox at Checkbox

### DIFF
--- a/src/components/checkbox/Checkbox.vue
+++ b/src/components/checkbox/Checkbox.vue
@@ -4,11 +4,9 @@
         :class="[size, { 'is-disabled': disabled }]"
         ref="label"
         :disabled="disabled"
-        :tabindex="disabled ? false : 0"
-        @keydown.prevent.enter.space="$refs.label.click()">
+        @keydown.prevent.enter="$refs.label.click()">
         <input
             v-model="computedValue"
-            tabindex="-1"
             :indeterminate.prop="indeterminate"
             type="checkbox"
             :disabled="disabled"

--- a/src/components/checkbox/CheckboxButton.vue
+++ b/src/components/checkbox/CheckboxButton.vue
@@ -3,19 +3,22 @@
         <label
             class="b-checkbox checkbox button"
             ref="label"
-            :class="[checked ? type : null, size, { 'is-disabled': disabled }]"
+            :class="[checked ? type : null, size, {
+                'is-disabled': disabled,
+                'is-focused': isFocused
+            }]"
             :disabled="disabled"
-            :tabindex="disabled ? false : 0"
-            @keydown.prevent.enter.space="$refs.label.click()">
+            @keydown.prevent.enter="$refs.label.click()">
             <slot/>
             <input
                 v-model="computedValue"
-                tabindex="-1"
                 type="checkbox"
                 :disabled="disabled"
                 :required="required"
                 :name="name"
-                :value="nativeValue">
+                :value="nativeValue"
+                @focus="isFocused = true"
+                @blur="isFocused = false">
         </label>
     </div>
 </template>
@@ -37,7 +40,8 @@
         },
         data() {
             return {
-                newValue: this.value
+                newValue: this.value,
+                isFocused: false
             }
         },
         computed: {

--- a/src/scss/components/_checkbox.scss
+++ b/src/scss/components/_checkbox.scss
@@ -48,6 +48,20 @@ $checkbox-checkmark-color: $primary-invert !default;
                     }
                 }
             }
+            &:focus {
+                + .check {
+                    box-shadow: 0 0 0.5em rgba($grey, 0.8);
+                }
+                &:checked + .check {
+                    box-shadow: 0 0 0.5em rgba($checkbox-active-background-color, 0.8);
+                    @each $name, $pair in $colors {
+                        $color: nth($pair, 1);
+                        &.is-#{$name} {
+                            box-shadow: 0 0 0.5em rgba($color, 0.8);
+                        }
+                    }
+                }
+            }
         }
         .control-label {
             padding-left: 0.5em;
@@ -62,20 +76,6 @@ $checkbox-checkmark-color: $primary-invert !default;
                     $color: nth($pair, 1);
                     &.is-#{$name} {
                         border-color: $color;
-                    }
-                }
-            }
-        }
-        &:focus {
-            input[type=checkbox] + .check {
-                box-shadow: 0 0 0.5em rgba($grey, 0.8);
-            }
-            input[type=checkbox]:checked + .check {
-                box-shadow: 0 0 0.5em rgba($checkbox-active-background-color, 0.8);
-                @each $name, $pair in $colors {
-                    $color: nth($pair, 1);
-                    &.is-#{$name} {
-                        box-shadow: 0 0 0.5em rgba($color, 0.8);
                     }
                 }
             }


### PR DESCRIPTION
Firefox can not prevent space key down event.
And then, after pressing the space key, focus on the checkbox element.

Focus on the checkbox instead of the label, so that native events work.