### PR TITLE
Add a way to overwrite the error message

### DIFF
--- a/docs/pages/components/input/api/input.js
+++ b/docs/pages/components/input/api/input.js
@@ -79,6 +79,13 @@ export default [
                 default: '—'
             },
             {
+                name: '<code>validation-message</code>',
+                description: 'The message which is shown when a validation error occurs',
+                type: 'String',
+                values: '—',
+                default: '—'
+            },
+            {
                 name: 'Any native attribute',
                 description: '—',
                 type: '—',

--- a/docs/pages/components/input/examples/ExValidation.vue
+++ b/docs/pages/components/input/examples/ExValidation.vue
@@ -13,6 +13,15 @@
         </b-field>
 
         <b-field>
+            <b-input placeholder="User handle (custom validation for only lowercase)"
+              type="text"
+              required
+              validation-message="Only lowercase is allowed"
+              pattern="[a-z]*">
+            </b-input>
+        </b-field>
+
+        <b-field>
             <b-input placeholder="URL" type="url"></b-input>
         </b-field>
 

--- a/src/utils/FormElementMixin.js
+++ b/src/utils/FormElementMixin.js
@@ -14,7 +14,8 @@ export default {
         useHtml5Validation: {
             type: Boolean,
             default: () => config.defaultUseHtml5Validation
-        }
+        },
+        validationMessage: String
     },
     data() {
         return {
@@ -117,7 +118,7 @@ export default {
             let isValid = true
             if (!el.checkValidity()) {
                 type = 'is-danger'
-                message = el.validationMessage
+                message = this.validationMessage || el.validationMessage
                 isValid = false
             }
             this.isValid = isValid


### PR DESCRIPTION
For my current project we use the [`pattern`](https://developer.mozilla.org/en-US/docs/Learn/HTML/Forms/Form_validation#Validating_against_a_regular_expression) feature of HTML. When using this feature we want be able to customize the error a user sees when the error occurs.

That's why I added a property to the `FormElementMixin.js`.

This is what it looks when you use this code:

```
<b-field>
    <b-input placeholder="User handle (custom validation for only lowercase)"
      type="text"
      required
      validation-error="Only lowercase is allowed"
      pattern="[a-z]*">
    </b-input>
</b-field>
```

![2019-05-23 13 36 28](https://user-images.githubusercontent.com/167882/58249671-cca15100-7d5f-11e9-8ae9-098dacecdb4e.gif)
