### PR TITLE
Deep merging for customIconPacks

### DIFF
--- a/docs/pages/components/icon/examples/ExCustom.vue
+++ b/docs/pages/components/icon/examples/ExCustom.vue
@@ -2,17 +2,17 @@
     <section>
         <div class="block">
             <b-icon
-                pack="icon"
+                pack="ionicons"
                 icon="person"
                 size="is-small">
             </b-icon>
             <b-icon
-                pack="icon"
+                pack="ionicons"
                 icon="home"
                 size="is-small">
             </b-icon>
             <b-icon
-                pack="icon"
+                pack="ionicons"
                 icon="apps"
                 size="is-small">
             </b-icon>
@@ -20,32 +20,32 @@
 
         <div class="block">
             <b-icon
-                pack="icon"
+                pack="ionicons"
                 icon="person">
             </b-icon>
             <b-icon
-                pack="icon"
+                pack="ionicons"
                 icon="home">
             </b-icon>
             <b-icon
-                pack="icon"
+                pack="ionicons"
                 icon="apps">
             </b-icon>
         </div>
 
         <div class="block">
             <b-icon
-                pack="icon"
+                pack="ionicons"
                 icon="person"
                 size="is-medium">
             </b-icon>
             <b-icon
-                pack="icon"
+                pack="ionicons"
                 icon="home"
                 size="is-medium">
             </b-icon>
             <b-icon
-                pack="icon"
+                pack="ionicons"
                 icon="apps"
                 size="is-medium">
             </b-icon>
@@ -53,19 +53,19 @@
 
         <div class="block">
             <b-icon
-                pack="icon"
+                pack="ionicons"
                 icon="person"
                 size="is-large"
                 type="is-success">
             </b-icon>
             <b-icon
-                pack="icon"
+                pack="ionicons"
                 icon="home"
                 size="is-large"
                 type="is-info">
             </b-icon>
             <b-icon
-                pack="icon"
+                pack="ionicons"
                 icon="apps"
                 size="is-large"
                 type="is-primary">
@@ -73,29 +73,68 @@
         </div>
 
         <button class="button is-dark">
-            <b-icon pack="icon" icon="checkmark"></b-icon>
+            <b-icon pack="ionicons" icon="checkmark"></b-icon>
             <span>Finish</span>
         </button>
 
         <button class="button is-warning">
-            <b-icon pack="icon" icon="checkmark"></b-icon>
+            <b-icon pack="ionicons" icon="checkmark"></b-icon>
             <span>Finish</span>
         </button>
 
         <button class="button is-warning">
             <b-icon
-                pack="icon"
+                pack="ionicons"
                 icon="refresh">
             </b-icon>
             <span>Refresh</span>
         </button>
+
+        <div class="block">
+            <p>
+                Can also customize some properties of the default icon packs. In this example, default sizes for FontAwesome have been modified.
+            </p>
+            <b-icon
+                pack="fas"
+                icon="user"
+                size="is-small"
+                type="is-success">
+            </b-icon>
+            <b-icon
+                pack="fas"
+                icon="user"
+                type="is-info">
+            </b-icon>
+            <b-icon
+                pack="fas"
+                icon="user"
+                size="is-medium"
+                type="is-danger">
+            </b-icon>
+            <b-icon
+                pack="fas"
+                icon="user"
+                size="is-large"
+                type="is-primary">
+            </b-icon>
+        </div>
     </section>
 </template>
 
 <script>
+    import config from "../../../../../src/utils/config"
+
     const customIconConfig = {
         customIconPacks: {
-            'icon': {
+            'fas': {
+                sizes: {
+                    'default': 'fa-sm',
+                    'is-small': 'fa-xs',
+                    'is-medium': 'fa-lg',
+                    'is-large': 'fa-2x'
+                }
+            },
+            'ionicons': {
                 sizes: {
                     'default': 'is-size-5',
                     'is-small': '',
@@ -123,7 +162,7 @@
     }
     export default {
         created() {
-            this.$buefy.config.setOptions(customIconConfig)
+            this.$buefy.config.setOptions(Object.assign(config, customIconConfig))
         }
     }
 </script>

--- a/docs/pages/components/icon/examples/ExCustom.vue
+++ b/docs/pages/components/icon/examples/ExCustom.vue
@@ -122,8 +122,6 @@
 </template>
 
 <script>
-    import config from "../../../../../src/utils/config"
-
     const customIconConfig = {
         customIconPacks: {
             'fas': {

--- a/docs/pages/components/icon/examples/ExCustom.vue
+++ b/docs/pages/components/icon/examples/ExCustom.vue
@@ -162,7 +162,7 @@
     }
     export default {
         created() {
-            this.$buefy.config.setOptions(Object.assign(config, customIconConfig))
+            this.$buefy.config.setOptions(customIconConfig)
         }
     }
 </script>

--- a/src/components/icon/Icon.vue
+++ b/src/components/icon/Icon.vue
@@ -14,6 +14,7 @@
 </template>
 
 <script>
+import {merge} from '../../utils/helpers'
 import config from '../../utils/config'
 import icons from '../../utils/icons'
 
@@ -31,10 +32,11 @@ export default {
     },
     computed: {
         iconConfig() {
+            let allIcons = icons
             if (config.customIconPacks) {
-                Object.assign(icons, config.customIconPacks)
+                allIcons = merge(icons, config.customIconPacks)
             }
-            return icons[this.newPack]
+            return allIcons[this.newPack]
         },
         iconPrefix() {
             if (this.iconConfig && this.iconConfig.iconPrefix) {

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -24,6 +24,25 @@ export function indexOf(array, obj, fn) {
 }
 
 /**
+* Merge function to replace Object.assign with deep merging possibility
+*/
+const isObject = (item) => typeof item === 'object' && !Array.isArray(item)
+const mergeFn = (target, source) => {
+    const isDeep = (prop) =>
+        isObject(source[prop]) && target.hasOwnProperty(prop) && isObject(target[prop])
+    const replaced = Object.getOwnPropertyNames(source)
+        .map((prop) =>
+            ({ [prop]: isDeep(prop) ? mergeFn(target[prop], source[prop]) : source[prop] }))
+        .reduce((a, b) => ({ ...a, ...b }), {})
+
+    return {
+        ...target,
+        ...replaced
+    }
+}
+export const merge = mergeFn
+
+/**
  * Mobile detection
  * https://www.abeautifulsite.net/detecting-mobile-devices-with-javascript
  */

--- a/src/utils/helpers.spec.js
+++ b/src/utils/helpers.spec.js
@@ -1,4 +1,4 @@
-import { getValueByPath, indexOf, escapeRegExpChars, removeElement } from './helpers'
+import { getValueByPath, indexOf, merge, escapeRegExpChars, removeElement } from './helpers'
 
 describe('helpers', () => {
     describe('getValueByPath', () => {
@@ -55,6 +55,60 @@ describe('helpers', () => {
             expect(indexOf(arr, obj5, fnc)).toBe(-1)
             expect(indexOf(null, obj1, fnc)).toBe(-1)
             expect(indexOf(arr, obj1)).toBe(0)
+        })
+    })
+
+    describe('merge', () => {
+        describe('shallow merges', () => {
+            it('merges objects', () => {
+                const a = { a: 'discard' }
+                const b = { a: 'test' }
+                expect(merge(a, b)).toEqual({ a: 'test' })
+            })
+
+            it('extends objects', () => {
+                const a = { a: 'test' }
+                const b = { b: 'test' }
+                expect(merge(a, b)).toEqual({ a: 'test', b: 'test' })
+            })
+
+            it('extends a property with an object', () => {
+                const a = { a: 'test' }
+                const b = { b: { c: 'test' } }
+                expect(merge(a, b)).toEqual({ a: 'test', b: { c: 'test' } })
+            })
+
+            it('replaces a property with an object', () => {
+                const a = { b: 'whatever', a: 'test' }
+                const b = { b: { c: 'test' } }
+                expect(merge(a, b)).toEqual({ a: 'test', b: { c: 'test' } })
+            })
+        })
+
+        describe('deep merges', () => {
+            it('merges objects', () => {
+                const a = { test: { a: 'discard', b: 'test' } }
+                const b = { test: { a: 'test' } }
+                expect(merge(a, b)).toEqual({ test: { a: 'test', b: 'test' } })
+            })
+
+            it('extends objects', () => {
+                const a = { test: { a: 'test' } }
+                const b = { test: { b: 'test' } }
+                expect(merge(a, b)).toEqual({ test: { a: 'test', b: 'test' } })
+            })
+
+            it('extends a property with an object', () => {
+                const a = { test: { a: 'test' } }
+                const b = { test: { b: { c: 'test' } } }
+                expect(merge(a, b)).toEqual({ test: { a: 'test', b: { c: 'test' } } })
+            })
+
+            it('replaces a property with an object', () => {
+                const a = { test: { b: 'whatever', a: 'test' } }
+                const b = { test: { b: { c: 'test' } } }
+                expect(merge(a, b)).toEqual({ test: { a: 'test', b: { c: 'test' } } })
+            })
         })
     })
 

--- a/src/utils/icons.js
+++ b/src/utils/icons.js
@@ -1,4 +1,5 @@
 import config from '../utils/config'
+import {merge} from '../utils/helpers'
 
 let mdiIcons = {
     sizes: {
@@ -41,7 +42,7 @@ let icons = {
 }
 
 if (config.customIconPacks) {
-    Object.assign(icons, config.customIconPacks)
+    icons = merge(icons, config.customIconPacks)
 }
 
 export default icons


### PR DESCRIPTION
## Proposed Changes

- Enable default Icon packs customization without using the full object

----------

Fixes #1434 
Fixes #1329
Default size for FontAwesome could be customize using `customIconPacks` config. Something like this for example:
```
Vue.use(Buefy, {
    customIconPacks: {
        'fas': {
            sizes: {
                'default': 'fa-sm',
                'is-small': 'fa-xs',
                'is-medium': 'fa-lg',
                'is-large': 'fa-2x'
            }
        }
    }
})
```
----------
Fixes #1355
Default internal icons could be customize using `customIconPacks` config. Something like this for example:
```
Vue.use(Buefy, {
    customIconPacks: {
        'mdi': {
            internalIcons: {
                'eye': 'eye-off',
                'eye-off': 'eye'
            }
        },
        'fas': {
            internalIcons: {
                'eye': 'eye-slash',
                'eye-off': 'eye'
            }
        }
    }
})
```