### PR TITLE
name navbar-item propogate all evens out from tag, and a simple test too

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "scrollreveal": "3.3.6",
     "semver": "5.3.0",
     "shelljs": "0.8.3",
+    "sinon": "^7.5.0",
     "sortablejs": "1.7.0",
     "uglifyjs-webpack-plugin": "1.2.5",
     "url-loader": "0.5.8",

--- a/src/components/navbar/NavBarItem.spec.js
+++ b/src/components/navbar/NavBarItem.spec.js
@@ -1,5 +1,6 @@
 import { shallowMount } from '@vue/test-utils'
 import BNavbarItem from '@components/navbar/NavbarItem.vue'
+import sinon from 'sinon'
 
 let wrapper
 
@@ -21,5 +22,24 @@ describe('BNavbarItem', () => {
     it('correctly renders the provided tag', () => {
         wrapper.setProps({tag})
         expect(wrapper.contains(tag)).toBeTruthy()
+    })
+
+    it('emit event from tag and out', () => {
+        let testStub = sinon.stub()
+
+        let emitWrap = shallowMount(BNavbarItem, {
+            listeners: {
+                test_event: testStub
+            },
+            slots: {
+                default: '<div class="test_inner"/>'
+            }
+        })
+
+        let inner = emitWrap.find('.test_inner')
+
+        expect(inner.name()).toBe('div')
+        inner.trigger('test_event')
+        expect(testStub.called).toBe(true)
     })
 })

--- a/src/components/navbar/NavbarItem.vue
+++ b/src/components/navbar/NavbarItem.vue
@@ -6,9 +6,7 @@
             'is-active': active
         }"
         v-bind="$attrs"
-        @click="$emit('click', $event)"
-        @click.native="$emit('click', $event)"
-    >
+        v-on="$listeners">
         <slot/>
     </component>
 </template>


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #1818 in a more generic way

## Proposed Changes

I have changed the `navbar-item` to propagate all events from the tag, and not just the `click` events.
There is a test that shows the effect too