### PR TITLE
Fix Mobile referencing dropdown component

### DIFF
--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -501,7 +501,7 @@
              */
             keyPress(event) {
                 // Esc key
-                if (this.$refs.dropdown.isActive && event.keyCode === 27) {
+                if (this.$refs.dropdown && this.$refs.dropdown.isActive && event.keyCode === 27) {
                     this.toggle(false)
                 }
             }


### PR DESCRIPTION
On mobile, the $refs.dropdown component doesn't exist, but the keyPress event handler is still referencing it.
Since the only key event being cared about right now is the Escape key, it may make more sense to just not create or destroy the keyPress event listener, but this change touched the least stuff.