### PR TITLE
Disable timepicker hour if no enabled minutes available

### DIFF
--- a/src/components/timepicker/Timepicker.spec.js
+++ b/src/components/timepicker/Timepicker.spec.js
@@ -22,4 +22,15 @@ describe('BTimepicker', () => {
 
         expect(wrapper.vm.nativeStep).toBe('1')
     })
+
+    it('disables hour if no selectable minutes available', () => {
+        const wrapper = shallowMount(BTimepicker, {
+            propsData: {
+                'min-time': new Date(2019, 8, 22, 11, 55),
+                'increment-minutes': 10
+            }
+        })
+        expect(wrapper.find('option[value="11"]').hasAttribute('disabled', 'disabled')).toBe(true)
+        expect(wrapper.find('option[value="12"]').hasAttribute('disabled', 'disabled')).toBe(false)
+    })
 })

--- a/src/components/timepicker/Timepicker.spec.js
+++ b/src/components/timepicker/Timepicker.spec.js
@@ -30,7 +30,7 @@ describe('BTimepicker', () => {
                 'increment-minutes': 10
             }
         })
-        expect(wrapper.find('option[value="11"]').hasAttribute('disabled', 'disabled')).toBe(true)
-        expect(wrapper.find('option[value="12"]').hasAttribute('disabled', 'disabled')).toBe(false)
+        expect(wrapper.find('option[value="11"]').attributes()['disabled']).toBe('disabled')
+        expect(wrapper.find('option[value="12"]').attributes()['disabled']).not.toBe('disabled')
     })
 })

--- a/src/utils/TimepickerMixin.js
+++ b/src/utils/TimepickerMixin.js
@@ -314,7 +314,10 @@ export default {
             let disabled = false
             if (this.minTime) {
                 const minHours = this.minTime.getHours()
-                disabled = hour < minHours
+                const noMinutesAvailable = this.minutes.every((minute) => {
+                    return this.isMinuteDisabledForHour(hour, minute.value)
+                })
+                disabled = hour < minHours || noMinutesAvailable
             }
             if (this.maxTime) {
                 if (!disabled) {
@@ -342,24 +345,31 @@ export default {
             return disabled
         },
 
+        isMinuteDisabledForHour(hour, minute) {
+            let disabled = false
+            if (this.minTime) {
+                const minHours = this.minTime.getHours()
+                const minMinutes = this.minTime.getMinutes()
+                disabled = hour === minHours && minute < minMinutes
+            }
+            if (this.maxTime) {
+                if (!disabled) {
+                    const maxHours = this.maxTime.getHours()
+                    const maxMinutes = this.maxTime.getMinutes()
+                    disabled = hour === maxHours && minute > maxMinutes
+                }
+            }
+
+            return disabled
+        },
+
         isMinuteDisabled(minute) {
             let disabled = false
             if (this.hoursSelected !== null) {
                 if (this.isHourDisabled(this.hoursSelected)) {
                     disabled = true
                 } else {
-                    if (this.minTime) {
-                        const minHours = this.minTime.getHours()
-                        const minMinutes = this.minTime.getMinutes()
-                        disabled = this.hoursSelected === minHours && minute < minMinutes
-                    }
-                    if (this.maxTime) {
-                        if (!disabled) {
-                            const maxHours = this.maxTime.getHours()
-                            const maxMinutes = this.maxTime.getMinutes()
-                            disabled = this.hoursSelected === maxHours && minute > maxMinutes
-                        }
-                    }
+                    disabled = this.isMinuteDisabledForHour(this.hoursSelected, minute)
                 }
                 if (this.unselectableTimes) {
                     if (!disabled) {


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #1686 

## Proposed Changes

When checking against minTime in isHourDisabled() in TimepickerMixin.js, add a further call to check if all of the minutes values are disabled and set disabled to true if so. 

The check for the disabled minutes was extracted from the isMinuteDisabled function and extracted to a seperate function isMinuteDisabledForHour, now used by both functions.

Test included in Timepicker.spec.js
