### PR TITLE
Prevent extra onStopLongPress calls

### DIFF
--- a/src/components/numberinput/Numberinput.vue
+++ b/src/components/numberinput/Numberinput.vue
@@ -197,6 +197,7 @@
                 }, 250)
             },
             onStopLongPress(inc) {
+                if (!this._$intervalRef) return
                 const d = new Date()
                 if (d - this._$intervalTime < 250) {
                     if (inc) this.increment()


### PR DESCRIPTION
Follow up of d590672a85f409cee2cee136c4351e69462f12a9. When the interval is long, it is possible to trigger `onStopLongPress` both from `@mouseup` and `@mouseleave` and change the number by 2.