### PR TITLE
Fix changing Switch states with space key in Firefox

### DIFF
--- a/src/components/switch/Switch.vue
+++ b/src/components/switch/Switch.vue
@@ -5,7 +5,7 @@
         ref="label"
         :disabled="disabled"
         :tabindex="disabled ? false : 0"
-        @keydown.prevent.enter.space="$refs.label.click()"
+        @keydown.prevent.enter.space="toggle"
         @mousedown="isMouseDown = true"
         @mouseup="isMouseDown = false"
         @mouseout="isMouseDown = false"
@@ -69,6 +69,15 @@
              */
             value(value) {
                 this.newValue = value
+            }
+        },
+        methods: {
+            toggle() {
+                if (this.computedValue === this.trueValue) {
+                    this.computedValue = this.falseValue
+                } else {
+                    this.computedValue = this.trueValue
+                }
             }
         }
     }


### PR DESCRIPTION
Related to the checkbox issue in #1272. The problem is in Firefox on Windows and Linux. I think this is a simpler approach to fix the problem. Could do the same for checkboxes. 