### PR TITLE
insure getValueByPath successfully returns

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -2,8 +2,10 @@
  * Get value of an object property/path even if it's nested
  */
 export function getValueByPath(obj, path) {
-    const value = path.split('.').reduce((o, i) => o[i], obj)
-    return value
+    if (typeof obj === 'object'){
+        const value = path.split('.').reduce((o, i) => o ? o[i] : null, obj)
+        return value
+    }
 }
 
 /**

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -2,7 +2,7 @@
  * Get value of an object property/path even if it's nested
  */
 export function getValueByPath(obj, path) {
-    if (typeof obj === 'object'){
+    if (typeof obj === 'object') {
         const value = path.split('.').reduce((o, i) => o ? o[i] : null, obj)
         return value
     }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -2,10 +2,8 @@
  * Get value of an object property/path even if it's nested
  */
 export function getValueByPath(obj, path) {
-    if (typeof obj === 'object') {
-        const value = path.split('.').reduce((o, i) => o ? o[i] : null, obj)
-        return value
-    }
+    const value = path.split('.').reduce((o, i) => o ? o[i] : null, obj)
+    return value
 }
 
 /**


### PR DESCRIPTION
insure that getValueByPath always returns a value without throwing an error caused by missing nested objects

<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #1862 

## Proposed Changes

-improve reliability of getValueByPath helper function, insuring it does not throw error on null nested object
-
-
