### PR TITLE
Added "close-on-click" prop to docs for dropdown

### DIFF
--- a/docs/pages/components/dropdown/api/dropdown.js
+++ b/docs/pages/components/dropdown/api/dropdown.js
@@ -84,7 +84,7 @@ export default [
                 description: 'Close dropdown when content is clicked',
                 type: 'Boolean',
                 values: '—',
-                default: '<code>false</code>'
+                default: '<code>true</code>'
             }
         ],
         slots: [

--- a/docs/pages/components/dropdown/api/dropdown.js
+++ b/docs/pages/components/dropdown/api/dropdown.js
@@ -78,6 +78,13 @@ export default [
                 type: 'Boolean, Array',
                 values: '<code>escape</code>, <code>outside</code>',
                 default: '<code>true</code>'
+            },
+            {
+                name: '<code>close-on-click</code>',
+                description: 'Close dropdown when content is clicked',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
             }
         ],
         slots: [


### PR DESCRIPTION
Prop "close-on-click" was missing from documentation
