### PR TITLE
feat: add mouse hover events to b-table

### DIFF
--- a/docs/pages/components/table/api/table.js
+++ b/docs/pages/components/table/api/table.js
@@ -417,7 +417,7 @@ export default [
 
             },
             {
-                name: '<code> mouseover </code>',
+                name: '<code> mouseenter </code>',
                 description: 'Triggers when mouse enters a row',
                 parameters: '<code> row: Object </code>'
             },

--- a/docs/pages/components/table/api/table.js
+++ b/docs/pages/components/table/api/table.js
@@ -415,6 +415,16 @@ export default [
                 description: 'Triggers when dragging over a row',
                 parameters: '<code> row: Object </code>, <code> dragover: Event </code>, <code> index: Number </code>'
 
+            },
+            {
+                name: '<code> mouseover </code>',
+                description: 'Triggers when mouse enters a row',
+                parameters: '<code> row: Object </code>'
+            },
+            {
+                name: '<code> mouseleave </code>',
+                description: 'Triggers when mouse leaves a row',
+                parameters: '<code> row: Object </code>'
             }
         ],
         methods: [

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -116,7 +116,7 @@
                             }]"
                             @click="selectRow(row)"
                             @dblclick="$emit('dblclick', row)"
-                            @mouseover="$emit('mouseover', row)"
+                            @mouseenter="$emit('mouseenter', row)"
                             @mouseleave="$emit('mouseleave', row)"
                             @contextmenu="$emit('contextmenu', row, $event)"
                             :draggable="draggable"

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -116,6 +116,8 @@
                             }]"
                             @click="selectRow(row)"
                             @dblclick="$emit('dblclick', row)"
+                            @mouseover="$emit('mouseover', row)"
+                            @mouseleave="$emit('mouseleave', row)"
                             @contextmenu="$emit('contextmenu', row, $event)"
                             :draggable="draggable"
                             @dragstart="handleDragStart($event, row, index)"


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->
Why we need this:
We are trying to add an action bar on hover of table row (similar to Gmail's inbox shows a bar on hovering over an email). Currently it's not possible because mouse enter/leave events are not emitted from b-table.  

<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Implements #520
## Proposed Changes

- Emit a mouseenter event when mouse enters a table row
- Emit a mouseleave event when mouse leaves a table row