### PR TITLE
Add typings for programmatic use of dist components

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -15,6 +15,26 @@ declare module 'vue/types/vue' {
     }
 }
 
+declare module 'buefy/dist/components/dialog' {
+    export { Dialog };
+}
+
+declare module 'buefy/dist/components/modal' {
+    export { ModalProgrammatic };
+}
+
+declare module 'buefy/dist/components/toast' {
+    export { Toast };
+}
+
+declare module 'buefy/dist/components/snackbar' {
+    export { Snackbar };
+}
+
+declare module 'buefy/dist/components/notification' {
+    export { NotificationProgrammatic };
+}
+
 export declare type BuefyConfig = {
     defaultContainerElement?: string,
     defaultIconPack?: string;


### PR DESCRIPTION
This pull request adds simple module declarations for the programmatic use of components outside of Vue.

# Current Situation
```ts
/* example.ts */
import { Toast } from 'buefy/dist/components/toast';
// types for the import will not be found
```

# Target Situation
```ts
/* buefy/types/index.d.ts */
declare module 'buefy/dist/components/toast' {
    export { Toast };
}

/* example.ts */
import { Toast } from 'buefy/dist/components/toast';
// TypeScript is able to resolve the type 😄 
```