### PR TITLE
Icon props (next / previous)

### DIFF
--- a/docs/pages/components/datepicker/Datepicker.vue
+++ b/docs/pages/components/datepicker/Datepicker.vue
@@ -44,7 +44,6 @@
 
         <Example :component="ExEvents" :code="ExEventsCode" title="Events" vertical>
             <p>Dates can be passed to the datepicker with the <code>events</code> prop and shown with indicators.</p>
-            <p>You can also customize the icons used to navigate months.</p>
         </Example>
 
         <ApiView :data="api"/>

--- a/docs/pages/components/datepicker/Datepicker.vue
+++ b/docs/pages/components/datepicker/Datepicker.vue
@@ -44,6 +44,7 @@
 
         <Example :component="ExEvents" :code="ExEventsCode" title="Events" vertical>
             <p>Dates can be passed to the datepicker with the <code>events</code> prop and shown with indicators.</p>
+            <p>You can also customize the icons used to navigate months.</p>
         </Example>
 
         <ApiView :data="api"/>

--- a/docs/pages/components/datepicker/api/datepicker.js
+++ b/docs/pages/components/datepicker/api/datepicker.js
@@ -107,6 +107,20 @@ export default [
                 default: '<code>mdi</code>'
             },
             {
+                name: '<code>icon-prev</code>',
+                description: 'Icon to use for previous month',
+                type: 'String',
+                values: '—',
+                default: '<code>chevron-left</code>'
+            },
+            {
+                name: '<code>icon-next</code>',
+                description: 'Icon to use for next month',
+                type: 'String',
+                values: '—',
+                default: '<code>chevron-right</code>'
+            },
+            {
                 name: '<code>unselectable-dates</code>',
                 description: 'Array of unselectable dates',
                 type: 'Array',

--- a/docs/pages/components/datepicker/examples/ExEvents.vue
+++ b/docs/pages/components/datepicker/examples/ExEvents.vue
@@ -3,23 +3,11 @@
         <b-field>
             <b-switch v-model="bars">Bars</b-switch>
         </b-field>
-        <b-field grouped group-multiline>
-            <b-select v-model="prevIcon">
-                <option value="chevron-left">Chevron prev icon </option>
-                <option value="arrow-left">Arrow prev icon</option>
-            </b-select>
-            <b-select v-model="nextIcon">
-                <option value="chevron-right">Chevron next icon </option>
-                <option value="arrow-right">Arrow next icon</option>
-            </b-select>
-        </b-field>
         <b-datepicker
             inline
             v-model="date"
             :events="events"
             :indicators="indicators"
-            :icon-prev="prevIcon"
-            :icon-next="nextIcon"
             >
         </b-datepicker>
     </span>
@@ -79,9 +67,7 @@
                         type: 'is-info'
                     }
                 ],
-                bars: false,
-                prevIcon: 'chevron-left',
-                nextIcon: 'chevron-right'
+                bars: false
             }
         }
     }

--- a/docs/pages/components/datepicker/examples/ExEvents.vue
+++ b/docs/pages/components/datepicker/examples/ExEvents.vue
@@ -3,11 +3,23 @@
         <b-field>
             <b-switch v-model="bars">Bars</b-switch>
         </b-field>
+        <b-field grouped group-multiline>
+            <b-select v-model="prevIcon">
+                <option value="chevron-left">Chevron prev icon </option>
+                <option value="arrow-left">Arrow prev icon</option>
+            </b-select>
+            <b-select v-model="nextIcon">
+                <option value="chevron-right">Chevron next icon </option>
+                <option value="arrow-right">Arrow next icon</option>
+            </b-select>
+        </b-field>
         <b-datepicker
             inline
-            v-model="date" 
+            v-model="date"
             :events="events"
             :indicators="indicators"
+            :icon-prev="prevIcon"
+            :icon-next="nextIcon"
             >
         </b-datepicker>
     </span>
@@ -67,7 +79,9 @@
                         type: 'is-info'
                     }
                 ],
-                bars: false
+                bars: false,
+                prevIcon: 'chevron-left',
+                nextIcon: 'chevron-right'
             }
         }
     }

--- a/docs/pages/components/pagination/api/pagination.js
+++ b/docs/pages/components/pagination/api/pagination.js
@@ -72,6 +72,20 @@ export default [
                 default: '<code>mdi</code>'
             },
             {
+                name: '<code>icon-prev</code>',
+                description: 'Icon to use for previous button',
+                type: 'String',
+                values: '—',
+                default: '<code>chevron-left</code>'
+            },
+            {
+                name: '<code>icon-next</code>',
+                description: 'Icon to use for next button',
+                type: 'String',
+                values: '—',
+                default: '<code>chevron-right</code>'
+            },
+            {
                 name: '<code>aria-next-label</code>',
                 description: 'Accessibility label for the next page link.',
                 type: 'String',

--- a/docs/pages/components/pagination/examples/ExSimple.vue
+++ b/docs/pages/components/pagination/examples/ExSimple.vue
@@ -33,6 +33,20 @@
                 </b-select>
             </b-field>
         </b-field>
+        <b-field grouped group-multiline>
+            <b-field label="Previous icon">
+                <b-select v-model="prevIcon">
+                    <option value="chevron-left">Chevron</option>
+                    <option value="arrow-left">Arrow</option>
+                </b-select>
+            </b-field>
+            <b-field label="Next icon">
+                <b-select v-model="nextIcon">
+                    <option value="chevron-right">Chevron</option>
+                    <option value="arrow-right">Arrow</option>
+                </b-select>
+            </b-field>
+        </b-field>
         <div class="block">
             <b-switch v-model="isSimple">Simple</b-switch>
             <b-switch v-model="isRounded">Rounded</b-switch>
@@ -49,6 +63,8 @@
             :simple="isSimple"
             :rounded="isRounded"
             :per-page="perPage"
+            :icon-prev="prevIcon"
+            :icon-next="nextIcon"
             aria-next-label="Next page"
             aria-previous-label="Previous page"
             aria-page-label="Page"
@@ -69,7 +85,9 @@
                 order: '',
                 size: '',
                 isSimple: false,
-                isRounded: false
+                isRounded: false,
+                prevIcon: 'chevron-left',
+                nextIcon: 'chevron-right'
             }
         }
     }

--- a/docs/pages/components/steps/api/steps.js
+++ b/docs/pages/components/steps/api/steps.js
@@ -48,6 +48,20 @@ export default [
                 default: '<code>mdi</code>'
             },
             {
+                name: '<code>icon-prev</code>',
+                description: 'Icon to use for navigation button',
+                type: 'String',
+                values: '—',
+                default: '<code>chevron-left</code>'
+            },
+            {
+                name: '<code>icon-next</code>',
+                description: 'Icon to use for navigation button',
+                type: 'String',
+                values: '—',
+                default: '<code>chevron-right</code>'
+            },
+            {
                 name: '<code>has-navigation</code>',
                 description: `Next and previous buttons below the component.
                     You can use this property if you want to use your own custom navigation items.`,

--- a/docs/pages/components/steps/examples/ExSimple.vue
+++ b/docs/pages/components/steps/examples/ExSimple.vue
@@ -10,7 +10,22 @@
             <b-switch v-model="hasNavigation"> Navigation Buttons </b-switch>
             <b-switch v-model="isProfileSuccess"> Set <code>is-success</code> for profile </b-switch>
         </div>
-        <b-steps v-model="activeStep" :animated="isAnimated" :has-navigation="hasNavigation">
+        <b-field v-if="hasNavigation" grouped group-multiline>
+            <b-select v-model="prevIcon">
+                <option value="chevron-left">Chevron prev icon </option>
+                <option value="arrow-left">Arrow prev icon</option>
+            </b-select>
+            <b-select v-model="nextIcon">
+                <option value="chevron-right">Chevron next icon </option>
+                <option value="arrow-right">Arrow next icon</option>
+            </b-select>
+        </b-field>
+        <b-steps
+            v-model="activeStep"
+            :animated="isAnimated"
+            :has-navigation="hasNavigation"
+            :icon-prev="prevIcon"
+            :icon-next="nextIcon">
             <b-step-item label="Account" :clickable="isStepsClickable">
                 Lorem ipsum dolor sit amet.
             </b-step-item>
@@ -44,6 +59,8 @@
                 showSocial: false,
                 isAnimated: true,
                 hasNavigation: true,
+                prevIcon: 'chevron-left',
+                nextIcon: 'chevron-right',
                 isStepsClickable: false,
                 isProfileSuccess: false
             }

--- a/docs/pages/installation/api/constructor-options.js
+++ b/docs/pages/installation/api/constructor-options.js
@@ -21,6 +21,22 @@ export default [
                 default: '<code></code>'
             },
             {
+                name: '<code>defaultIconPrev</code>',
+                description: `Icon used internally for prev. —
+                    Used in Datepicker, Pagination and Steps for example`,
+                type: 'String',
+                values: '—',
+                default: '<code>chevron-left</code>'
+            },
+            {
+                name: '<code>defaultIconNext</code>',
+                description: `Icon used internally for next. —
+                    Used in Datepicker, Pagination and Steps for example`,
+                type: 'String',
+                values: '—',
+                default: '<code>chevron-right</code>'
+            },
+            {
                 name: '<code>defaultContainerElement</code>',
                 description: `Default container attribute for floating Notices (Toasts & Snackbars). Note that this also
                     changes the <code>position</code> of the Notices from <code>fixed</code> to <code>absolute</code>.

--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -48,7 +48,7 @@
                             @keydown.space.prevent="prev">
 
                             <b-icon
-                                icon="chevron-left"
+                                :icon="newIconPrev"
                                 :pack="iconPack"
                                 both
                                 type="is-primary is-clickable"/>
@@ -64,7 +64,7 @@
                             @keydown.space.prevent="next">
 
                             <b-icon
-                                icon="chevron-right"
+                                :icon="newIconNext"
                                 :pack="iconPack"
                                 both
                                 type="is-primary is-clickable"/>
@@ -351,7 +351,9 @@ export default {
         nearbySelectableMonthDays: {
             type: Boolean,
             default: () => config.defaultDatepickerNearbySelectableMonthDays
-        }
+        },
+        iconPrev: String,
+        iconNext: String
     },
     data() {
         const focusedDate = this.value || this.focusedDate || this.dateCreator()
@@ -398,6 +400,13 @@ export default {
             }
 
             return arrayOfYears.reverse()
+        },
+
+        newIconPrev() {
+            return this.iconPrev || config.defaultIconPrev
+        },
+        newIconNext() {
+            return this.iconNext || config.defaultIconNext
         },
 
         showPrev() {

--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -330,6 +330,14 @@ export default {
             default: 'dots'
         },
         openOnFocus: Boolean,
+        iconPrev: {
+            type: String,
+            default: config.defaultIconPrev
+        },
+        iconNext: {
+            type: String,
+            default: config.defaultIconNext
+        },
         yearsRange: {
             type: Array,
             default: () => {
@@ -351,14 +359,6 @@ export default {
         nearbySelectableMonthDays: {
             type: Boolean,
             default: () => config.defaultDatepickerNearbySelectableMonthDays
-        },
-        iconPrev: {
-            type: String,
-            default: config.defaultIconPrev
-        },
-        iconNext: {
-            type: String,
-            default: config.defaultIconNext
         }
     },
     data() {

--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -48,7 +48,7 @@
                             @keydown.space.prevent="prev">
 
                             <b-icon
-                                :icon="newIconPrev"
+                                :icon="iconPrev"
                                 :pack="iconPack"
                                 both
                                 type="is-primary is-clickable"/>
@@ -64,7 +64,7 @@
                             @keydown.space.prevent="next">
 
                             <b-icon
-                                :icon="newIconNext"
+                                :icon="iconNext"
                                 :pack="iconPack"
                                 both
                                 type="is-primary is-clickable"/>
@@ -352,8 +352,14 @@ export default {
             type: Boolean,
             default: () => config.defaultDatepickerNearbySelectableMonthDays
         },
-        iconPrev: String,
-        iconNext: String
+        iconPrev: {
+            type: String,
+            default: config.defaultIconPrev
+        },
+        iconNext: {
+            type: String,
+            default: config.defaultIconNext
+        }
     },
     data() {
         const focusedDate = this.value || this.focusedDate || this.dateCreator()
@@ -400,13 +406,6 @@ export default {
             }
 
             return arrayOfYears.reverse()
-        },
-
-        newIconPrev() {
-            return this.iconPrev || config.defaultIconPrev
-        },
-        newIconNext() {
-            return this.iconNext || config.defaultIconNext
         },
 
         showPrev() {

--- a/src/components/pagination/Pagination.vue
+++ b/src/components/pagination/Pagination.vue
@@ -8,7 +8,7 @@
             @click.prevent="prev"
             :aria-label="ariaPreviousLabel">
             <b-icon
-                :icon="newIconPrev"
+                :icon="iconPrev"
                 :pack="iconPack"
                 both
                 aria-hidden="true"/>
@@ -21,7 +21,7 @@
             @click.prevent="next"
             :aria-label="ariaNextLabel">
             <b-icon
-                :icon="newIconNext"
+                :icon="iconNext"
                 :pack="iconPack"
                 both
                 aria-hidden="true"/>
@@ -110,8 +110,14 @@ export default {
         rounded: Boolean,
         order: String,
         iconPack: String,
-        iconPrev: String,
-        iconNext: String,
+        iconPrev: {
+            type: String,
+            default: config.defaultIconPrev
+        },
+        iconNext: {
+            type: String,
+            default: config.defaultIconNext
+        },
         ariaNextLabel: String,
         ariaPreviousLabel: String,
         ariaPageLabel: String,
@@ -135,13 +141,6 @@ export default {
 
         afterCurrent() {
             return parseInt(this.rangeAfter)
-        },
-
-        newIconPrev() {
-            return this.iconPrev || config.defaultIconPrev
-        },
-        newIconNext() {
-            return this.iconNext || config.defaultIconNext
         },
 
         /**

--- a/src/components/pagination/Pagination.vue
+++ b/src/components/pagination/Pagination.vue
@@ -8,7 +8,7 @@
             @click.prevent="prev"
             :aria-label="ariaPreviousLabel">
             <b-icon
-                icon="chevron-left"
+                :icon="newIconPrev"
                 :pack="iconPack"
                 both
                 aria-hidden="true"/>
@@ -21,7 +21,7 @@
             @click.prevent="next"
             :aria-label="ariaNextLabel">
             <b-icon
-                icon="chevron-right"
+                :icon="newIconNext"
                 :pack="iconPack"
                 both
                 aria-hidden="true"/>
@@ -80,6 +80,7 @@
 
 <script>
 import Icon from '../icon/Icon'
+import config from '../../utils/config'
 
 export default {
     name: 'BPagination',
@@ -109,6 +110,8 @@ export default {
         rounded: Boolean,
         order: String,
         iconPack: String,
+        iconPrev: String,
+        iconNext: String,
         ariaNextLabel: String,
         ariaPreviousLabel: String,
         ariaPageLabel: String,
@@ -132,6 +135,13 @@ export default {
 
         afterCurrent() {
             return parseInt(this.rangeAfter)
+        },
+
+        newIconPrev() {
+            return this.iconPrev || config.defaultIconPrev
+        },
+        newIconNext() {
+            return this.iconNext || config.defaultIconNext
         },
 
         /**

--- a/src/components/steps/Steps.vue
+++ b/src/components/steps/Steps.vue
@@ -41,7 +41,7 @@
                 @click.prevent="prev"
                 :aria-label="ariaPreviousLabel">
                 <b-icon
-                    icon="chevron-left"
+                    :icon="newIconPrev"
                     :pack="iconPack"
                     both
                     aria-hidden="true"/>
@@ -54,7 +54,7 @@
                 @click.prevent="next"
                 :aria-label="ariaNextLabel">
                 <b-icon
-                    icon="chevron-right"
+                    :icon="newIconNext"
                     :pack="iconPack"
                     both
                     aria-hidden="true"/>
@@ -66,6 +66,7 @@
 <script>
 import Icon from '../icon/Icon'
 import SlotComponent from '../../utils/SlotComponent'
+import config from '../../utils/config'
 
 export default {
     name: 'BSteps',
@@ -86,6 +87,8 @@ export default {
             default: false
         },
         iconPack: String,
+        iconPrev: String,
+        iconNext: String,
         hasNavigation: {
             type: Boolean,
             default: true
@@ -114,9 +117,16 @@ export default {
             return this.stepItems.slice().reverse()
         },
 
+        newIconPrev() {
+            return this.iconPrev || config.defaultIconPrev
+        },
+        newIconNext() {
+            return this.iconNext || config.defaultIconNext
+        },
+
         /**
-            * Check the first visible step index.
-            */
+         * Check the first visible step index.
+         */
         firstVisibleStepIndex() {
             return this.stepItems.findIndex((step, idx) => {
                 return step.visible
@@ -124,8 +134,8 @@ export default {
         },
 
         /**
-            * Check if previous button is available.
-            */
+         * Check if previous button is available.
+         */
         hasPrev() {
             return this.firstVisibleStepIndex >= 0 &&
                 this.activeStep > this.firstVisibleStepIndex

--- a/src/components/steps/Steps.vue
+++ b/src/components/steps/Steps.vue
@@ -41,7 +41,7 @@
                 @click.prevent="prev"
                 :aria-label="ariaPreviousLabel">
                 <b-icon
-                    :icon="newIconPrev"
+                    :icon="iconPrev"
                     :pack="iconPack"
                     both
                     aria-hidden="true"/>
@@ -54,7 +54,7 @@
                 @click.prevent="next"
                 :aria-label="ariaNextLabel">
                 <b-icon
-                    :icon="newIconNext"
+                    :icon="iconNext"
                     :pack="iconPack"
                     both
                     aria-hidden="true"/>
@@ -87,8 +87,14 @@ export default {
             default: false
         },
         iconPack: String,
-        iconPrev: String,
-        iconNext: String,
+        iconPrev: {
+            type: String,
+            default: config.defaultIconPrev
+        },
+        iconNext: {
+            type: String,
+            default: config.defaultIconNext
+        },
         hasNavigation: {
             type: Boolean,
             default: true
@@ -115,13 +121,6 @@ export default {
 
         reversedStepItems() {
             return this.stepItems.slice().reverse()
-        },
-
-        newIconPrev() {
-            return this.iconPrev || config.defaultIconPrev
-        },
-        newIconNext() {
-            return this.iconNext || config.defaultIconNext
         },
 
         /**

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -2,6 +2,8 @@ let config = {
     defaultContainerElement: null,
     defaultIconPack: 'mdi',
     defaultIconComponent: null,
+    defaultIconPrev: 'chevron-left',
+    defaultIconNext: 'chevron-right',
     defaultDialogConfirmText: null,
     defaultDialogCancelText: null,
     defaultSnackbarDuration: 3500,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -29,6 +29,8 @@ export declare type BuefyConfig = {
     defaultContainerElement?: string,
     defaultIconPack?: string;
     defaultIconComponent?: string;
+    defaultIconPrev?: string;
+    defaultIconNext?: string;
     defaultDialogConfirmText?: string;
     defaultDialogCancelText?: string;
     defaultSnackbarDuration?: number;


### PR DESCRIPTION
## Proposed Changes#

- Add default config for next/previous icon (used in Steps, Datepicker and Pagination)
- [Steps] Use default config for next/previous button icons. Also add a prop into the component
- [Datepicker] Use default config for next/previous button icons. Also add a prop into the component
- [Pagination] Use default config for next/previous button icons. Also add a prop into the component
