### PR TITLE
Focus for Radio, Checkbox and Switch

### DIFF
--- a/docs/pages/components/radio/examples/ExSimple.vue
+++ b/docs/pages/components/radio/examples/ExSimple.vue
@@ -2,18 +2,22 @@
     <section>
         <div class="block">
             <b-radio v-model="radio"
+                name="name"
                 native-value="Flint">
                 Flint
             </b-radio>
             <b-radio v-model="radio"
+                name="name"
                 native-value="Silver">
                 Silver
             </b-radio>
             <b-radio v-model="radio"
+                name="name"
                 native-value="Jack">
                 Jack
             </b-radio>
             <b-radio v-model="radio"
+                name="name"
                 native-value="Vane"
                 disabled>
                 Vane

--- a/src/components/checkbox/Checkbox.vue
+++ b/src/components/checkbox/Checkbox.vue
@@ -4,11 +4,13 @@
         :class="[size, { 'is-disabled': disabled }]"
         ref="label"
         :disabled="disabled"
+        @click="focus"
         @keydown.prevent.enter="$refs.label.click()">
         <input
             v-model="computedValue"
             :indeterminate.prop="indeterminate"
             type="checkbox"
+            ref="input"
             @click.stop
             :disabled="disabled"
             :required="required"
@@ -64,6 +66,12 @@ export default {
          */
         value(value) {
             this.newValue = value
+        }
+    },
+    methods: {
+        focus() {
+            // MacOS FireFox and Safari do not focus when clicked
+            this.$refs.input.focus()
         }
     }
 }

--- a/src/components/checkbox/CheckboxButton.vue
+++ b/src/components/checkbox/CheckboxButton.vue
@@ -8,11 +8,13 @@
                 'is-focused': isFocused
             }]"
             :disabled="disabled"
+            @click="focus"
             @keydown.prevent.enter="$refs.label.click()">
             <slot/>
             <input
                 v-model="computedValue"
                 type="checkbox"
+                ref="input"
                 @click.stop
                 :disabled="disabled"
                 :required="required"
@@ -68,6 +70,12 @@ export default {
          */
         value(value) {
             this.newValue = value
+        }
+    },
+    methods: {
+        focus() {
+            // MacOS FireFox and Safari do not focus when clicked
+            this.$refs.input.focus()
         }
     }
 }

--- a/src/components/radio/Radio.vue
+++ b/src/components/radio/Radio.vue
@@ -4,11 +4,9 @@
         ref="label"
         :class="[size, { 'is-disabled': disabled }]"
         :disabled="disabled"
-        :tabindex="disabled ? false : 0"
-        @keydown.prevent.enter.space="$refs.label.click()">
+        @keydown.prevent.enter="$refs.label.click()">
         <input
             v-model="computedValue"
-            tabindex="-1"
             type="radio"
             @click.stop
             :disabled="disabled"

--- a/src/components/radio/Radio.vue
+++ b/src/components/radio/Radio.vue
@@ -4,10 +4,12 @@
         ref="label"
         :class="[size, { 'is-disabled': disabled }]"
         :disabled="disabled"
+        @click="focus"
         @keydown.prevent.enter="$refs.label.click()">
         <input
             v-model="computedValue"
             type="radio"
+            ref="input"
             @click.stop
             :disabled="disabled"
             :required="required"
@@ -52,6 +54,12 @@ export default {
         */
         value(value) {
             this.newValue = value
+        }
+    },
+    methods: {
+        focus() {
+            // MacOS FireFox and Safari do not focus when clicked
+            this.$refs.input.focus()
         }
     }
 }

--- a/src/components/radio/RadioButton.vue
+++ b/src/components/radio/RadioButton.vue
@@ -8,11 +8,13 @@
                 'is-focused': isFocused
             }]"
             :disabled="disabled"
+            @click="focus"
             @keydown.prevent.enter="$refs.label.click()">
             <slot/>
             <input
                 v-model="computedValue"
                 type="radio"
+                ref="input"
                 @click.stop
                 :disabled="disabled"
                 :required="required"
@@ -62,6 +64,12 @@ export default {
         */
         value(value) {
             this.newValue = value
+        }
+    },
+    methods: {
+        focus() {
+            // MacOS FireFox and Safari do not focus when clicked
+            this.$refs.input.focus()
         }
     }
 }

--- a/src/components/radio/RadioButton.vue
+++ b/src/components/radio/RadioButton.vue
@@ -3,20 +3,23 @@
         <label
             class="b-radio radio button"
             ref="label"
-            :class="[newValue === nativeValue ? type : null, size]"
+            :class="[newValue === nativeValue ? type : null, size, {
+                'is-disabled': disabled,
+                'is-focused': isFocused
+            }]"
             :disabled="disabled"
-            :tabindex="disabled ? false : 0"
-            @keydown.prevent.enter.space="$refs.label.click()">
+            @keydown.prevent.enter="$refs.label.click()">
             <slot/>
             <input
                 v-model="computedValue"
-                tabindex="-1"
                 type="radio"
                 @click.stop
                 :disabled="disabled"
                 :required="required"
                 :name="name"
-                :value="nativeValue">
+                :value="nativeValue"
+                @focus="isFocused = true"
+                @blur="isFocused = false">
         </label>
     </div>
 </template>
@@ -38,7 +41,8 @@ export default {
     },
     data() {
         return {
-            newValue: this.value
+            newValue: this.value,
+            isFocused: false
         }
     },
     computed: {

--- a/src/components/switch/Switch.vue
+++ b/src/components/switch/Switch.vue
@@ -4,6 +4,7 @@
         :class="newClass"
         ref="label"
         :disabled="disabled"
+        @click="focus"
         @keydown.prevent.enter="$refs.label.click()"
         @mousedown="isMouseDown = true"
         @mouseup="isMouseDown = false"
@@ -12,6 +13,7 @@
         <input
             v-model="computedValue"
             type="checkbox"
+            ref="input"
             @click.stop
             :disabled="disabled"
             :name="name"
@@ -83,6 +85,12 @@ export default {
         */
         value(value) {
             this.newValue = value
+        }
+    },
+    methods: {
+        focus() {
+            // MacOS FireFox and Safari do not focus when clicked
+            this.$refs.input.focus()
         }
     }
 }

--- a/src/scss/components/_radio.scss
+++ b/src/scss/components/_radio.scss
@@ -60,6 +60,20 @@ $radio-size: 1.25em !default;
                     transform: scale(.5);
                 }
             }
+            &:focus {
+                + .check {
+                    box-shadow: 0 0 0.5em rgba($grey, 0.8);
+                }
+                &:checked + .check {
+                    box-shadow: 0 0 0.5em rgba($radio-active-background-color, 0.8);
+                    @each $name, $pair in $colors {
+                        $color: nth($pair, 1);
+                        &.is-#{$name} {
+                            box-shadow: 0 0 0.5em rgba($color, 0.8);
+                        }
+                    }
+                }
+            }
         }
         .control-label {
             padding-left: 0.5em;
@@ -74,20 +88,6 @@ $radio-size: 1.25em !default;
                     $color: nth($pair, 1);
                     &.is-#{$name} {
                         border-color: $color;
-                    }
-                }
-            }
-        }
-        &:focus {
-            input[type=radio] + .check {
-                box-shadow: 0 0 0.5em rgba($grey, 0.8);
-            }
-            input[type=radio]:checked + .check {
-                box-shadow: 0 0 0.5em rgba($radio-active-background-color, 0.8);
-                @each $name, $pair in $colors {
-                    $color: nth($pair, 1);
-                    &.is-#{$name} {
-                        box-shadow: 0 0 0.5em rgba($color, 0.8);
                     }
                 }
             }


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

## Proposed Changes

This is a follow-up of #1341 

1. The focusable element is moved to input for Radio like what was done for Checkbox and Switch. I said browser behavior slightly differs, but it is only for ungrouped radio buttons (without name). In practice, it should not be a breaking change. Also name attribute is added for the first example in the doc.

2. There is a [browser bug](https://allyjs.io/tutorials/mutating-active-element.html#running-tests) in MacOS FireFox and Safari that checkbox and radio input do not receive focus when clicked. So manually calling focus method is added. I think it is necessary in radio group so that arrow keys can be used to navigate after clicking one radio button. For Checkbox and Switch, it is mostly for the visual box shadow.
Although button is also affected, it is untouched because the desired behavior could be more complicated, e.g. focus is recommended to move into modal if one is activated upon clicking.

<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

