### PR TITLE
make b-table with take number as px, or else user string directly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1667,15 +1667,13 @@
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.7.tgz",
       "integrity": "sha512-dBtBbrc+qTHy1WdfHYjBwRln4+LWqASWakLHsWHR2NWHIFkv4W3O070IGoGLEBrJBvct3r0L1BUPuvURi7kYUQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@types/babylon": {
       "version": "6.16.5",
       "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.5.tgz",
       "integrity": "sha512-xH2e58elpj1X4ynnKp9qSnWlsRTIs6n3tgLGNfwAGHwePw0mulHQllV34n0T25uYSu1k0hRKkWXF890B1yS47w==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@types/babel-types": "*"
       }
@@ -4697,7 +4695,6 @@
       "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.1.2.tgz",
       "integrity": "sha512-yePcBqEFhLOqSBtwYOGGS1exHo/s1xjekXiinh4itpNQGCu4KA1euPh1fg07N2wMITZXQkBz75Ntdt1ctGZouw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@types/babel-types": "^7.0.0",
         "@types/babylon": "^6.16.2",
@@ -7074,8 +7071,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7096,14 +7092,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7118,20 +7112,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7248,8 +7239,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7261,7 +7251,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7276,7 +7265,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7284,14 +7272,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7310,7 +7296,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7398,8 +7383,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7411,7 +7395,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7497,8 +7480,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7534,7 +7516,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7554,7 +7535,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7598,14 +7578,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -9678,8 +9656,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
       "integrity": "sha1-Fzb939lyTyijaCrcYjCufk6Weds=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -13993,8 +13970,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-1.3.3.tgz",
       "integrity": "sha512-qE3YhESP2mRAWMFJgKdtT5D7ckThRScXRwkfo+Erqga7dyJdY3ZquspprMCj/9sJ2ijm5hXFWQE/A3l4poMWiQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "pug-filters": {
       "version": "3.1.1",
@@ -14128,8 +14104,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-2.0.5.tgz",
       "integrity": "sha512-P+rXKn9un4fQY77wtpcuFyvFaBww7/91f3jHa154qU26qFAnOe6SW1CbIDcxiG5lLK9HazYrMCCuDvNgDQNptw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "pug-strip-comments": {
       "version": "1.0.4",
@@ -14145,8 +14120,7 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.8.tgz",
       "integrity": "sha512-GMu3M5nUL3fju4/egXwZO0XLi6fW/K3T3VTgFQ14GxNi8btlxgT5qZL//JwZFm/2Fa64J/PNS8AZeys3wiMkVA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "pump": {
       "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1667,13 +1667,15 @@
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.7.tgz",
       "integrity": "sha512-dBtBbrc+qTHy1WdfHYjBwRln4+LWqASWakLHsWHR2NWHIFkv4W3O070IGoGLEBrJBvct3r0L1BUPuvURi7kYUQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "@types/babylon": {
       "version": "6.16.5",
       "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.5.tgz",
       "integrity": "sha512-xH2e58elpj1X4ynnKp9qSnWlsRTIs6n3tgLGNfwAGHwePw0mulHQllV34n0T25uYSu1k0hRKkWXF890B1yS47w==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@types/babel-types": "*"
       }
@@ -4695,6 +4697,7 @@
       "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.1.2.tgz",
       "integrity": "sha512-yePcBqEFhLOqSBtwYOGGS1exHo/s1xjekXiinh4itpNQGCu4KA1euPh1fg07N2wMITZXQkBz75Ntdt1ctGZouw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@types/babel-types": "^7.0.0",
         "@types/babylon": "^6.16.2",
@@ -7071,7 +7074,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7092,12 +7096,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7112,17 +7118,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7239,7 +7248,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7251,6 +7261,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7265,6 +7276,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7272,12 +7284,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7296,6 +7310,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7383,7 +7398,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7395,6 +7411,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7480,7 +7497,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7516,6 +7534,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7535,6 +7554,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7578,12 +7598,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -9656,7 +9678,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
       "integrity": "sha1-Fzb939lyTyijaCrcYjCufk6Weds=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -13970,7 +13993,8 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-1.3.3.tgz",
       "integrity": "sha512-qE3YhESP2mRAWMFJgKdtT5D7ckThRScXRwkfo+Erqga7dyJdY3ZquspprMCj/9sJ2ijm5hXFWQE/A3l4poMWiQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "pug-filters": {
       "version": "3.1.1",
@@ -14104,7 +14128,8 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-2.0.5.tgz",
       "integrity": "sha512-P+rXKn9un4fQY77wtpcuFyvFaBww7/91f3jHa154qU26qFAnOe6SW1CbIDcxiG5lLK9HazYrMCCuDvNgDQNptw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "pug-strip-comments": {
       "version": "1.0.4",
@@ -14120,7 +14145,8 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.8.tgz",
       "integrity": "sha512-GMu3M5nUL3fju4/egXwZO0XLi6fW/K3T3VTgFQ14GxNi8btlxgT5qZL//JwZFm/2Fa64J/PNS8AZeys3wiMkVA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "pump": {
       "version": "2.0.1",

--- a/src/components/table/Table.spec.js
+++ b/src/components/table/Table.spec.js
@@ -8,12 +8,44 @@ describe('BTable', () => {
         wrapper = shallowMount(BTable)
     })
 
+    let tableCols = shallowMount(BTable, {
+        propsData: {
+            columns: [
+                {label: 'default', width: '100px'},
+                {label: 'pecent', width: '50%'},
+                {label: 'fixed_num', width: 100},
+                {label: 'fixed_str', width: '100'}
+            ]
+        }
+    })
+
     it('is called', () => {
         expect(wrapper.name()).toBe('BTable')
         expect(wrapper.isVueInstance()).toBeTruthy()
+
+        expect(tableCols.name()).toBe('BTable')
+        expect(tableCols.isVueInstance()).toBeTruthy()
     })
 
     it('render correctly', () => {
         expect(wrapper.html()).toMatchSnapshot()
+    })
+
+    it('holds columns', () => {
+        let headers = tableCols.findAll('th')
+
+        expect(headers.length).toBeGreaterThanOrEqual(4)
+
+        let cols = headers.filter((th) => {
+            let div = th.find('div')
+
+            return div.classes('th-wrap')
+        })
+
+        expect(cols.length).toBe(4)
+        expect(cols.at(0).attributes('style')).toBe('width: 100px;')
+        expect(cols.at(1).attributes('style')).toBe('width: 50%;')
+        expect(cols.at(2).attributes('style')).toBe('width: 100px;')
+        expect(cols.at(3).attributes('style')).toBe('width: 100px;')
     })
 })

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -64,7 +64,7 @@
                             }"
                             :style="{
                                 width: column.width === undefined ? null :
-                                (isNaN(parseInt(column.width)) ? column.width : column.width + 'px')
+                                (isNaN(column.width) ? column.width : column.width + 'px')
                             }"
                             @click.stop="sort(column)">
                             <div

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -64,7 +64,8 @@
                             }"
                             :style="{
                                 width: column.width === undefined ? null :
-                                (column.width == 'number' ? column.width + 'px' : column.width )
+                                (typeof column.width == 'number' ? column.width + 'px' :
+                                column.width)
                             }"
                             @click.stop="sort(column)">
                             <div

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -63,7 +63,8 @@
                                 'is-sortable': column.sortable
                             }"
                             :style="{
-                                width: column.width === undefined ? null : column.width + 'px'
+                                width: column.width === undefined ? null :
+                                (column.width == 'number' ? column.width + 'px' : column.width )
                             }"
                             @click.stop="sort(column)">
                             <div

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -64,8 +64,7 @@
                             }"
                             :style="{
                                 width: column.width === undefined ? null :
-                                (typeof column.width == 'number' ? column.width + 'px' :
-                                column.width)
+                                (isNaN(parseInt(column.width)) ? column.width : column.width + 'px')
                             }"
                             @click.stop="sort(column)">
                             <div


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #

<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

It would be really nice if we could use table column width as either a number, that is pixels as it is now, but if given as a string it it could be use it directly ?

This PR change the column render to handle this situation.