### PR TITLE
Improve icon for support fab

### DIFF
--- a/src/utils/icons.js
+++ b/src/utils/icons.js
@@ -41,7 +41,8 @@ const getIcons = () => {
         fa: faIcons(),
         fas: faIcons(),
         far: faIcons(),
-        fad: faIcons()
+        fad: faIcons(),
+        fab: faIcons()
     }
 
     if (config && config.customIconPacks) {


### PR DESCRIPTION
Example: 
`<b-icon pack="fab" icon="github"/></b-icon>`
This not working because `fab` not added in `utils/icons.js`