### PR TITLE
Fix incorrect props for rounded controls

### DIFF
--- a/docs/pages/components/numberinput/examples/ExSimple.vue
+++ b/docs/pages/components/numberinput/examples/ExSimple.vue
@@ -13,7 +13,7 @@
         </b-field>
 
         <b-field label="Rounded">
-            <b-numberinput rounded></b-numberinput>
+            <b-numberinput controls-rounded></b-numberinput>
         </b-field>
 
         <b-field label="Loading">


### PR DESCRIPTION
Replace `rounded` with `controls-rounded` in the documentation samples