### PR TITLE
[Slider] Style fixes for IE 11

### DIFF
--- a/src/scss/components/_slider.scss
+++ b/src/scss/components/_slider.scss
@@ -36,6 +36,8 @@ $slider-mark-size: 0.75rem !default;
         font-size: $slider-mark-size;
         position: absolute;
         top: calc(#{$track-height} / 2 + 2px);
+        left: 50%;
+        transform: translateX(-50%);
     }
 }
 
@@ -130,8 +132,6 @@ $slider-mark-size: 0.75rem !default;
 
     .b-slider-tick {
         position: absolute;
-        display: flex;
-        justify-content: center;
 		width: $slider-tick-width;
         transform: translate(-50%, -50%);
         background: $slider-tick-background;

--- a/src/scss/components/_slider.scss
+++ b/src/scss/components/_slider.scss
@@ -70,6 +70,7 @@ $slider-mark-size: 0.75rem !default;
         transform: translate(-50%, -50%);
         cursor: grab;
         top: 50%;
+        flex-direction: column; // Fix shrinked thumb at the end in IE 11
 
         .b-slider-thumb {
             box-shadow: $slider-thumb-shadow;

--- a/src/scss/components/_slider.scss
+++ b/src/scss/components/_slider.scss
@@ -59,13 +59,17 @@ $slider-mark-size: 0.75rem !default;
         background: $slider-track-background;
         border-radius: $slider-track-radius;
         border: $slider-track-border;
+        // Fix alignment in IE 11. Cancel out for others
+        top: 50%;
+        transform: translateY(-50%);
     }
     .b-slider-thumb-wrapper {
         display: inline-flex;
         align-items: center;
         position: absolute;
-        transform: translateX(-50%);
+        transform: translate(-50%, -50%);
         cursor: grab;
+        top: 50%;
 
         .b-slider-thumb {
             box-shadow: $slider-thumb-shadow;
@@ -128,9 +132,10 @@ $slider-mark-size: 0.75rem !default;
         display: flex;
         justify-content: center;
 		width: $slider-tick-width;
-        transform: translateX(-50%);
+        transform: translate(-50%, -50%);
         background: $slider-tick-background;
         border-radius: $slider-tick-radius;
+        top: 50%;
         &.is-tick-hidden {
             background: transparent;
         }

--- a/src/scss/components/_slider.scss
+++ b/src/scss/components/_slider.scss
@@ -69,8 +69,8 @@ $slider-mark-size: 0.75rem !default;
         display: inline-flex;
         align-items: center;
         position: absolute;
-        transform: translate(-50%, -50%);
         cursor: grab;
+        transform: translate(-50%, -50%);
         top: 50%;
         flex-direction: column; // Fix shrinked thumb at the end in IE 11
 
@@ -134,9 +134,9 @@ $slider-mark-size: 0.75rem !default;
         position: absolute;
 		width: $slider-tick-width;
         transform: translate(-50%, -50%);
+        top: 50%;
         background: $slider-tick-background;
         border-radius: $slider-tick-radius;
-        top: 50%;
         &.is-tick-hidden {
             background: transparent;
         }


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes a few style problems related to flexbox bugs in IE 11. Other browsers should not be affected.
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

![image](https://user-images.githubusercontent.com/1696853/62798627-554ca500-baa4-11e9-8b29-27d90df03f3e.png)

## Proposed Changes

- Fix vertical alignment of track, thumb and tick (found a workaround from Vuetify)
- Fix shrink-to-fit problem of thumb at the end of the track
- Fix label centering
