### PR TITLE
Allow html in snackbar message (as it is for toast)

### DIFF
--- a/docs/pages/components/snackbar/examples/ExSimple.vue
+++ b/docs/pages/components/snackbar/examples/ExSimple.vue
@@ -38,7 +38,7 @@
             danger() {
                 this.$snackbar.open({
                     duration: 5000,
-                    message: 'Snackbar with red action, positioned on bottom-left and a callback',
+                    message: 'Snackbar with red action, positioned on bottom-left and a callback.<br>Note: <em>Message can include html</em>.',
                     type: 'is-danger',
                     position: 'is-bottom-left',
                     actionText: 'Undo',

--- a/src/components/snackbar/Snackbar.vue
+++ b/src/components/snackbar/Snackbar.vue
@@ -6,7 +6,7 @@
             v-show="isActive"
             class="snackbar"
             :class="[type,position]">
-            <p class="text">{{ message }}</p>
+            <div class="text" v-html="message"/>
             <div
                 v-if="actionText"
                 class="action"


### PR DESCRIPTION
I often use multi-lines messages with toast, nicely split with `<br>`, and I want the same behaviour for snackbar. So this tiny commit allow just this.

Plus it bring consistency to the many way to notify user.

![snackbar-vhtml](https://user-images.githubusercontent.com/601587/57107095-62345c80-6d2f-11e9-994b-be52708dce3a.png)