### PR TITLE
Datepicker years dropdown updated to show number of years based on prop

### DIFF
--- a/docs/pages/components/datepicker/api/datepicker.js
+++ b/docs/pages/components/datepicker/api/datepicker.js
@@ -177,7 +177,7 @@ export default [
                 default: '-'
             },
             {
-                name: '<code>type</code>',
+                name: '<code>years-to-show</code>',
                 description: 'No of Years to show starting from selected year in the years dropdown',
                 type: 'Number',
                 values: '<code>Any positive number</code>',

--- a/docs/pages/components/datepicker/api/datepicker.js
+++ b/docs/pages/components/datepicker/api/datepicker.js
@@ -177,6 +177,13 @@ export default [
                 default: '-'
             },
             {
+                name: '<code>type</code>',
+                description: 'No of Years to show starting from selected year in the years dropdown',
+                type: 'Number',
+                values: '<code>Any positive number</code>',
+                default: '3'
+            },
+            {
                 name: 'Any native attribute',
                 description: '—',
                 type: '—',

--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -339,6 +339,10 @@
             yearsToShow: {
                 type: Number,
                 default: 3
+            },
+            yearsRange: {
+                type: Number,
+                default: 10
             }
         },
         data() {

--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -338,7 +338,7 @@
             },
             yearsToShow: {
                 type: Number,
-                default: 3,
+                default: 3
             }
         },
         data() {

--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -385,7 +385,7 @@
                 }
 
                 const arrayOfYears = []
-                for (let i = earliestYear; i <= latestYear; i++) {
+                for (let i = earliestYear, populated = 0; i <= latestYear && populated <= this.yearsRange; i++, populated++) {
                     arrayOfYears.push(i)
                 }
 

--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -335,6 +335,10 @@
                         'month'
                     ].indexOf(value) >= 0
                 }
+            },
+            yearsToShow: {
+                type: Number,
+                default: 3,
             }
         },
         data() {
@@ -366,12 +370,12 @@
             * dates are set by props, range of years will fall within those dates.
             */
             listOfYears() {
-                let latestYear = this.focusedDateData.year + 3
+                let latestYear = this.focusedDateData.year + this.yearsToShow
                 if (this.maxDate && this.maxDate.getFullYear() < latestYear) {
                     latestYear = this.maxDate.getFullYear()
                 }
 
-                let earliestYear = (latestYear - 100) + 3
+                let earliestYear = (latestYear - 100) + this.yearsToShow
                 if (this.minDate && this.minDate.getFullYear() > earliestYear) {
                     earliestYear = this.minDate.getFullYear()
                 }


### PR DESCRIPTION
Datepicker years dropdown updated to show number of years based on prop.
which is currently `3` now exposed it via prop so that people can customize it for now.

Addresses #1410 

ping @jtommy 