### PR TITLE
Add autocomplete's OpenOnFocus prop to tagInput

### DIFF
--- a/src/components/taginput/Taginput.vue
+++ b/src/components/taginput/Taginput.vue
@@ -35,6 +35,7 @@
                 :disabled="disabled"
                 :loading="loading"
                 :autocomplete="nativeAutocomplete"
+                :open-on-focus="autocompleteOpenOnFocus"
                 :keep-first="!allowNew"
                 @typing="onTyping"
                 @focus="onFocus"
@@ -109,6 +110,7 @@
                 default: 'value'
             },
             autocomplete: Boolean,
+            autocompleteOpenOnFocus: Boolean,
             nativeAutocomplete: String,
             disabled: Boolean,
             ellipsis: Boolean,


### PR DESCRIPTION
Simple fix that should allow the dropdown to show on the auto complete for tagInput components