### PR TITLE
Update Openbook to Okuna

### DIFF
--- a/docs/data/expo.json
+++ b/docs/data/expo.json
@@ -68,10 +68,10 @@
         "url": "https://nestandcut.com"
     },
     {
-        "title": "Openbook",
+        "title": "Okuna",
         "date": "2019-04-24",
         "img": "openbook.png",
-        "url": "https://www.open-book.org",
+        "url": "https://www.okuna.io",
         "featured": true
     },
     {


### PR DESCRIPTION
We're one of the featured sites.

We've recently changed our name from Openbook to Okuna.

# Proposed Changes

Change feature page from Openbook to Okuna