### PR TITLE
Fix grouped/addons size with inside labels

### DIFF
--- a/docs/pages/components/field/examples/ExLabelPosition.vue
+++ b/docs/pages/components/field/examples/ExLabelPosition.vue
@@ -58,14 +58,14 @@
         <b-field label="Search..." :label-position="labelPosition" grouped>
             <b-input placeholder="Search..." type="search"></b-input>
             <p class="control">
-                <button class="button is-primary">Search</button>
+                <b-button class="button is-primary">Search</b-button>
             </p>
         </b-field>
 
         <b-field label="Search..." :label-position="labelPosition">
             <b-input placeholder="Search..." type="search"></b-input>
             <p class="control">
-                <button class="button is-primary">Search</button>
+                <b-button class="button is-primary">Search</b-button>
             </p>
         </b-field>
     </section>

--- a/docs/pages/components/field/examples/ExLabelPosition.vue
+++ b/docs/pages/components/field/examples/ExLabelPosition.vue
@@ -51,6 +51,23 @@
             :label-position="labelPosition">
             <b-input maxlength="200" type="textarea"></b-input>
         </b-field>
+
+        <hr>
+        <p class="title is-6">Also works for grouped field and with addons.</p>
+
+        <b-field label="Search..." :label-position="labelPosition" grouped>
+            <b-input placeholder="Search..." type="search"></b-input>
+            <p class="control">
+                <button class="button is-primary">Search</button>
+            </p>
+        </b-field>
+
+        <b-field label="Search..." :label-position="labelPosition">
+            <b-input placeholder="Search..." type="search"></b-input>
+            <p class="control">
+                <button class="button is-primary">Search</button>
+            </p>
+        </b-field>
     </section>
 </template>
 

--- a/src/scss/components/_form.scss
+++ b/src/scss/components/_form.scss
@@ -160,6 +160,16 @@ $floating-in-height: 3.25em;
                 }
             }
         }
+
+        &.has-addons, &.is-grouped {
+            .control {
+                .button,
+                .input,
+                .select select {
+                    height: $floating-in-height
+                }
+            }
+        }
     }
     &.is-floating-label, &.is-floating-in-label {
         &.has-numberinput {


### PR DESCRIPTION
Adapt grouped or addons elements height if we use `label-position="inside"`

## Proposed Changes

- Keep every grouped elements the same height

### Results
![image](https://user-images.githubusercontent.com/12817388/64816207-3646a480-d575-11e9-8c4b-a2bd2a174878.png)

