### PR TITLE
Update Datepicker docs for API

### DIFF
--- a/docs/pages/components/datepicker/api/datepicker.js
+++ b/docs/pages/components/datepicker/api/datepicker.js
@@ -79,7 +79,7 @@ export default [
                 default: '<code>false</code>'
             },
             {
-                name: '<code>readonly</code>',
+                name: '<code>editable</code>',
                 description: 'Enable input/typing. <b>Note that you might have to set a custom date parser</b>',
                 type: 'Boolean',
                 values: '—',


### PR DESCRIPTION
Dear maintainers,

Though there is a description about `readonly` flag in the docs, the flag doesn't work.

As far as I've read source code of datepicker, this component accepts `editable` flag, not `readable`, as one of props.
https://github.com/buefy/buefy/blob/dev/src/components/datepicker/Datepicker.vue#L292
Actually, `editable` flag works.

## Proposed Changes

- correct Datepicker API docs.