### PR TITLE
Add support for FontAwesome Light Style icons

### DIFF
--- a/src/utils/icons.js
+++ b/src/utils/icons.js
@@ -42,7 +42,8 @@ const getIcons = () => {
         fas: faIcons(),
         far: faIcons(),
         fad: faIcons(),
-        fab: faIcons()
+        fab: faIcons(),
+        fal: faIcons()
     }
 
     if (config && config.customIconPacks) {


### PR DESCRIPTION
## Proposed Changes
Add support for FontAwesome Light Style icons.

Example:
<b-icon pack="fal" icon="clock"/></b-icon>
This is not working because fal was not added in utils/icons.js