### PR TITLE
Fix #1786: icons warning for vue-fontawesome

### DIFF
--- a/docs/pages/components/icon/examples/ExCustom.vue
+++ b/docs/pages/components/icon/examples/ExCustom.vue
@@ -126,7 +126,7 @@
         customIconPacks: {
             'fas': {
                 sizes: {
-                    'default': 'fa-sm',
+                    'default': null,
                     'is-small': 'fa-xs',
                     'is-medium': 'fa-lg',
                     'is-large': 'fa-2x'

--- a/src/components/icon/Icon.vue
+++ b/src/components/icon/Icon.vue
@@ -80,7 +80,7 @@ export default {
                     return this.iconConfig.sizes.default
                 }
             }
-            return ''
+            return null
         },
         useIconComponent() {
             return this.component || config.defaultIconComponent

--- a/src/utils/icons.js
+++ b/src/utils/icons.js
@@ -4,7 +4,7 @@ import {merge} from '../utils/helpers'
 const mdiIcons = {
     sizes: {
         'default': 'mdi-24px',
-        'is-small': '',
+        'is-small': null,
         'is-medium': 'mdi-36px',
         'is-large': 'mdi-48px'
     },
@@ -16,7 +16,7 @@ const faIcons = () => {
     return {
         sizes: {
             'default': faIconPrefix + 'lg',
-            'is-small': '',
+            'is-small': null,
             'is-medium': faIconPrefix + '2x',
             'is-large': faIconPrefix + '3x'
         },


### PR DESCRIPTION
Fixes #1786
Fixes #1768

I will do some more tests, but I think this should solve the warning when using vue-fontawesome.
