### PR TITLE
[B-Table] Allow custom detail rows

### DIFF
--- a/docs/pages/components/table/Table.vue
+++ b/docs/pages/components/table/Table.vue
@@ -42,6 +42,14 @@
             <p> You can also toggle row detail programmatically using <code>toggleDetails</code> method and <code>:show-detail-icon="false"</code> if you want to hide chevron icon.</p>
         </Example>
 
+        <Example :component="ExCustomDetailedRow" :code="ExCustomDetailedRowCode" title="Custom Detailed rows">
+            <p>You can add anything you like into the <code>detail</code> named scoped by providing the <code>customDetailRow</code> prop to the table.</p>
+            <b-message type="is-warning">
+                Be cautious when using a custom detailed row and toggling the display of columns,
+                as you will have to manage either the content within (with <code>colspan</code>) or the columns themselves dependent on the content displayed.
+            </b-message>
+        </Example>
+
         <Example :component="ExRowStatus" :code="ExRowStatusCode" title="Row status">
             <p>Use the <code>row-class</code> prop to return a class name. It's a function that receives <code>row</code> and <code>index</code> parameters.</p>
             <p>Note that <strong>you have to style the class yourself</strong>.</p>
@@ -102,6 +110,9 @@
     import ExDetailedRow from './examples/ExDetailedRow'
     import ExDetailedRowCode from '!!raw-loader!./examples/ExDetailedRow'
 
+    import ExCustomDetailedRow from './examples/ExCustomDetailedRow';
+    import ExCustomDetailedRowCode from '!!raw-loader!./examples/ExCustomDetailedRow';
+
     import ExRowStatus from './examples/ExRowStatus'
     import ExRowStatusCode from '!!raw-loader!./examples/ExRowStatus'
 
@@ -130,6 +141,7 @@
                 ExCheckable,
                 ExPaginationSort,
                 ExDetailedRow,
+                ExCustomDetailedRow,
                 ExRowStatus,
                 ExCustomHeaders,
                 ExToggleColumns,
@@ -142,6 +154,7 @@
                 ExCheckableCode,
                 ExPaginationSortCode,
                 ExDetailedRowCode,
+                ExCustomDetailedRowCode,
                 ExRowStatusCode,
                 ExCustomHeadersCode,
                 ExToggleColumnsCode,

--- a/docs/pages/components/table/api/table.js
+++ b/docs/pages/components/table/api/table.js
@@ -171,6 +171,13 @@ export default [
                 default: '<code>false</code>'
             },
             {
+                name: '<code>customDetailRow</code>',
+                description: 'Allow a custom detail row',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
                 name: '<code>showDetailIcon</code>',
                 description: 'Allow chevron icon and column to be visible',
                 type: 'Boolean',

--- a/docs/pages/components/table/examples/ExCustomDetailedRow.vue
+++ b/docs/pages/components/table/examples/ExCustomDetailedRow.vue
@@ -1,0 +1,217 @@
+<template>
+    <section>
+        <b-field grouped group-multiline>
+            <div class="control">
+                <b-checkbox v-model="showDetailIcon">Detail column</b-checkbox>
+            </div>
+            <div v-for="(column, index) in columnsVisible"
+                 :key="index"
+                 class="control">
+                <b-checkbox v-model="column.display">
+                    {{ column.title }}
+                </b-checkbox>
+            </div>
+        </b-field>
+
+        <b-table
+            :data="data"
+            ref="table"
+            detailed
+            hoverable
+            customDetailRow
+            :opened-detailed="['Board Games']"
+            :default-sort="['name', 'asc']"
+            detail-key="name"
+            @details-open="(row, index) => $toast.open(`Expanded ${row.name}`)"
+            :show-detail-icon="showDetailIcon">
+
+            <template slot-scope="props">
+                <b-table-column
+                    field="name"
+                    :visible="columnsVisible['name'].display"
+                    :label="columnsVisible['name'].title"
+                    width="300"
+                    sortable
+                >
+                    <template v-if="showDetailIcon">
+                        {{ props.row.name }}
+                    </template>
+                    <template v-else>
+                        <a @click="toggle(props.row)">
+                            {{ props.row.name }}
+                        </a>
+                    </template>
+                </b-table-column>
+
+                <b-table-column
+                    field="sold"
+                    :visible="columnsVisible['sold'].display"
+                    :label="columnsVisible['sold'].title"
+                    sortable
+                    centered
+                >
+                    {{ props.row.sold }}
+                </b-table-column>
+
+                <b-table-column
+                    field="available"
+                    :visible="columnsVisible['available'].display"
+                    :label="columnsVisible['available'].title"
+                    sortable
+                    centered
+                >
+                    {{ props.row.available }}
+                </b-table-column>
+
+                <b-table-column
+                    :visible="columnsVisible['cleared'].display"
+                    :label="columnsVisible['cleared'].title"
+                    centered
+                >
+                    <span :class="
+                            [
+                                'tag',
+                                {'is-danger': props.row.sold / props.row.available <= 0.45},
+                                {'is-success': props.row.sold / props.row.available > 0.45}
+                            ]">
+                        {{ Math.round((props.row.sold / props.row.available) * 100) }}%
+                    </span>
+                </b-table-column>
+            </template>
+
+            <template slot="detail" slot-scope="props">
+                <tr v-for="item in props.row.items">
+                    <td v-if="showDetailIcon"></td>
+                    <td v-show="columnsVisible['name'].display" >&nbsp;&nbsp;&nbsp;&nbsp;{{ item.name }}</td>
+                    <td v-show="columnsVisible['sold'].display" class="has-text-centered">{{ item.sold }}</td>
+                    <td v-show="columnsVisible['available'].display" class="has-text-centered">{{ item.available }}</td>
+                    <td v-show="columnsVisible['cleared'].display" class="has-text-centered">
+                        <span :class="
+                            [
+                                'tag',
+                                {'is-danger': item.sold / item.available <= 0.45},
+                                {'is-success': item.sold / item.available > 0.45}
+                            ]">
+                            {{ Math.round((item.sold / item.available) * 100) }}%
+                        </span>
+                    </td>
+                </tr>
+            </template>
+        </b-table>
+
+    </section>
+</template>
+
+<script>
+    export default {
+        data() {
+            return {
+                data: [
+                    {
+                        name: 'Board Games',
+                        sold: 131,
+                        available: 301,
+                        items: [
+                            {
+                                name: 'Monopoly',
+                                sold: 57,
+                                available: 100
+                            },
+                            {
+                                name: 'Scrabble',
+                                sold: 23,
+                                available: 84
+                            },
+                            {
+                                name: 'Chess',
+                                sold: 37,
+                                available: 61
+                            },
+                            {
+                                name: 'Battleships',
+                                sold: 14,
+                                available: 56
+                            }
+                        ]
+                    },
+                    {
+                        name: 'Jigsaws & Puzzles',
+                        sold: 88,
+                        available: 167,
+                        items: [
+                            {
+                                name: 'World Map',
+                                sold: 31,
+                                available: 38
+                            },
+                            {
+                                name: 'London',
+                                sold: 23,
+                                available: 29
+                            },
+                            {
+                                name: 'Sharks',
+                                sold: 20,
+                                available: 44
+                            },
+                            {
+                                name: 'Disney',
+                                sold: 14,
+                                available: 56
+                            }
+                        ]
+                    },
+                    {
+                        name: 'Books',
+                        sold: 434,
+                        available: 721,
+                        items: [
+                            {
+                                name: 'Hamlet',
+                                sold: 101,
+                                available: 187
+                            },
+                            {
+                                name: 'The Lord Of The Rings',
+                                sold: 85,
+                                available: 156
+                            },
+                            {
+                                name: 'To Kill a Mockingbird',
+                                sold: 78,
+                                available: 131
+                            },
+                            {
+                                name: 'Catch-22',
+                                sold: 73,
+                                available: 98
+                            },
+                            {
+                                name: 'Frankenstein',
+                                sold: 51,
+                                available: 81
+                            },
+                            {
+                                name: 'Alice\'s Adventures In Wonderland',
+                                sold: 46,
+                                available: 68
+                            }
+                        ]
+                    }
+                ],
+                columnsVisible: {
+                    name: { title: 'Name', display: true },
+                    sold: { title: 'Stock Sold', display: true },
+                    available: { title: 'Stock Available', display: true },
+                    cleared: { title: 'Stock Cleared', display: true },
+                },
+                showDetailIcon: true
+            }
+        },
+        methods: {
+            toggle(row) {
+                this.$refs.table.toggleDetails(row)
+            }
+        }
+    }
+</script>

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -126,7 +126,7 @@
                         <!-- Do not add `key` here (breaks details) -->
                         <!-- eslint-disable-next-line -->
                         <tr
-                            v-if="detailed && !customDetailRow && isVisibleDetailRow(row)"
+                            v-if="isActiveDetailRow(row)"
                             class="detail">
                             <td :colspan="columnCount">
                                 <div class="detail-container">
@@ -138,7 +138,7 @@
                             </td>
                         </tr>
                         <slot
-                            v-else-if="detailed && customDetailRow && isVisibleDetailRow(row)"
+                            v-if="isActiveCustomDetailRow(row)"
                             name="detail"
                             :row="row"
                             :index="index"
@@ -649,6 +649,14 @@
                 const index = this.handleDetailKey(obj)
                 const result = this.visibleDetailRows.indexOf(index) >= 0
                 return result
+            },
+
+            isActiveDetailRow(row) {
+                return this.detailed && !this.customDetailRow && this.isVisibleDetailRow(row)
+            },
+
+            isActiveCustomDetailRow(row) {
+                return this.detailed && this.customDetailRow && this.isVisibleDetailRow(row)
             },
 
             /**

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -126,7 +126,7 @@
                         <!-- Do not add `key` here (breaks details) -->
                         <!-- eslint-disable-next-line -->
                         <tr
-                            v-if="detailed && isVisibleDetailRow(row)"
+                            v-if="detailed && !customDetailRow && isVisibleDetailRow(row)"
                             class="detail">
                             <td :colspan="columnCount">
                                 <div class="detail-container">
@@ -137,6 +137,12 @@
                                 </div>
                             </td>
                         </tr>
+                        <slot
+                            v-else-if="detailed && customDetailRow && isVisibleDetailRow(row)"
+                            name="detail"
+                            :row="row"
+                            :index="index"
+                        />
                     </template>
                 </tbody>
                 <tbody v-else>
@@ -268,6 +274,10 @@
             detailKey: {
                 type: String,
                 default: ''
+            },
+            customDetailRow: {
+                type: Boolean,
+                default: false
             },
             backendPagination: Boolean,
             total: {


### PR DESCRIPTION
### Overview

This pull request allows the usage of a custom detail row. Providing the `customDetailRow` prop to the table will change the `detail` slot from the original one to a custom one, allowing any content to be provided in the detail.

### Reason for pull request

The detail row is a brilliant feature of the table. For normal usage, a custom detail row is unnecessary, but I think other datasets could benefit from an option where the content is not aligned in a single, full colspan `<tr>` tag, and instead in whatever the user wants to pass into the slot.

Previous pull request is https://github.com/buefy/buefy/pull/1127, but I couldn't commit to it and it looks to now be stale.