### PR TITLE
List of files is cleared by clicking cancel

### DIFF
--- a/src/components/upload/Upload.vue
+++ b/src/components/upload/Upload.vue
@@ -95,7 +95,7 @@ export default {
                 if (!this.newValue) {
                     return
                 }
-                if (!this.native) {
+                if (this.native) {
                     this.newValue = null
                 }
             } else if (!this.multiple) {

--- a/src/components/upload/Upload.vue
+++ b/src/components/upload/Upload.vue
@@ -95,6 +95,9 @@ export default {
                 if (!this.newValue) {
                     return
                 }
+                if (!this.native) {
+                    this.newValue = null
+                }
             } else if (!this.multiple) {
                 // only one element in case drag drop mode and isn't multiple
                 if (this.dragDrop && value.length !== 1) return

--- a/src/components/upload/Upload.vue
+++ b/src/components/upload/Upload.vue
@@ -95,7 +95,6 @@ export default {
                 if (!this.newValue) {
                     return
                 }
-                this.newValue = null
             } else if (!this.multiple) {
                 // only one element in case drag drop mode and isn't multiple
                 if (this.dragDrop && value.length !== 1) return


### PR DESCRIPTION
In chrome if you click cancel in a window to select files the previous list is clean, is it expected behavior?

<!-- Thank you for helping Buefy! -->

## Proposed Changes
- Removing the line that clears this.newValue behavior does not occur
