### PR TITLE
Added documentation for Autocomplete props on 'tag-input' elements

### DIFF
--- a/docs/pages/components/taginput/api/taginput.js
+++ b/docs/pages/components/taginput/api/taginput.js
@@ -76,7 +76,7 @@ export default [
             },
             {
                 name: '<code>autocomplete</code>',
-                description: 'Add autocomplete feature',
+                description: 'Add autocomplete feature (if <code>true</code>, any Autocomplete props may be used too)',
                 type: 'Boolean',
                 values: '—',
                 default: '<code>false</code>'
@@ -131,7 +131,7 @@ export default [
                 default: '<code>false</code>'
             },
             {
-                name: 'Any other native attribute or Autocomplete prop',
+                name: 'Any other native attribute',
                 description: '—',
                 type: '—',
                 values: '—',


### PR DESCRIPTION
I opened #1463 because the docs didn't state that `open-on-focus` was available as a property for `tag-input` elements