### PR TITLE
Add sortIcon and sortIconSize props to the table component

### DIFF
--- a/docs/pages/components/table/api/table.js
+++ b/docs/pages/components/table/api/table.js
@@ -31,6 +31,20 @@ export default [
                 default: '<code>asc</code>'
             },
             {
+                name: '<code>sort-icon</code>',
+                description: `Sets the header sorting icon`,
+                type: 'String',
+                values: '-',
+                default: '<code>arrow-up</code>'
+            },
+            {
+                name: '<code>sort-icon-size</code>',
+                description: `Sets the size of the sorting icon`,
+                type: 'String',
+                values: '<code>is-small</code>, <code></code>, <code>is-medium</code>, <code>is-large</code>',
+                default: '<code>is-small</code>'
+            },
+            {
                 name: '<code>bordered</code>',
                 description: 'Border to all cells',
                 type: 'Boolean',

--- a/docs/pages/components/table/examples/ExPaginationSort.vue
+++ b/docs/pages/components/table/examples/ExPaginationSort.vue
@@ -25,6 +25,17 @@
                 <option value="top">top pagination</option>
                 <option value="both">both</option>
             </b-select>
+            <b-select v-model="sortIcon">
+                <option value="arrow-up">Arrow sort icon</option>
+                <option value="menu-up">Caret sort icon</option>
+                <option value="chevron-up">Chevron sort icon </option>
+            </b-select>
+            <b-select v-model="sortIconSize">
+                <option value="is-small">Small sort icon</option>
+                <option value="">Regular sort icon</option>
+                <option value="is-medium">Medium sort icon</option>
+                <option value="is-large">Large sort icon</option>
+            </b-select>
         </b-field>
 
         <b-table
@@ -35,6 +46,8 @@
             :pagination-simple="isPaginationSimple"
             :pagination-position="paginationPosition"
             :default-sort-direction="defaultSortDirection"
+            :sort-icon="sortIcon"
+            :sort-icon-size="sortIconSize"
             default-sort="user.first_name"
             aria-next-label="Next page"
             aria-previous-label="Previous page"
@@ -82,6 +95,8 @@
                 isPaginationSimple: false,
                 paginationPosition: 'bottom',
                 defaultSortDirection: 'asc',
+                sortIcon: 'arrow-up',
+                sortIconSize: 'is-small',
                 currentPage: 1,
                 perPage: 5
             }

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -79,10 +79,10 @@
 
                                 <b-icon
                                     v-show="currentSortColumn === column"
-                                    icon="arrow-up"
+                                    :icon="sortIcon"
                                     :pack="iconPack"
                                     both
-                                    size="is-small"
+                                    :size="sortIconSize"
                                     :class="{ 'is-desc': !isAsc }"/>
                             </div>
                         </th>
@@ -309,6 +309,14 @@ export default {
         defaultSortDirection: {
             type: String,
             default: 'asc'
+        },
+        sortIcon: {
+            type: String,
+            default: 'arrow-up'
+        },
+        sortIconSize: {
+            type: String,
+            default: 'is-small'
         },
         paginated: Boolean,
         currentPage: {


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #1547
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

Adds `sortIcon` and `sortIconSize` props to table component
