### PR TITLE
Fix double click event for CheckBox(Button) and Radio(Button)

### DIFF
--- a/src/components/checkbox/Checkbox.vue
+++ b/src/components/checkbox/Checkbox.vue
@@ -11,6 +11,7 @@
             tabindex="-1"
             :indeterminate.prop="indeterminate"
             type="checkbox"
+            @click.stop
             :disabled="disabled"
             :required="required"
             :name="name"

--- a/src/components/checkbox/CheckboxButton.vue
+++ b/src/components/checkbox/CheckboxButton.vue
@@ -12,6 +12,7 @@
                 v-model="computedValue"
                 tabindex="-1"
                 type="checkbox"
+                @click.stop
                 :disabled="disabled"
                 :required="required"
                 :name="name"

--- a/src/components/radio/Radio.vue
+++ b/src/components/radio/Radio.vue
@@ -10,6 +10,7 @@
             v-model="computedValue"
             tabindex="-1"
             type="radio"
+            @click.stop
             :disabled="disabled"
             :required="required"
             :name="name"

--- a/src/components/radio/RadioButton.vue
+++ b/src/components/radio/RadioButton.vue
@@ -12,6 +12,7 @@
                 v-model="computedValue"
                 tabindex="-1"
                 type="radio"
+                @click.stop
                 :disabled="disabled"
                 :required="required"
                 :name="name"


### PR DESCRIPTION
Fix #940 for these label wrapped input. Clicking label will also trigger event on input. related to #711 