### PR TITLE
Fix missing notification config property in TS components types

### DIFF
--- a/types/components.d.ts
+++ b/types/components.d.ts
@@ -184,6 +184,7 @@ export declare type NotificationConfig = {
     container?: string;
     queue?: boolean;
     indefinite?: boolean;
+    hasIcon?: boolean;
 }
 export declare const NotificationProgrammatic: {
     open: (params: NotificationConfig | string) => void;


### PR DESCRIPTION
TypeScript error before the fix:

```
ERROR in /Users/trebler/eDrilling/KubernetesWellDeploymentClient/src/components/CreateWell.vue
113:13 Argument of type '{ duration: number; message: string; position: "is-top-right"; type: string; hasIcon: boolean; }' is not assignable to parameter of type 'string | NotificationConfig'.
  Object literal may only specify known properties, and 'hasIcon' does not exist in type 'NotificationConfig'.
    111 |             position: 'is-top-right',
    112 |             type: 'is-success',
  > 113 |             hasIcon: true
        |             ^
    114 |         });
```