### PR TITLE
Remove invalid type declarations

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -15,26 +15,6 @@ declare module 'vue/types/vue' {
     }
 }
 
-declare module 'buefy/dist/components/dialog' {
-    export { Dialog };
-}
-
-declare module 'buefy/dist/components/modal' {
-    export { ModalProgrammatic };
-}
-
-declare module 'buefy/dist/components/toast' {
-    export { Toast };
-}
-
-declare module 'buefy/dist/components/snackbar' {
-    export { Snackbar };
-}
-
-declare module 'buefy/dist/components/notification' {
-    export { NotificationProgrammatic };
-}
-
 export declare type BuefyConfig = {
     defaultContainerElement?: string,
     defaultIconPack?: string;


### PR DESCRIPTION
@jtommy I'm sorry these type declarations were not valid and didn't show up as errors in my IDE. Apparently, it's not possible to augment the global scope from within a module. Which kind of makes sense since you don't want to pollute the global type definitions from within.