### PR TITLE
Refactor Table/TableColumn to use provide/inject (fixes #1881)

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -284,6 +284,7 @@ import Pagination from '../pagination/Pagination'
 import SlotComponent from '../../utils/SlotComponent'
 import TableMobileSort from './TableMobileSort'
 import TableColumn from './TableColumn'
+import { createProvideOptions } from './provide'
 
 export default {
     name: 'BTable',
@@ -431,9 +432,11 @@ export default {
             currentSortColumn: {},
             isAsc: true,
             filters: {},
-            firstTimeSort: true, // Used by first time initSort
-            _isTable: true // Used by TableColumn
+            firstTimeSort: true // Used by first time initSort
         }
+    },
+    provide() {
+        return createProvideOptions(this)
     },
     computed: {
         /**

--- a/src/components/table/TableColumn.spec.js
+++ b/src/components/table/TableColumn.spec.js
@@ -1,13 +1,13 @@
 import { shallowMount } from '@vue/test-utils'
 import BTableColumn from '@components/table/TableColumn'
+import { createProvideOptions } from './provide'
 
 let wrapper
 const BTable = {
     template: '<b-table-stub></b-table-stub>',
     data() {
         return {
-            newColumns: [],
-            _isTable: true
+            newColumns: []
         }
     }
 }
@@ -15,7 +15,10 @@ const BTable = {
 describe('BTableColumn', () => {
     beforeEach(() => {
         wrapper = shallowMount(BTableColumn, {
-            parentComponent: BTable
+            parentComponent: BTable,
+            provide() {
+                return createProvideOptions(this)
+            }
         })
     })
 

--- a/src/components/table/provide.js
+++ b/src/components/table/provide.js
@@ -1,0 +1,26 @@
+export const repeated = Symbol('repeated')
+export const addColumn = Symbol('addColumn')
+export const removeColumn = Symbol('removeColumn')
+export const cancelBeforeDestroy = Symbol('cancelBeforeDestroy')
+
+export function createProvideOptions(vm) {
+    return {
+        // Since we're using scoped prop the columns gonna be multiplied,
+        // this finds when to stop based on the newKey property.
+        [repeated]: (key) => {
+            return vm.newColumns.some((column) => column.newKey === key)
+        },
+        [addColumn]: (column) => {
+            vm.newColumns.push(column)
+        },
+        [removeColumn]: (key) => {
+            const index = vm.newColumns.findIndex((column) => column.newKey === key)
+            if (index >= 0) vm.newColumns.splice(index, 1)
+        },
+        [cancelBeforeDestroy]: () => {
+            if (!vm.visibleData.length) return true
+            if (vm.$children.filter((vm) => vm.$options._componentTag === 'b-table-column' &&
+                vm.$data.newKey === this.newKey).length !== 1) return true
+        }
+    }
+}

--- a/src/components/table/provide.spec.js
+++ b/src/components/table/provide.spec.js
@@ -1,0 +1,42 @@
+import { createProvideOptions, repeated, addColumn, removeColumn } from './provide'
+
+describe('BTable - provide', () => {
+    const column = {
+        newKey: 'newKey'
+    }
+    const vm = {
+        newColumns: []
+    }
+
+    afterEach(() => {
+        Object.assign(vm, { newColumns: [] })
+    })
+
+    it.each([repeated, addColumn, removeColumn])('provide %p function', (key) => {
+        const provide = createProvideOptions(vm)
+        expect(provide[key]).toBeInstanceOf(Function)
+    })
+
+    it('adds new column', () => {
+        const provide = createProvideOptions(vm)
+        provide[addColumn](column)
+        expect(vm.newColumns).toHaveLength(1)
+    })
+
+    it('removes column', () => {
+        const provide = createProvideOptions(vm)
+
+        provide[addColumn](column)
+        expect(vm.newColumns).toHaveLength(1)
+
+        provide[removeColumn](column.newKey)
+        expect(vm.newColumns).toHaveLength(0)
+    })
+
+    it('returns true if column is repeated', () => {
+        const provide = createProvideOptions(vm)
+        provide[addColumn](column)
+
+        expect(provide[repeated](column.newKey)).toBe(true)
+    })
+})


### PR DESCRIPTION
Update Table/TableColumn to use provide/inject
instead of calling methods on the $parent property.

To do this a new utility module provide.js is added
beside the Table and TableColumn components.

provide.js exports Symbols for each method and
a utility function that creates the provide Vue
object.

<!-- Thank you for helping Buefy! -->

Fixes #1881
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

-
-
-
