### PR TITLE
rearrange modal close button

### DIFF
--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -19,12 +19,12 @@
                     v-else-if="content"
                     v-html="content"/>
                 <slot v-else/>
+                <button
+                    type="button"
+                    v-if="showX"
+                    class="modal-close is-large"
+                    @click="cancel('x')"/>
             </div>
-            <button
-                type="button"
-                v-if="showX"
-                class="modal-close is-large"
-                @click="cancel('x')"/>
         </div>
     </transition>
 </template>

--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -1,5 +1,8 @@
 <template>
-    <transition :name="animation">
+    <transition
+        :name="animation"
+        @after-enter="afterEnter"
+        @before-leave="beforeLeave">
         <div
             v-if="isActive"
             class="modal is-active"
@@ -20,9 +23,10 @@
                     v-html="content"/>
                 <slot v-else/>
                 <button
+                    ref="closeButton"
                     type="button"
                     v-if="showX"
-                    class="modal-close is-large"
+                    class="modal-close is-large is-invisible"
                     @click="cancel('x')"/>
             </div>
         </div>
@@ -180,6 +184,20 @@ export default {
         keyPress(event) {
             // Esc key
             if (this.isActive && event.keyCode === 27) this.cancel('escape')
+        },
+
+        /**
+        * Transition after-enter hook
+        */
+        afterEnter() {
+            if (this.showX) this.$refs.closeButton.classList.toggle('is-invisible')
+        },
+
+        /**
+        * Transition before-leave hook
+        */
+        beforeLeave() {
+            if (this.showX) this.$refs.closeButton.classList.toggle('is-invisible')
         }
     },
     created() {

--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -23,10 +23,9 @@
                     v-html="content"/>
                 <slot v-else/>
                 <button
-                    ref="closeButton"
                     type="button"
-                    v-if="showX"
-                    class="modal-close is-large is-invisible"
+                    v-if="showX && !animating"
+                    class="modal-close is-large"
                     @click="cancel('x')"/>
             </div>
         </div>
@@ -88,7 +87,8 @@ export default {
             savedScrollTop: null,
             newWidth: typeof this.width === 'number'
                 ? this.width + 'px'
-                : this.width
+                : this.width,
+            animating: true
         }
     },
     computed: {
@@ -190,14 +190,14 @@ export default {
         * Transition after-enter hook
         */
         afterEnter() {
-            if (this.showX) this.$refs.closeButton.classList.toggle('is-invisible')
+            this.animating = false
         },
 
         /**
         * Transition before-leave hook
         */
         beforeLeave() {
-            if (this.showX) this.$refs.closeButton.classList.toggle('is-invisible')
+            this.animating = true
         }
     },
     created() {

--- a/src/components/modal/__snapshots__/Modal.spec.js.snap
+++ b/src/components/modal/__snapshots__/Modal.spec.js.snap
@@ -4,7 +4,7 @@ exports[`BModal render correctly 1`] = `
 <transition-stub name="zoom-out">
     <div class="modal is-active">
         <div class="modal-background"></div>
-        <div class="animation-content modal-content" style="max-width: 960px;"></div> <button type="button" class="modal-close is-large"></button>
+        <div class="animation-content modal-content" style="max-width: 960px;"> <button type="button" class="modal-close is-large"></button></div>
     </div>
 </transition-stub>
 `;


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

## Description
At the moment, the modal close button is at top right corner. There's been cases where users want to make it close to modal box for convenience, like below

<img width="304" alt="Screenshot 2019-08-15 at 6 06 33 PM" src="https://user-images.githubusercontent.com/5061591/63089241-bfc08200-bf89-11e9-906d-8f1532658635.png">
<img width="311" alt="Screenshot 2019-08-15 at 6 15 28 PM" src="https://user-images.githubusercontent.com/5061591/63089246-c222dc00-bf89-11e9-841d-10910124b8a6.png">

Our real use case was that customer uses our website on big screen and for some modals we do not allow click outside or press escape to close the modal. The close button is the only option but it's too far on top right corner

## Proposed Changes

- Rearranges modal close button inside modal content, this PR will not break anything since it has `position fixed` applied
- With this approach, it's more flexible since user can position the close button `absolute` or `relative` to modal-content or `fixed` to window
