### PR TITLE
Fix disabled checkbox in table

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -716,6 +716,7 @@ export default {
         * Row checkbox click listener.
         */
         checkRow(row, index, event) {
+            if (!this.isRowCheckable(row)) return
             const lastIndex = this.lastCheckedRowIndex
             this.lastCheckedRowIndex = index
 


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Currently, disabled checkbox in table can still be checked on clicking, for example, row 3 of the Checkable example.

## Proposed Changes

- Fix disabled checkbox

