### PR TITLE
add full-screen option to ./api/modal

### DIFF
--- a/docs/pages/components/modal/Modal.vue
+++ b/docs/pages/components/modal/Modal.vue
@@ -27,6 +27,7 @@
 </template>
 
 <script>
+    // Update data here to include 'full-screen' option
     import api from './api/modal'
 
     import ExSimple from './examples/ExSimple'


### PR DESCRIPTION
It doesnt appear that I can propose a change to the ./api/modal file so I'm sending it in here. And it doesn't really fit the contributing guidelines so I hope this is ok.

I believe this is the file [here](https://github.com/buefy/buefy/blob/8c4c464448af869a1e6ae6551fe54740cecd2e4f/docs/pages/components/modal/api/modal.js)

Would be something like this:
```
            {
                name: '<code>full-screen</code>',
                description: 'Option to cover the whole page.',
                type: 'String',
                values: '—',
                default: '—'
            },
```

<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes
add full-screen option to ./api/modal
-
-
-
