### PR TITLE
Fix #1701 - Taginput cannot add Footer slot

### DIFF
--- a/src/components/taginput/Taginput.vue
+++ b/src/components/taginput/Taginput.vue
@@ -187,7 +187,7 @@ export default {
         },
 
         footerSlotName() {
-            return this.hasHeaderSlot ? 'footer' : 'dontrender'
+            return this.hasFooterSlot ? 'footer' : 'dontrender'
         },
 
         hasDefaultSlot() {


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #1701 
## Proposed Changes

Fixed typo in Taginput.vue. This will allow Taginput fields to have Footer slot in the list of options. Currently it won't work unless there is _also_ a header slot. 
