### PR TITLE
Fix an error during Tooltip merge

### DIFF
--- a/src/components/tooltip/Tooltip.vue
+++ b/src/components/tooltip/Tooltip.vue
@@ -28,35 +28,22 @@ export default {
         label: String,
         position: {
             type: String,
-            label: String,
-            position: {
-                type: String,
-                default: 'is-top',
-                validator(value) {
-                    return [
-                        'is-top',
-                        'is-bottom',
-                        'is-left',
-                        'is-right'
-                    ].indexOf(value) > -1
-                }
-            },
-            always: Boolean,
-            animated: Boolean,
-            square: Boolean,
-            dashed: Boolean,
-            multilined: Boolean,
-            size: {
-                type: String,
-                default: 'is-medium'
-            },
-            delay: {
-                type: Number,
-                default: 0
+            default: 'is-top',
+            validator(value) {
+                return [
+                    'is-top',
+                    'is-bottom',
+                    'is-left',
+                    'is-right'
+                ].indexOf(value) > -1
             }
         },
         always: Boolean,
         animated: Boolean,
+        delay: {
+            type: Number,
+            default: 0
+        },
         square: Boolean,
         dashed: Boolean,
         multilined: Boolean,


### PR DESCRIPTION
Looks like there was an error during the latest merge of the tooltip component.
Props were duplicated inside the position prop. It was causing some errors.