### PR TITLE
improve sorting

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -2,7 +2,7 @@
  * Get value of an object property/path even if it's nested
  */
 export function getValueByPath(obj, path) {
-    const value = path.split('.').reduce((o, i) => o[i], obj)
+    const value = path.split('.').reduce((o, i) => (o[i]||''), obj)
     return value
 }
 


### PR DESCRIPTION
Fixes #

## Proposed Changes

-prevent helper 'getValueByPath' from returning null, which was causing sort to fail when accessing nested properties that do not exist on all data rows of b-table
-
-
