### PR TITLE
Fix syntax error in IE11 and Edge

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -33,12 +33,9 @@ const mergeFn = (target, source) => {
     const replaced = Object.getOwnPropertyNames(source)
         .map((prop) =>
             ({ [prop]: isDeep(prop) ? mergeFn(target[prop], source[prop]) : source[prop] }))
-        .reduce((a, b) => ({ ...a, ...b }), {})
+        .reduce((a, b) => Object.assign({}, a, b))
 
-    return {
-        ...target,
-        ...replaced
-    }
+    return Object.assign({}, target, replaced)
 }
 export const merge = mergeFn
 


### PR DESCRIPTION
Fixes #1908 

IE 11 and Edge do not support the object spread operator. They should get transpiled, but for some reason, when using buetify with nuxt, this line does not get transpiled. 
All other occurrences of the object spread operator do however.  

This caused out application to break in IE 11 and Edge.

## Proposed Changes

- Use the Object.assign syntax in this helper