### PR TITLE
improve sorting with nested properties

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -2,7 +2,7 @@
  * Get value of an object property/path even if it's nested
  */
 export function getValueByPath(obj, path) {
-    const value = path.split('.').reduce((o, i) => (o[i]||''), obj)
+    const value = path.split('.').reduce((o, i) => (o[i] || ''), obj)
     return value
 }
 

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -2,7 +2,7 @@
  * Get value of an object property/path even if it's nested
  */
 export function getValueByPath(obj, path) {
-    const value = path.split('.').reduce((o, i) => o[i], obj)
+    const value = path.split('.').reduce((o, i) => (o[i]||''), obj)
     return value
 }
 


### PR DESCRIPTION
Fixes #

## Proposed Changes

-modify helper function 'getValueByPath' to always return a value, never null. Null values interfere with the sort function when this helper throws an error as it attempts to access a property of null
-
-
