### PR TITLE
Fix bug after resetting b-select in Firefox

### DIFF
--- a/src/components/select/Select.vue
+++ b/src/components/select/Select.vue
@@ -17,7 +17,6 @@
                     <option
                         v-if="computedValue == null"
                         :value="null"
-                        selected
                         disabled
                         hidden>
                         {{ placeholder }}


### PR DESCRIPTION
Fix #1301. It is a weird behavior and not only going to the first option. The `selected` is not needed anyway with v-model in control.

Before
![test_before](https://user-images.githubusercontent.com/1696853/55517961-cf24db80-5637-11e9-9222-bdbdb52418f1.gif)

After
![test_after](https://user-images.githubusercontent.com/1696853/55517965-d4822600-5637-11e9-86c2-2ba2c1a145a2.gif)
