### PR TITLE
Check url hash to see if it matches any tab labels

### DIFF
--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -118,6 +118,18 @@
             if (this.activeTab < this.tabItems.length) {
                 this.tabItems[this.activeTab].isActive = true
             }
+
+            /**
+             * Check the url hash and see if any tabs have the same label
+             * Get the index of the tab and change to that tab
+             */
+            let urlHash = window.location.hash.substr(1)
+            let urlTabIndex = this.tabItems.findIndex((tabItem) => {
+                return tabItem.label.toLowerCase().replace(' ', '-') === urlHash
+            })
+            if (urlTabIndex !== -1) {
+                this.changeTab(urlTabIndex)
+            }
         }
     }
 </script>


### PR DESCRIPTION
A simple way of jumping to a specific tab when the page is loaded using a url hash value. 

For example, clicking a link to `link/to/page#info` would automatically select the tab with the label `Info` if it exists. 