### PR TITLE
Clarify `container` behavior for notifices

### DIFF
--- a/docs/pages/components/snackbar/api/snackbar.js
+++ b/docs/pages/components/snackbar/api/snackbar.js
@@ -48,7 +48,7 @@ export default [
             },
             {
                 name: '<code>container</code>',
-                description: 'DOM element the toast will be created on. Note that this also changes the <code>position</code> of the toast from <code>fixed</code> to <code>absolute</code>. Meaning that the container should be <code>fixed</code>.',
+                description: 'DOM element the toast will be created on. Note that this also changes the <code>position</code> of the toast from <code>fixed</code> to <code>absolute</code>. Meaning that the container should be <code>fixed</code>. Also note that this will override the <code>defaultContainerElement</code> if you specified it in your Buefy Constructor Options. See Constructor options for more details.',
                 type: 'String',
                 values: '—',
                 default: '<code>body</code>'

--- a/docs/pages/components/toast/api/toast.js
+++ b/docs/pages/components/toast/api/toast.js
@@ -41,7 +41,7 @@ export default [
             },
             {
                 name: '<code>container</code>',
-                description: 'DOM element the toast will be created on. Note that this also changes the <code>position</code> of the toast from <code>fixed</code> to <code>absolute</code>. Meaning that the container should be <code>fixed</code>.',
+                description: 'DOM element the toast will be created on. Note that this also changes the <code>position</code> of the toast from <code>fixed</code> to <code>absolute</code>. Meaning that the container should be <code>fixed</code>. Also note that this will override the <code>defaultContainerElement</code> if you specified it in your Buefy Constructor Options. See Constructor options for more details.',
                 type: 'String',
                 values: '—',
                 default: '<code>body</code>'


### PR DESCRIPTION
Specify that the `container` overrides the `defaultContainerElement`
Refers the user to Constructor options to learn more.

This helps to answer issue #570 