### PR TITLE
Add icon-pack prop to TableMobileSort component

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -6,6 +6,7 @@
             :is-asc="isAsc"
             :columns="newColumns"
             :placeholder="mobileSortPlaceholder"
+            :icon-pack="iconPack"
             @sort="(column) => sort(column)"
         />
 

--- a/src/components/table/TableMobileSort.vue
+++ b/src/components/table/TableMobileSort.vue
@@ -28,6 +28,7 @@
                         v-show="currentSortColumn === mobileSort"
                         :class="{ 'is-desc': !isAsc }"
                         icon="arrow-up"
+                        :pack="iconPack"
                         size="is-small"
                         both
                     />
@@ -51,7 +52,8 @@
             currentSortColumn: Object,
             isAsc: Boolean,
             columns: Array,
-            placeholder: String
+            placeholder: String,
+            iconPack: String
         },
         data() {
             return {


### PR DESCRIPTION
This PR adds the missing `icon-pack` prop to `TableMobileSort` component, and make the `Table` component provide the proper icon-pack to it, providing the same sorting arrows icon display in both desktop and mobile views.