### PR TITLE
[Pagination] Added props for adding buttons before and after current page

### DIFF
--- a/docs/pages/components/pagination/api/pagination.js
+++ b/docs/pages/components/pagination/api/pagination.js
@@ -16,15 +16,15 @@ export default [
                 default: '<code>20</code>'
             },
             {
-                name: '<code>before</code>',
-                description: 'Items to show before current page',
+                name: '<code>range-before</code>',
+                description: 'Number of pagination items to show before current page',
                 type: 'Number',
                 values: '—',
                 default: '<code>1</code>'
             },
             {
-                name: '<code>after</code>',
-                description: 'Items to show after current page',
+                name: '<code>range-after</code>',
+                description: 'Items to paginatation items to show after current page',
                 type: 'Number',
                 values: '—',
                 default: '<code>1</code>'

--- a/docs/pages/components/pagination/api/pagination.js
+++ b/docs/pages/components/pagination/api/pagination.js
@@ -16,6 +16,20 @@ export default [
                 default: '<code>20</code>'
             },
             {
+                name: '<code>before</code>',
+                description: 'Items to show before current page',
+                type: 'Number',
+                values: '—',
+                default: '<code>1</code>'
+            },
+            {
+                name: '<code>after</code>',
+                description: 'Items to show after current page',
+                type: 'Number',
+                values: '—',
+                default: '<code>1</code>'
+            },
+            {
                 name: '<code>current</code>',
                 description: 'Current page number, use the <code>.sync</code> modifier to make it two-way binding',
                 type: 'Number',

--- a/docs/pages/components/pagination/examples/ExSimple.vue
+++ b/docs/pages/components/pagination/examples/ExSimple.vue
@@ -7,6 +7,16 @@
             <b-field label="Items per page">
                 <b-input type="number" v-model="perPage"></b-input>
             </b-field>
+        </b-field>
+        <b-field grouped group-multiline>
+            <b-field label="Show buttons before current">
+                <b-input type="number" v-model="before"></b-input>
+            </b-field>
+            <b-field label="Show buttons after current">
+                <b-input type="number" v-model="after"></b-input>
+            </b-field>
+        </b-field>
+        <b-field grouped group-multiline>
             <b-field label="Order">
                 <b-select v-model="order">
                     <option value="">default</option>
@@ -32,6 +42,8 @@
         <b-pagination
             :total="total"
             :current.sync="current"
+            :before="before"
+            :after="after"
             :order="order"
             :size="size"
             :simple="isSimple"
@@ -50,8 +62,10 @@
         data() {
             return {
                 total: 200,
-                current: 1,
-                perPage: 20,
+                current: 10,
+                perPage: 10,
+                before: 3,
+                after: 1,
                 order: '',
                 size: '',
                 isSimple: false,

--- a/docs/pages/components/pagination/examples/ExSimple.vue
+++ b/docs/pages/components/pagination/examples/ExSimple.vue
@@ -10,10 +10,10 @@
         </b-field>
         <b-field grouped group-multiline>
             <b-field label="Show buttons before current">
-                <b-input type="number" v-model="before"></b-input>
+                <b-input type="number" v-model="rangeBefore" min="0"></b-input>
             </b-field>
             <b-field label="Show buttons after current">
-                <b-input type="number" v-model="after"></b-input>
+                <b-input type="number" v-model="rangeAfter" min="0"></b-input>
             </b-field>
         </b-field>
         <b-field grouped group-multiline>
@@ -42,8 +42,8 @@
         <b-pagination
             :total="total"
             :current.sync="current"
-            :before="before"
-            :after="after"
+            :range-before="rangeBefore"
+            :range-after="rangeAfter"
             :order="order"
             :size="size"
             :simple="isSimple"
@@ -64,8 +64,8 @@
                 total: 200,
                 current: 10,
                 perPage: 10,
-                before: 3,
-                after: 1,
+                rangeBefore: 3,
+                rangeAfter: 1,
                 order: '',
                 size: '',
                 isSimple: false,

--- a/src/components/pagination/Pagination.vue
+++ b/src/components/pagination/Pagination.vue
@@ -96,6 +96,14 @@ export default {
             type: [Number, String],
             default: 1
         },
+        before: {
+            type: [Number, String],
+            default: 1
+        },
+        after: {
+            type: [Number, String],
+            default: 1
+        },
         size: String,
         simple: Boolean,
         rounded: Boolean,
@@ -116,6 +124,14 @@ export default {
                     'is-rounded': this.rounded
                 }
             ]
+        },
+
+        beforeCurrent() {
+            return parseInt(this.before)
+        },
+
+        afterCurrent() {
+            return parseInt(this.after)
         },
 
         /**
@@ -151,7 +167,7 @@ export default {
         * Check if first ellipsis should be visible.
         */
         hasFirstEllipsis() {
-            return this.current >= 5
+            return this.current >= (this.beforeCurrent + 4)
         },
 
         /**
@@ -165,7 +181,7 @@ export default {
         * Check if last ellipsis should be visible.
         */
         hasLastEllipsis() {
-            return this.current < this.pageCount - 3
+            return this.current < this.pageCount - (2 + this.afterCurrent)
         },
 
         /**
@@ -182,11 +198,11 @@ export default {
         pagesInRange() {
             if (this.simple) return
 
-            let left = Math.max(1, this.current - 1)
+            let left = Math.max(2, this.current - this.beforeCurrent)
             if (left - 1 === 2) {
                 left-- // Do not show the ellipsis if there is only one to hide
             }
-            let right = Math.min(this.current + 1, this.pageCount)
+            let right = Math.min(this.current + this.afterCurrent, this.pageCount)
             if (this.pageCount - right === 2) {
                 right++ // Do not show the ellipsis if there is only one to hide
             }

--- a/src/components/pagination/Pagination.vue
+++ b/src/components/pagination/Pagination.vue
@@ -96,11 +96,11 @@ export default {
             type: [Number, String],
             default: 1
         },
-        before: {
+        rangeBefore: {
             type: [Number, String],
             default: 1
         },
-        after: {
+        rangeAfter: {
             type: [Number, String],
             default: 1
         },
@@ -127,11 +127,11 @@ export default {
         },
 
         beforeCurrent() {
-            return parseInt(this.before)
+            return parseInt(this.rangeBefore)
         },
 
         afterCurrent() {
-            return parseInt(this.after)
+            return parseInt(this.rangeAfter)
         },
 
         /**

--- a/src/components/pagination/Pagination.vue
+++ b/src/components/pagination/Pagination.vue
@@ -160,7 +160,7 @@ export default {
         * Check if first page button should be visible.
         */
         hasFirst() {
-            return this.current >= 3
+            return this.current >= (2 + this.beforeCurrent)
         },
 
         /**
@@ -174,7 +174,7 @@ export default {
         * Check if last page button should be visible.
         */
         hasLast() {
-            return this.current <= this.pageCount - 2
+            return this.current <= this.pageCount - (1 + this.afterCurrent)
         },
 
         /**
@@ -198,7 +198,7 @@ export default {
         pagesInRange() {
             if (this.simple) return
 
-            let left = Math.max(2, this.current - this.beforeCurrent)
+            let left = Math.max(1, this.current - this.beforeCurrent)
             if (left - 1 === 2) {
                 left-- // Do not show the ellipsis if there is only one to hide
             }


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes some of #1573 
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

I wasnt sure what I should call the props, so it became before and after

I also updated the documentation for pagination

I have made it on dev branch so #1529 (with breaking changes) also will be included. (can also make it to another branch if needed)

But otherwise its not a breaking change, as the props are default as 1

![Screenshot from 2019-07-18 07-35-03](https://user-images.githubusercontent.com/20708/61431779-ed84bd80-a92e-11e9-8a68-3944ecd4c51c.png)

![Screenshot from 2019-07-18 07-38-30](https://user-images.githubusercontent.com/20708/61431892-12793080-a92f-11e9-9e90-30517d0755ae.png)
