### PR TITLE
Trap focus (Fixes #1706)

### DIFF
--- a/docs/pages/components/dialog/api/dialog.js
+++ b/docs/pages/components/dialog/api/dialog.js
@@ -116,6 +116,13 @@ export default [
                 type: 'String',
                 values: '<code>confirm</code>, <code>cancel</code>',
                 default: '<code>confirm</code>'
+            },
+            {
+                name: '<code>trap-focus</code>',
+                description: `Trap focus inside the dialog.`,
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
             }
         ]
     }

--- a/docs/pages/components/dropdown/api/dropdown.js
+++ b/docs/pages/components/dropdown/api/dropdown.js
@@ -66,6 +66,13 @@ export default [
                 default: '<code>false</code>'
             },
             {
+                name: '<code>trap-focus</code>',
+                description: `Trap focus inside the dropdown.`,
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
                 name: '<code>can-close</code>',
                 description: 'Can close dropdown by pressing escape or by clicking outside',
                 type: 'Boolean, Array',

--- a/docs/pages/components/modal/Modal.vue
+++ b/docs/pages/components/modal/Modal.vue
@@ -7,6 +7,9 @@
                 A modal with a component. When you want to close the Modal, call the 'close' method —
                 <code>this.$parent.close()</code> — from the injected component.
             </p>
+            <p>
+                `trap-focus` prop could be useful in this case.
+            </p>
         </Example>
 
         <Example :component="ExProgrammatic" :code="ExProgrammaticCode" title="Programmatic">

--- a/docs/pages/components/modal/api/modal.js
+++ b/docs/pages/components/modal/api/modal.js
@@ -88,6 +88,13 @@ export default [
                 default: '<code>clip</code>'
             },
             {
+                name: '<code>trap-focus</code>',
+                description: `Trap focus inside the modal.`,
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
                 name: '<code>custom-class</code>',
                 description: 'CSS classes to be applied on modal',
                 type: 'String',

--- a/docs/pages/components/modal/examples/ExComponent.vue
+++ b/docs/pages/components/modal/examples/ExComponent.vue
@@ -5,7 +5,7 @@
             Launch component modal
         </button>
 
-        <b-modal :active.sync="isComponentModalActive" has-modal-card>
+        <b-modal :active.sync="isComponentModalActive" has-modal-card trap-focus>
             <modal-form v-bind="formProps"></modal-form>
         </b-modal>
     </section>

--- a/src/components/dialog/Dialog.vue
+++ b/src/components/dialog/Dialog.vue
@@ -3,7 +3,8 @@
         <div
             v-if="isActive"
             class="dialog modal is-active"
-            :class="size">
+            :class="size"
+            v-trap-focus="trapFocus">
             <div class="modal-background" @click="cancel('outside')"/>
             <div class="modal-card animation-content">
                 <header class="modal-card-head" v-if="title">
@@ -65,6 +66,7 @@
 </template>
 
 <script>
+import trapFocus from '../../directives/trapFocus'
 import Icon from '../icon/Icon'
 import Modal from '../modal/Modal'
 import config from '../../utils/config'
@@ -74,6 +76,9 @@ export default {
     name: 'BDialog',
     components: {
         [Icon.name]: Icon
+    },
+    directives: {
+        trapFocus
     },
     extends: Modal,
     props: {
@@ -115,6 +120,10 @@ export default {
         focusOn: {
             type: String,
             default: 'confirm'
+        },
+        trapFocus: {
+            type: Boolean,
+            default: false
         }
     },
     data() {

--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -23,7 +23,8 @@
                 v-show="(!disabled && (isActive || isHoverable)) || inline"
                 ref="dropdownMenu"
                 class="dropdown-menu"
-                :aria-hidden="!isActive">
+                :aria-hidden="!isActive"
+                v-trap-focus="trapFocus">
                 <div
                     class="dropdown-content"
                     :role="ariaRoleMenu">
@@ -35,12 +36,16 @@
 </template>
 
 <script>
+import trapFocus from '../../directives/trapFocus'
 import config from '../../utils/config'
 
 const DEFAULT_CLOSE_OPTIONS = ['escape', 'outside']
 
 export default {
     name: 'BDropdown',
+    directives: {
+        trapFocus
+    },
     props: {
         value: {
             type: [String, Number, Boolean, Object, Array, Function],
@@ -74,6 +79,10 @@ export default {
             default: 'fade'
         },
         multiple: Boolean,
+        trapFocus: {
+            type: Boolean,
+            default: false
+        },
         closeOnClick: {
             type: Boolean,
             default: true

--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -6,7 +6,8 @@
         <div
             v-if="isActive"
             class="modal is-active"
-            :class="[{'is-full-screen': fullScreen}, customClass]">
+            :class="[{'is-full-screen': fullScreen}, customClass]"
+            v-trap-focus="trapFocus">
             <div class="modal-background" @click="cancel('outside')"/>
             <div
                 class="animation-content"
@@ -33,11 +34,15 @@
 </template>
 
 <script>
+import trapFocus from '../../directives/trapFocus'
 import { removeElement } from '../../utils/helpers'
 import config from '../../utils/config'
 
 export default {
     name: 'BModal',
+    directives: {
+        trapFocus
+    },
     props: {
         active: Boolean,
         component: [Object, Function],
@@ -79,6 +84,10 @@ export default {
             }
         },
         fullScreen: Boolean,
+        trapFocus: {
+            type: Boolean,
+            default: false
+        },
         customClass: String
     },
     data() {

--- a/src/directives/trapFocus.js
+++ b/src/directives/trapFocus.js
@@ -1,0 +1,51 @@
+const findFocusable = (element) => {
+    if (!element) {
+        return null
+    }
+    return element.querySelectorAll(`a[href],
+                                     area[href],
+                                     input:not([disabled]),
+                                     select:not([disabled]),
+                                     textarea:not([disabled]),
+                                     button:not([disabled]),
+                                     iframe,
+                                     object,
+                                     embed,
+                                     *[tabindex],
+                                     *[contenteditable]`)
+}
+
+let onKeyDown
+
+const bind = (el, { value = true }) => {
+    if (value) {
+        const focusable = findFocusable(el)
+
+        if (focusable && focusable.length > 0) {
+            const firstFocusable = focusable[0]
+            const lastFocusable = focusable[focusable.length - 1]
+
+            onKeyDown = (event) => {
+                if (event.target === firstFocusable && event.shiftKey && event.key === 'Tab') {
+                    event.preventDefault()
+                    lastFocusable.focus()
+                } else if (event.target === lastFocusable && !event.shiftKey && event.key === 'Tab') {
+                    event.preventDefault()
+                    firstFocusable.focus()
+                }
+            }
+            el.addEventListener('keydown', onKeyDown)
+        }
+    }
+}
+
+const unbind = (el) => {
+    el.removeEventListener('keydown', onKeyDown)
+}
+
+const directive = {
+    bind,
+    unbind
+}
+
+export default directive


### PR DESCRIPTION
Fixes #1706
Related to: #576

## Proposed Changes

- Add a trap focus directive
- Add a prop `trap-focus` to dialog, dropdown and modal
- Trap focus inside the component when the prop is true
