### PR TITLE
Allow user to add classes to modal

### DIFF
--- a/docs/pages/components/modal/examples/ExProgrammatic.vue
+++ b/docs/pages/components/modal/examples/ExProgrammatic.vue
@@ -64,7 +64,8 @@
                 this.$modal.open({
                     parent: this,
                     component: ModalForm,
-                    hasModalCard: true
+                    hasModalCard: true,
+                    customClass: 'custom-class custom-class-2'
                 })
             }
         }

--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -3,7 +3,7 @@
         <div
             v-if="isActive"
             class="modal is-active"
-            :class="{ 'is-full-screen': fullScreen }">
+            :class="[{'is-full-screen': fullScreen}, customClass]">
             <div class="modal-background" @click="cancel('outside')"/>
             <div
                 class="animation-content"
@@ -75,7 +75,8 @@
                     ].indexOf(value) >= 0
                 }
             },
-            fullScreen: Boolean
+            fullScreen: Boolean,
+            customClass: String
         },
         data() {
             return {


### PR DESCRIPTION
The addition of a fullscreen option for modals is great. Here's an idea to allow repurposing of the modal component. By adding custom classes, a user will be able to style individual modals differently.