### PR TITLE
 Add ariaCloseLabel prop for Tag

### DIFF
--- a/docs/pages/components/tag/api/tag.js
+++ b/docs/pages/components/tag/api/tag.js
@@ -60,6 +60,13 @@ export default [
                 type: 'Boolean',
                 values: '—',
                 default: '<code>false</code>'
+            },
+            {
+                name: '<code>aria-close-label</code>',
+                description: 'Accessibility label for the close button',
+                type: 'String',
+                values: '—',
+                default: '-'
             }
         ],
         events: [

--- a/docs/pages/components/tag/examples/ExClosable.vue
+++ b/docs/pages/components/tag/examples/ExClosable.vue
@@ -4,6 +4,7 @@
             <b-tag v-if="isTag1Active"
                 type="is-primary"
                 closable
+                aria-close-label="Close tag"
                 @close="isTag1Active = false">
                 Colored closable tag label
             </b-tag>
@@ -13,6 +14,7 @@
             <b-tag v-if="isTag2Active"
                 attached
                 closable
+                aria-close-label="Close tag"
                 @close="isTag2Active = false">
                 Attached closable tag label
             </b-tag>
@@ -23,6 +25,7 @@
                 type="is-danger"
                 attached
                 closable
+                aria-close-label="Close tag"
                 @close="isTag3Active = false">
                 Colored attached closable tag label
             </b-tag>

--- a/docs/pages/components/tag/examples/ExFieldCombine.vue
+++ b/docs/pages/components/tag/examples/ExFieldCombine.vue
@@ -26,19 +26,39 @@
 
         <b-field grouped group-multiline>
             <div class="control">
-                <b-tag type="is-primary" attached closable>Technology</b-tag>
+                <b-tag type="is-primary"
+                    attached
+                    aria-close-label="Close tag"
+                    closable>
+                    Technology
+                </b-tag>
             </div>
 
             <div class="control">
-                <b-tag type="is-primary" attached closable>Vuejs</b-tag>
+                <b-tag type="is-primary"
+                    attached
+                    aria-close-label="Close tag"
+                    closable>
+                    Vuejs
+                </b-tag>
             </div>
 
             <div class="control">
-                <b-tag type="is-primary" attached closable>CSS</b-tag>
+                <b-tag type="is-primary"
+                    attached
+                    aria-close-label="Close tag"
+                    closable>
+                    CSS
+                </b-tag>
             </div>
 
             <div class="control">
-                <b-tag type="is-primary" attached closable>Flexbox</b-tag>
+                <b-tag type="is-primary"
+                    attached
+                    aria-close-label="Close tag"
+                    closable>
+                    Flexbox
+                </b-tag>
             </div>
         </b-field>
     </section>

--- a/src/components/tag/Tag.vue
+++ b/src/components/tag/Tag.vue
@@ -10,7 +10,7 @@
         <a
             class="tag is-delete"
             role="button"
-            aria-label="close"
+            :aria-label="ariaCloseLabel"
             :tabindex="tabstop ? 0 : false"
             :disabled="disabled"
             :class="[size, { 'is-rounded': rounded }]"
@@ -29,7 +29,7 @@
         <a
             v-if="closable"
             role="button"
-            aria-label="close"
+            :aria-label="ariaCloseLabel"
             class="delete is-small"
             :disabled="disabled"
             :tabindex="tabstop ? 0 : false"
@@ -53,7 +53,8 @@ export default {
         tabstop: {
             type: Boolean,
             default: true
-        }
+        },
+        ariaCloseLabel: String
     },
     methods: {
         /**

--- a/src/components/tag/Tag.vue
+++ b/src/components/tag/Tag.vue
@@ -10,6 +10,7 @@
         <a
             class="tag is-delete"
             role="button"
+            aria-label="close"
             :tabindex="tabstop ? 0 : false"
             :disabled="disabled"
             :class="[size, { 'is-rounded': rounded }]"
@@ -28,6 +29,7 @@
         <a
             v-if="closable"
             role="button"
+            aria-label="close"
             class="delete is-small"
             :disabled="disabled"
             :tabindex="tabstop ? 0 : false"


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

## Proposed Changes

- Add `aria-close-label` prop for `tag` component to let users customize the label
- To be consistent with `message`, no default is set
- Examples updated

