### PR TITLE
Validate tabItems index

### DIFF
--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -101,7 +101,7 @@ export default {
         * Change the active tab and emit change event.
         */
         changeTab(newIndex) {
-            if (this.activeTab === newIndex) return
+            if (this.activeTab === newIndex || this.tabItems[newIndex] === undefined) return
 
             if (this.activeTab < this.tabItems.length) {
                 this.tabItems[this.activeTab].deactivate(this.activeTab, newIndex)


### PR DESCRIPTION
## Issues
- Sends error when using dynamic tabs.
- If you remove a tab got this: TypeError: Cannot read property 'activate' of undefined

<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Include additional validation in changeTab method to validate tabItems index to work with dynamic tabs

