### PR TITLE
Add 'is-right' option for NavbarDropdown

### DIFF
--- a/docs/pages/components/navbar/api/navbar.js
+++ b/docs/pages/components/navbar/api/navbar.js
@@ -115,7 +115,7 @@ export default [
             default: 'false'
         },
         {
-            name: '<code>is-right</code>',
+            name: '<code>right</code>',
             description: 'Dropdown will be anchored to the right side',
             type: 'Boolean',
             values: '-',

--- a/docs/pages/components/navbar/api/navbar.js
+++ b/docs/pages/components/navbar/api/navbar.js
@@ -113,6 +113,13 @@ export default [
             type: 'Boolean',
             values: '-',
             default: 'false'
+        },
+        {
+            name: '<code>is-right</code>',
+            description: 'Dropdown will be anchored to the right side',
+            type: 'Boolean',
+            values: '-',
+            default: 'false'
         }
     ],
     slots: [

--- a/src/components/navbar/NavbarDropdown.vue
+++ b/src/components/navbar/NavbarDropdown.vue
@@ -11,7 +11,7 @@
             <template v-if="label">{{ label }}</template>
             <slot v-else name="label" />
         </a>
-        <div class="navbar-dropdown">
+        <div class="navbar-dropdown" :class="{'is-right': isRight}">
             <slot />
         </div>
     </div>
@@ -28,7 +28,11 @@ export default {
     props: {
         label: String,
         hoverable: Boolean,
-        active: Boolean
+        active: Boolean,
+        isRight: {
+            type: Boolean,
+            default: false
+        }
     },
     data() {
         return {

--- a/src/components/navbar/NavbarDropdown.vue
+++ b/src/components/navbar/NavbarDropdown.vue
@@ -11,7 +11,7 @@
             <template v-if="label">{{ label }}</template>
             <slot v-else name="label" />
         </a>
-        <div class="navbar-dropdown" :class="{'is-right': isRight}">
+        <div class="navbar-dropdown" :class="{'is-right': right}">
             <slot />
         </div>
     </div>
@@ -29,7 +29,7 @@ export default {
         label: String,
         hoverable: Boolean,
         active: Boolean,
-        isRight: {
+        right: {
             type: Boolean,
             default: false
         }


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

## Proposed Changes
- Add 'is-right' class for `NavbarDropdown` menus in order for menus that are put in the `end` slot of the Navbar component to not be cut
