### PR TITLE
Fix slanted x when attached props is used

### DIFF
--- a/src/scss/components/_taginput.scss
+++ b/src/scss/components/_taginput.scss
@@ -24,6 +24,9 @@ $taginput-height: 1.7em;
                 margin-bottom: 0;
                 font-size: 0.9em;
                 height: $taginput-height;
+                &.is-delete {
+                    width: $taginput-height;
+                }
             }
             &:not(:last-child) {
                 margin-left: 0.275rem;


### PR DESCRIPTION
## Proposed Changes

- Adjust width for the delete button using `attached` prop

The lines for the `x` are related to width and height of the direct parent. `$taginput-height` is not necessarily equals to the default width for the `x` parent.

### Current behavior without this fix
![image](https://user-images.githubusercontent.com/12817388/61314572-e6dd3580-a7ca-11e9-9fd9-ae9f9e261dd5.png)
If you look closely, the `x` is slightly slanted (default parent size is 2em x 1.7em)

### Behavior after the fix
![image](https://user-images.githubusercontent.com/12817388/61314607-01171380-a7cb-11e9-9777-518f28ca1a51.png)

