### PR TITLE
Fix radio button circle on Internet Explorer

### DIFF
--- a/src/scss/components/_radio.scss
+++ b/src/scss/components/_radio.scss
@@ -27,6 +27,7 @@ $radio-active-background-color: $primary !default;
                 transition: background $speed-slow $easing;
                 &:before {
                     content: "";
+                    display: flex;
                     border-radius: 50%;
                     width: 0.625em;
                     height: 0.625em;


### PR DESCRIPTION
This fixes issue #1401.

When the before element is set to "display: flex", the radio buttons will render correctly on IE11. Behavior of other browsers remains unchanged.