### PR TITLE
SortableJS link update in docs

### DIFF
--- a/docs/pages/extensions/sortablejs/Sortablejs.vue
+++ b/docs/pages/extensions/sortablejs/Sortablejs.vue
@@ -3,13 +3,13 @@
         <div class="buttons">
             <a
                 class="button"
-                href="http://rubaxa.github.io/Sortable"
+                href="https://sortablejs.github.io/Sortable/"
                 target="_blank">
                 Website
             </a>
             <a
                 class="button"
-                href="https://github.com/RubaXa/Sortable"
+                href="https://github.com/SortableJS/Sortable"
                 target="_blank">
                 Docs
             </a>


### PR DESCRIPTION
Sortable has changed its official Github page. Just updated the new links.

<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

-
-
-
