### PR TITLE
fixed dropdown items on select event after user types value

### DIFF
--- a/src/components/taginput/Taginput.vue
+++ b/src/components/taginput/Taginput.vue
@@ -264,6 +264,7 @@ export default {
                     this.tags.push(tagToAdd)
                     this.$emit('input', this.tags)
                     this.$emit('add', tagToAdd)
+                    this.$emit('typing', '')
                 }
             }
 
@@ -292,6 +293,7 @@ export default {
             this.$nextTick(() => {
                 this.newTag = ''
             })
+            // this.$emit('typing', '')
         },
 
         removeTag(index) {

--- a/src/components/taginput/Taginput.vue
+++ b/src/components/taginput/Taginput.vue
@@ -293,7 +293,6 @@ export default {
             this.$nextTick(() => {
                 this.newTag = ''
             })
-            // this.$emit('typing', '')
         },
 
         removeTag(index) {


### PR DESCRIPTION
## Problem
Steps:
1. User have taginput with autocomplete and open-on-focus modes
2. User types text to taginput.
3. User selects proposed item.
4. User sees only filtered items even when he clears the input


## Proposed Changes
This change allows users to see all dropdown items after typing and selecting an item
