### PR TITLE
B-navbar documentation update for close on click

### DIFF
--- a/docs/pages/components/navbar/api/navbar.js
+++ b/docs/pages/components/navbar/api/navbar.js
@@ -52,7 +52,7 @@ export default [
                 description: 'Control the behavior of the mobile menu by clicking on a link or outside the menu',
                 type: 'Boolean',
                 values: '<code>true</code>, <code>false</code>',
-                default: '<code>false</code>'
+                default: '<code>true</code>'
             },
             {
                 name: '<code>spaced</code>',


### PR DESCRIPTION
Close on click default is true rather than false update docs to reflect this. If this is not intended behaviour suggest to change default within Navbar.vue

<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

-
-
-
