### PR TITLE
Fix to show copyright in rollup minify

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -143,7 +143,11 @@ export default () => {
         config = config.filter((c) => c.output.format === 'umd')
         config.forEach((c) => {
             c.output.file = c.output.file.replace(/\.js/g, '.min.js')
-            c.plugins.push(terser())
+            c.plugins.push(terser({
+                output: {
+                    comments: "/^!/"
+                }
+            }))
         })
     }
     return config


### PR DESCRIPTION
I Add comment copyright in rollup minify.
@jtommy  for next, can you add option for dist output tree shake (component) to inculde or not.
i have component carousel and rate (rating) with vue and bulma, can i share to here? thanks.