### PR TITLE
Add a  focusable prop to dropdown-item

### DIFF
--- a/docs/pages/components/dropdown/Dropdown.vue
+++ b/docs/pages/components/dropdown/Dropdown.vue
@@ -9,6 +9,7 @@
 
         <Example :component="ExContentPosition" :code="ExContentPositionCode" title="Content and position" paddingless>
             <p>Add the <code>custom</code> prop to the item to add <strong>any type of content</strong>.</p>
+            <p>Add the <code>:focusable="false"</code> prop to the <code>dropdown-item</code> if you dont want it to be focusable.</p>
         </Example>
 
         <Example :component="ExHasLinkDisabled" :code="ExHasLinkDisabledCode" title="Links within" paddingless>

--- a/docs/pages/components/dropdown/api/dropdown.js
+++ b/docs/pages/components/dropdown/api/dropdown.js
@@ -122,6 +122,13 @@ export default [
                 default: '<code>false</code>'
             },
             {
+                name: '<code>focusable</code>',
+                description: 'Item can be focused',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>true</code>'
+            },
+            {
                 name: '<code>custom</code>',
                 description: 'Item is not a clickable item',
                 type: 'Boolean',

--- a/docs/pages/components/dropdown/examples/ExContentPosition.vue
+++ b/docs/pages/components/dropdown/examples/ExContentPosition.vue
@@ -11,7 +11,7 @@
         <div class="navbar-menu">
             <div class="navbar-end">
                 <b-dropdown position="is-bottom-left" aria-role="menu">
-                    <a  
+                    <a
                         class="navbar-item"
                         slot="trigger"
                         role="button">
@@ -19,7 +19,11 @@
                         <b-icon icon="menu-down"></b-icon>
                     </a>
 
-                    <b-dropdown-item aria-role="menu-item" custom paddingless>
+                    <b-dropdown-item
+                        aria-role="menu-item"
+                        :focusable="false"
+                        custom
+                        paddingless>
                         <form action="">
                             <div class="modal-card" style="width:300px;">
                                 <section class="modal-card-body">

--- a/src/components/dropdown/DropdownItem.vue
+++ b/src/components/dropdown/DropdownItem.vue
@@ -6,7 +6,7 @@
         :class="anchorClasses"
         @click="selectItem"
         :role="ariaRoleItem"
-        tabindex="0">
+        :tabindex="focusable ? 0 : null">
         <slot/>
     </a>
     <div
@@ -14,7 +14,7 @@
         :class="itemClasses"
         @click="selectItem"
         :role="ariaRoleItem"
-        tabindex="0">
+        :tabindex="focusable ? 0 : null">
         <slot/>
     </div>
 </template>
@@ -30,6 +30,10 @@ export default {
         separator: Boolean,
         disabled: Boolean,
         custom: Boolean,
+        focusable: {
+            type: Boolean,
+            default: true
+        },
         paddingless: Boolean,
         hasLink: Boolean,
         ariaRole: {


### PR DESCRIPTION
Fix #1437

### Proposed changes:
The default behavior for dropdown item right now is to be focusable.
This prop will keep the default behavior, but can be disabled.

The login example in the doc ("Content and position" from https://buefy.org/documentation/dropdown) is a good example. In this case, we do not really expect the item to get focus. Instead, we want the first input to get focus when using tab.

### Current behavior when clicking on the dropdown and using tab key:
![captured](https://user-images.githubusercontent.com/12817388/61391628-19e6fe00-a88b-11e9-9457-4b42cd7d2f14.gif)

### New behavior when clicking on the dropdown and using tab key (when `focusable` is false):
![captured (1)](https://user-images.githubusercontent.com/12817388/61391650-29fedd80-a88b-11e9-966f-c65942b1c810.gif)
