### PR TITLE
Add "expanded" prop to RadioButton 

### DIFF
--- a/src/components/radio/RadioButton.vue
+++ b/src/components/radio/RadioButton.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="control">
+    <div class="control" :class="{ 'is-expanded': expanded }">
         <label
             class="b-radio radio button"
             ref="label"
@@ -38,6 +38,7 @@ export default {
         },
         disabled: Boolean,
         required: Boolean,
+        expanded: Boolean,
         name: String,
         size: String
     },

--- a/src/scss/components/_radio.scss
+++ b/src/scss/components/_radio.scss
@@ -4,7 +4,7 @@ $radio-size: 1.25em !default;
 .b-radio {
     &.radio {
         outline: none;
-        display: flex;
+        display: inline-flex;
         align-items: center;
         @include unselectable;
         & + .radio {
@@ -77,6 +77,9 @@ $radio-size: 1.25em !default;
         }
         .control-label {
             padding-left: 0.5em;
+        }
+        &.button {
+            display: flex;
         }
         &[disabled] {
             opacity: 0.5;

--- a/src/scss/components/_radio.scss
+++ b/src/scss/components/_radio.scss
@@ -4,7 +4,7 @@ $radio-size: 1.25em !default;
 .b-radio {
     &.radio {
         outline: none;
-        display: inline-flex;
+        display: flex;
         align-items: center;
         @include unselectable;
         & + .radio {


### PR DESCRIPTION
- Added "expanded" prop to RadioButton 
- Also css .b-radio.radio changed to "display: flex" to expanded works properly

P.S. If CSS property display: inline-flex is critical for some behavior, we can just add new:
```
.control.is-expanded .b-radio.radio {
    display: flex;
}
```
We have tested most cases of using RadioButton, and can confirm that .b-radio.radio with property display: flex; is works properly