### PR TITLE
Add a submit event for Autocomplete and Taginput

### DIFF
--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -244,7 +244,12 @@
              * Select the hovered option.
              */
             enterPressed() {
-                if (this.hovered === null) return
+                // If an enter key pressed and there's nothing hovered,
+                // emit an event for custom handling (e.g. submit requests)
+                if (this.hovered === null) {
+                    this.$emit('submit')
+                    return
+                }
                 this.setSelected(this.hovered)
             },
 

--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -243,11 +243,19 @@
              * Enter key listener.
              * Select the hovered option.
              */
-            enterPressed() {
-                // If an enter key pressed and there's nothing hovered,
+            enterPressed(event) {
+                // When auto complete is activated,
+                // if the enter key is pressed and there's nothing hovered,
                 // emit an event for custom handling (e.g. submit requests)
-                if (this.hovered === null) {
-                    this.$emit('submit')
+                if (this.newAutocomplete !== 'off' && this.hovered === null) {
+                    this.$emit('submit', event)
+                    return
+                }
+                // When auto complete is not activated,
+                // if the enter key is pressed and there's nothing in the input,
+                // emit an event for custom handling
+                if (this.newAutocomplete === 'off' && !this.newValue) {
+                    this.$emit('submit', event)
                     return
                 }
                 this.setSelected(this.hovered)

--- a/src/components/taginput/Taginput.vue
+++ b/src/components/taginput/Taginput.vue
@@ -39,6 +39,7 @@
                 @typing="onTyping"
                 @focus="onFocus"
                 @blur="customOnBlur"
+                @submit="onSubmit"
                 @keydown.native="keydown"
                 @select="onSelect">
                 <template :slot="headerSlotName">
@@ -294,11 +295,6 @@
                     this.removeLastTag()
                 }
 
-                // If an enter key pressed and there's no current input, 
-                // emit an event for custom handling (e.g. submit requests)
-                if (this.newTag.length < 1 && event.keyCode === 13)
-                    this.$emit('submit', $event.trim()) 
-
                 // Stop if is to accept select only
                 if (this.autocomplete && !this.allowNew) return
 
@@ -310,6 +306,10 @@
 
             onTyping($event) {
                 this.$emit('typing', $event.trim())
+            },
+
+            onSubmit() {
+                this.$emit('submit')
             }
         }
     }

--- a/src/components/taginput/Taginput.vue
+++ b/src/components/taginput/Taginput.vue
@@ -308,8 +308,8 @@
                 this.$emit('typing', $event.trim())
             },
 
-            onSubmit() {
-                this.$emit('submit')
+            onSubmit(event) {
+                this.$emit('submit', event)
             }
         }
     }

--- a/src/components/taginput/Taginput.vue
+++ b/src/components/taginput/Taginput.vue
@@ -293,6 +293,12 @@
                 if (this.removeOnKeys.indexOf(event.keyCode) !== -1 && !this.newTag.length) {
                     this.removeLastTag()
                 }
+
+                // If an enter key pressed and there's no current input, 
+                // emit an event for custom handling (e.g. submit requests)
+                if (this.newTag.length < 1 && event.keyCode === 13)
+                    this.$emit('submit', $event.trim()) 
+
                 // Stop if is to accept select only
                 if (this.autocomplete && !this.allowNew) return
 


### PR DESCRIPTION
Hi,

I added a submit event for `Autocomplete` and `Taginput` to signal when a user presses enter while not adding a new tag. It is useful and intuitive for users to submit requests by pressing enter after adding all tags they want.

Thanks for considering the pull request.