### PR TITLE
Add SCSS Variables for Datepicker

### DIFF
--- a/docs/pages/components/datepicker/Datepicker.vue
+++ b/docs/pages/components/datepicker/Datepicker.vue
@@ -61,11 +61,13 @@
         </Example>
 
         <ApiView :data="api"/>
+        <VariablesView :data="variables"/>
     </div>
 </template>
 
 <script>
     import api from './api/datepicker'
+    import variables from './variables/datepicker'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from '!!raw-loader!./examples/ExSimple'
@@ -104,6 +106,7 @@
         data() {
             return {
                 api,
+                variables,
                 ExSimple,
                 ExSimpleCode,
                 ExEditable,

--- a/docs/pages/components/datepicker/variables/datepicker.js
+++ b/docs/pages/components/datepicker/variables/datepicker.js
@@ -1,0 +1,46 @@
+export default [
+    {
+        name: '<code>$datepicker-background-color</code>',
+        default: '<code>$dropdown-content-background-color</code>'
+    },
+    {
+        name: '<code>$datepicker-radius</code>',
+        default: '<code>$dropdown-content-radius</code>'
+    },
+    {
+        name: '<code>$datepicker-shadow</code>',
+        default: '<code>$dropdown-content-shadow</code>'
+    },
+    {
+        name: '<code>$datepicker-header-color</code>',
+        default: '<code>$grey</code>'
+    },
+    {
+        name: '<code>$datepicker-today-border</code>',
+        default: '<code>solid 1px rgba($primary, 0.5)</code>'
+    },
+    {
+        name: '<code>$datepicker-item-color</code>',
+        default: '<code>$grey-dark</code>'
+    },
+    {
+        name: '<code>$datepicker-item-disabled-color</code>',
+        default: '<code>$grey-light</code>'
+    },
+    {
+        name: '<code>$datepicker-item-hover-color</code>',
+        default: '<code>$black</code>'
+    },
+    {
+        name: '<code>$datepicker-item-hover-background-color</code>',
+        default: '<code>$background</code>'
+    },
+    {
+        name: '<code>$datepicker-item-selected-color</code>',
+        default: '<code>$primary-invert</code>'
+    },
+    {
+        name: '<code>$datepicker-item-selected-background-color</code>',
+        default: '<code>$primary</code>'
+    }
+]

--- a/src/scss/components/_datepicker.scss
+++ b/src/scss/components/_datepicker.scss
@@ -1,3 +1,15 @@
+$datepicker-background-color: $dropdown-content-background-color !default;
+$datepicker-radius: $dropdown-content-radius !default;
+$datepicker-shadow: $dropdown-content-shadow !default;
+$datepicker-header-color: $grey !default;
+$datepicker-today-border: solid 1px rgba($primary, 0.5) !default;
+$datepicker-item-color: $grey-dark !default;
+$datepicker-item-disabled-color: $grey-light !default;
+$datepicker-item-hover-color: $black !default;
+$datepicker-item-hover-background-color: $background !default;
+$datepicker-item-selected-color: $primary-invert !default;
+$datepicker-item-selected-background-color: $primary !default;
+
 .datepicker {
     font-size: 0.875rem;
     .dropdown,
@@ -9,6 +21,11 @@
         &.is-disabled {
             opacity: 1;
         }
+    }
+    .dropdown-content {
+        background-color: $datepicker-background-color;
+        border-radius: $datepicker-radius;
+        box-shadow: $datepicker-shadow;
     }
     .dropdown-item {
         font-size: inherit;
@@ -36,7 +53,7 @@
         .datepicker-header {
             display: table-header-group;
             .datepicker-cell {
-                color: $grey;
+                color: $datepicker-header-color;
                 font-weight: $weight-semibold;
             }
         }
@@ -60,17 +77,17 @@
             }
             .datepicker-cell {
                 &.is-unselectable {
-                    color: $grey-light;
+                    color: $datepicker-item-disabled-color;
                 }
                 &.is-today {
-                    border: solid 1px rgba($primary, 0.5);
+                    border: $datepicker-today-border;
                 }
                 &.is-selectable {
-                    color: $grey-dark;
+                    color: $datepicker-item-color;
                     &:hover:not(.is-selected),
                     &:focus:not(.is-selected) {
-                        background-color: $background;
-                        color: $black;
+                        background-color: $datepicker-item-hover-background-color;
+                        color: $datepicker-item-hover-color;
                         cursor: pointer;
                     }
                     &.is-within-hovered-range {
@@ -81,8 +98,8 @@
                             border-top-right-radius: 0;
                         }
                         &.is-within-hovered {
-                            background-color: $background;
-                            color: $black;
+                            background-color: $datepicker-item-hover-background-color;
+                            color: $datepicker-item-hover-color;
                             border-radius: 0;
                         }
                         &.is-last-hovered {
@@ -94,21 +111,21 @@
                     }
                 }
                 &.is-selected {
-                    background-color: $primary;
-                    color: $primary-invert;
+                    background-color: $datepicker-item-selected-background-color;
+                    color: $datepicker-item-selected-color;
                     &.is-first-selected {
-                        background-color: $primary;
-                        color: $primary-invert;
+                        background-color: $datepicker-item-selected-background-color;
+                        color: $datepicker-item-selected-color;
                         border-bottom-right-radius: 0;
                         border-top-right-radius: 0;
                     }
                     &.is-within-selected {
-                        background-color: rgba($primary, 0.5);
+                        background-color: rgba($datepicker-item-selected-background-color, 0.5);
                         border-radius: 0;
                     }
                     &.is-last-selected {
-                        background-color: $primary;
-                        color: $primary-invert;
+                        background-color: $datepicker-item-selected-background-color;
+                        color: $datepicker-item-selected-color;
                         border-bottom-left-radius: 0;
                         border-top-left-radius: 0;
                     }
@@ -159,7 +176,7 @@
                             // Currently datepicker only uses primary coloring
                             // Ensure indicator is visible when selected
                             &.is-primary {
-                                background-color: lighten($primary,15);
+                                background-color: lighten($primary, 15);
                             }
                         }
                     }


### PR DESCRIPTION
Request from Discord

## Proposed Changes

```
$datepicker-background-color: $dropdown-content-background-color !default;
$datepicker-radius: $dropdown-content-radius !default;
$datepicker-shadow: $dropdown-content-shadow !default;
$datepicker-header-color: $grey !default;
$datepicker-today-border: solid 1px rgba($primary, 0.5) !default;
$datepicker-item-color: $grey-dark !default;
$datepicker-item-disabled-color: $grey-light !default;
$datepicker-item-hover-color: $black !default;
$datepicker-item-hover-background-color: $background !default;
$datepicker-item-selected-color: $primary-invert !default;
$datepicker-item-selected-background-color: $primary !default;
```
![image](https://user-images.githubusercontent.com/12817388/67425711-8cf8c280-f5a6-11e9-9cac-be6893f5106b.png)

