### PR TITLE
Add new style options for switch

### DIFF
--- a/docs/pages/components/switch/Switch.vue
+++ b/docs/pages/components/switch/Switch.vue
@@ -6,6 +6,8 @@
 
         <Example :component="ExSizes" :code="ExSizesCode" title="Sizes" vertical/>
 
+        <Example :component="ExStyles" :code="ExStylesCode" title="Styles" vertical/>
+
         <ApiView :data="api"/>
     </div>
 </template>
@@ -22,6 +24,9 @@
     import ExSizes from './examples/ExSizes'
     import ExSizesCode from '!!raw-loader!./examples/ExSizes'
 
+    import ExStyles from './examples/ExStyles'
+    import ExStylesCode from '!!raw-loader!./examples/ExStyles'
+
     export default {
         data() {
             return {
@@ -29,9 +34,11 @@
                 ExSimple,
                 ExTypes,
                 ExSizes,
+                ExStyles,
                 ExSimpleCode,
                 ExTypesCode,
-                ExSizesCode
+                ExSizesCode,
+                ExStylesCode
             }
         }
     }

--- a/docs/pages/components/switch/api/switch.js
+++ b/docs/pages/components/switch/api/switch.js
@@ -59,6 +59,20 @@ export default [
                 type: 'String',
                 values: '<code>is-small</code>, <code>is-medium</code>, <code>is-large</code>',
                 default: '—'
+            },
+            {
+                name: '<code>rounded</code>',
+                description: 'Rounded style',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
+                name: '<code>outlined</code>',
+                description: 'Outlined style',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
             }
         ],
         events: [

--- a/docs/pages/components/switch/examples/ExStyles.vue
+++ b/docs/pages/components/switch/examples/ExStyles.vue
@@ -1,0 +1,22 @@
+<template>
+    <section>
+        <b-field grouped>
+            <b-switch v-model="isRounded">Rounded</b-switch>
+            <b-switch v-model="isOutlined">Outlined</b-switch>
+        </b-field>
+        <b-switch
+            :rounded="isRounded"
+            :outlined="isOutlined">Sample</b-switch>
+    </section>
+</template>
+
+<script>
+    export default {
+        data() {
+            return {
+                isRounded: false,
+                isOutlined: false,
+            }
+        }
+    }
+</script>

--- a/src/components/switch/Switch.vue
+++ b/src/components/switch/Switch.vue
@@ -1,7 +1,7 @@
 <template>
     <label
         class="switch"
-        :class="[size, { 'is-disabled': disabled }]"
+        :class="newClass"
         ref="label"
         :disabled="disabled"
         @keydown.prevent.enter="$refs.label.click()"
@@ -42,6 +42,14 @@ export default {
         falseValue: {
             type: [String, Number, Boolean, Function, Object, Array, Symbol],
             default: false
+        },
+        rounded: {
+            type: Boolean,
+            default: false
+        },
+        outlined: {
+            type: Boolean,
+            default: false
         }
     },
     data() {
@@ -59,6 +67,14 @@ export default {
                 this.newValue = value
                 this.$emit('input', value)
             }
+        },
+        newClass() {
+            return [
+                this.size,
+                { 'is-disabled': this.disabled },
+                { 'is-rounded': this.rounded },
+                { 'is-outlined': this.outlined }
+            ]
         }
     },
     watch: {

--- a/src/scss/components/_switch.scss
+++ b/src/scss/components/_switch.scss
@@ -26,12 +26,12 @@ $switch-active-background-color: $primary !default;
             height: #{$switch-width / 2 + $switch-padding};
             padding: $switch-padding;
             background: $grey-light;
-            border-radius: 1em;
+            border-radius: $radius;
             transition: background $speed-slow $easing;
             &:before {
                 content: "";
                 display: block;
-                border-radius: 1em;
+                border-radius: $radius;
                 width: #{($switch-width - $switch-padding * 2) / 2};
                 height: #{($switch-width - $switch-padding * 2) / 2};
                 background: $background;
@@ -88,6 +88,58 @@ $switch-active-background-color: $primary !default;
                 $color: nth($pair, 1);
                 &.is-#{$name} {
                     background: rgba($color, 0.9);
+                }
+            }
+        }
+    }
+    &.is-rounded {
+        input[type=checkbox] {
+            + .check {
+                border-radius: $radius-rounded;
+                &:before {
+                    border-radius: $radius-rounded;
+                }
+            }
+        }
+    }
+    &.is-outlined {
+        input[type=checkbox] {
+            + .check {
+                background: transparent;
+                border: .1rem solid $grey-light;
+                &:before {
+                    background: $grey-light;
+                }
+            }
+            &:checked + .check {
+                border-color: $switch-active-background-color;
+                @each $name, $pair in $colors {
+                    $color: nth($pair, 1);
+                    &.is-#{$name} {
+                        border-color: $color;
+                        &:before {
+                            background: $color;
+                        }
+                    }
+                }
+                &:before {
+                    background: $switch-active-background-color;
+                }
+            }
+        }
+        &:hover {
+            input[type=checkbox] + .check {
+                background: transparent;
+                border-color: rgba($grey-light, 0.9);
+            }
+            input[type=checkbox]:checked + .check {
+                background: transparent;
+                border-color: rgba($switch-active-background-color, 0.9);
+                @each $name, $pair in $colors {
+                    $color: nth($pair, 1);
+                    &.is-#{$name} {
+                        border-color: rgba($color, 0.9);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Proposed changes:
- Give a more squarish default style
- Add a rounded prop
- Add a outlined prop

Breaking changes:
- The default style is not rounded anymore

I think it fits more with the default Bulma/Buefy styling.

Probably need to be discussed before merging (even in a breaking release)

![captured](https://user-images.githubusercontent.com/12817388/61317394-e3e54380-a7d0-11e9-844d-d7f2c9add786.gif)
