### PR TITLE
Pagination ellipsis behavior

### DIFF
--- a/src/components/pagination/Pagination.vue
+++ b/src/components/pagination/Pagination.vue
@@ -151,7 +151,7 @@ export default {
         * Check if first ellipsis should be visible.
         */
         hasFirstEllipsis() {
-            return this.current >= 4
+            return this.current >= 5
         },
 
         /**
@@ -165,7 +165,7 @@ export default {
         * Check if last ellipsis should be visible.
         */
         hasLastEllipsis() {
-            return this.current < this.pageCount - 2 && this.current <= this.pageCount - 3
+            return this.current < this.pageCount - 3
         },
 
         /**
@@ -182,8 +182,14 @@ export default {
         pagesInRange() {
             if (this.simple) return
 
-            const left = Math.max(1, this.current - 1)
-            const right = Math.min(this.current + 1, this.pageCount)
+            let left = Math.max(1, this.current - 1)
+            if (left - 1 === 2) {
+                left-- // Do not show the ellipsis if there is only one to hide
+            }
+            let right = Math.min(this.current + 1, this.pageCount)
+            if (this.pageCount - right === 2) {
+                right++ // Do not show the ellipsis if there is only one to hide
+            }
 
             const pages = []
             for (let i = left; i <= right; i++) {


### PR DESCRIPTION
Ref: #1321

This fix the case where the ellipsis were shown with only one item to hide.

Display
![image](https://user-images.githubusercontent.com/12817388/60603585-0a908c80-9d84-11e9-9867-346ce832c9e5.png)
Instead of
![image](https://user-images.githubusercontent.com/12817388/60603547-f9e01680-9d83-11e9-951d-a2b9577fc71e.png)

-----

Display
![image](https://user-images.githubusercontent.com/12817388/60603707-4166a280-9d84-11e9-80ad-a2d90e0874bc.png)
Instead of
![image](https://user-images.githubusercontent.com/12817388/60603733-517e8200-9d84-11e9-9436-d43b85ea2b21.png)

