### PR TITLE
Revert "Fix changing Switch states with space key in Firefox"

### DIFF
--- a/src/components/switch/Switch.vue
+++ b/src/components/switch/Switch.vue
@@ -5,7 +5,7 @@
         ref="label"
         :disabled="disabled"
         :tabindex="disabled ? false : 0"
-        @keydown.prevent.enter.space="toggle"
+        @keydown.prevent.enter.space="$refs.label.click()"
         @mousedown="isMouseDown = true"
         @mouseup="isMouseDown = false"
         @mouseout="isMouseDown = false"
@@ -69,15 +69,6 @@
              */
             value(value) {
                 this.newValue = value
-            }
-        },
-        methods: {
-            toggle() {
-                if (this.computedValue === this.trueValue) {
-                    this.computedValue = this.falseValue
-                } else {
-                    this.computedValue = this.trueValue
-                }
             }
         }
     }


### PR DESCRIPTION
Reverts buefy/buefy#1285

Although the "fix" sort of works, combining with adding `@click.stop` to input, keyboard interaction does not emit a native click event now. 

And for checkbox, similar approach need check type of Boolean or Array and becomes over complicated. I also found adding ref to input and using `$refs.input.click()` seems to work for Firefox, although click event would be stopped as well. If the native listeners are passed on to input, then stop is not needed and this maybe a real solution then.