### PR TITLE
Include CSS files as side effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   "module": "dist/esm/index.js",
   "unpkg": "dist/buefy.min.js",
   "typings": "types/index.d.ts",
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "files": [
     "dist",
     "src",


### PR DESCRIPTION
Fixes #1626 

## Proposed Changes

@jtommy according to webpack docs, the css files should be stated as side effects, otherwise webpack drops them during tree-shaking on production mode so the `buefy/dist/buefy.css` file is omited from the bundle

https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free

This probably should fix 
https://github.com/buefy/buefy/issues/1626
https://github.com/buefy/nuxt-buefy/issues/45
+ the issue discussed in discord by Dr.Monty 

This should be tested first though.

Thanks