### PR TITLE
Update `numberinput` prop `type` API docs

### DIFF
--- a/docs/pages/components/numberinput/api/numberinput.js
+++ b/docs/pages/components/numberinput/api/numberinput.js
@@ -10,10 +10,13 @@ export default [
             },
             {
                 name: '<code>type</code>',
-                description: 'Input type, like native',
+                description: 'Type (color) of the control, optional',
                 type: 'String',
-                values: 'Any native input type, and <code>textarea</code>',
-                default: '<code>text</code>'
+                values: `<code>is-white</code>, <code>is-black</code>, <code>is-light</code>,
+                <code>is-dark</code>, <code>is-primary</code>, <code>is-info</code>, <code>is-success</code>,
+                <code>is-warning</code>, <code>is-danger</code>,
+                and any other colors you've set in the <code>$colors</code> list on Sass`,
+                default: '<code>is-primary</code>'
             },
             {
                 name: '<code>size</code>',


### PR DESCRIPTION
The API docs for the new `numberinput` component show that the `type` prop determines the HTML input type (i.e. `<input type="fromTheProp">`.

But the `type` prop actually controls the color, i.e. `is-primary`, `is-dark`, etc. The examples show `type` used to control the color, as well. 

So the component does behave as expected according to the examples (but not according to the API docs at the bottom of the page).


This pull request updates the API docs to match the component's actual behavior.
(It's a modified paste of the `type` prop from the `button` component.)

(In case my PR fails some tests or is bunk in some way, here's that paste if it's easier for someone else to just paste it in [Tiny change]:)

`docs/pages/components/numberinput/api/numberinput.js`

```
{
    name: '<code>type</code>',
    description: 'Type (color) of the control, optional',
    type: 'String',
    values: `<code>is-white</code>, <code>is-black</code>, <code>is-light</code>,
    <code>is-dark</code>, <code>is-primary</code>, <code>is-info</code>, <code>is-success</code>,
    <code>is-warning</code>, <code>is-danger</code>,
    and any other colors you've set in the <code>$colors</code> list on Sass`,
    default: '<code>is-primary</code>'
},
```