### PR TITLE
BREAKING: Use KeyboardEvent.key instead of keyCode

### DIFF
--- a/docs/pages/components/taginput/api/taginput.js
+++ b/docs/pages/components/taginput/api/taginput.js
@@ -100,14 +100,14 @@ export default [
                 description: 'Allow removing last tag when pressing given keys, if input is empty',
                 type: 'Array',
                 values: '—',
-                default: '<code>[8]</code>'
+                default: '<code>["Backspace"]</code>'
             },
             {
-                name: '<code>confirm-key-codes</code>',
-                description: 'Array of key codes which will add a tag when typing (default comma, enter and tab)',
+                name: '<code>confirm-keys</code>',
+                description: 'Array of key (https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values) which will add a tag when typing (default comma and enter)',
                 type: 'Array',
                 values: '—',
-                default: '<code>[13, 188, 9]</code>'
+                default: '<code>[",", "Enter"]</code>'
             },
             {
                 name: '<code>on-paste-separators</code>',

--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -742,9 +742,7 @@ export default {
         /**
          * Keypress event that is bound to the document.
          */
-        keyPress(event) {
-            // Esc key
-            const { key } = event
+        keyPress({ key }) {
             if (this.$refs.dropdown && this.$refs.dropdown.isActive && (key === 'Escape' || key === 'Esc')) {
                 this.togglePicker(false)
             }

--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -744,7 +744,8 @@ export default {
          */
         keyPress(event) {
             // Esc key
-            if (this.$refs.dropdown && this.$refs.dropdown.isActive && event.keyCode === 27) {
+            const { key } = event
+            if (this.$refs.dropdown && this.$refs.dropdown.isActive && (key === 'Escape' || key === 'Esc')) {
                 this.togglePicker(false)
             }
         },

--- a/src/components/dropdown/Dropdown.spec.js
+++ b/src/components/dropdown/Dropdown.spec.js
@@ -127,6 +127,19 @@ describe('BDropdown', () => {
         expect(wrapper.vm.isActive).toBeTruthy()
     })
 
+    it('close on escape', () => {
+        wrapper.vm.isActive = true
+        const event = new KeyboardEvent('keyup', {'key': 'Escape'})
+        wrapper.vm.keyPress({})
+        wrapper.vm.keyPress(event)
+        expect(wrapper.vm.isActive).toBeFalsy()
+
+        wrapper.vm.isActive = true
+        wrapper.setProps({canClose: ['click']})
+        wrapper.vm.keyPress(event)
+        expect(wrapper.vm.isActive).toBeTruthy()
+    })
+
     it('manage toggle function accordingly', (done) => {
         wrapper.vm.isActive = true
         wrapper.setProps({ disabled: true })

--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -239,9 +239,7 @@ export default {
         /**
          * Keypress event that is bound to the document
          */
-        keyPress(event) {
-            // Esc key
-            const { key } = event
+        keyPress({ key }) {
             if (this.isActive && (key === 'Escape' || key === 'Esc')) {
                 if (this.cancelOptions.indexOf('escape') < 0) return
                 this.isActive = false

--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -241,7 +241,8 @@ export default {
          */
         keyPress(event) {
             // Esc key
-            if (this.isActive && event.keyCode === 27) {
+            const { key } = event
+            if (this.isActive && (key === 'Escape' || key === 'Esc')) {
                 if (this.cancelOptions.indexOf('escape') < 0) return
                 this.isActive = false
             }

--- a/src/components/loading/Loading.spec.js
+++ b/src/components/loading/Loading.spec.js
@@ -48,6 +48,15 @@ describe('BLoading', () => {
             })
         })
 
+        it('close on escape', () => {
+            wrapper.vm.isActive = true
+            wrapper.vm.cancel = jest.fn(() => wrapper.vm.cancel)
+            const event = new KeyboardEvent('keyup', {'key': 'Escape'})
+            wrapper.vm.keyPress({})
+            wrapper.vm.keyPress(event)
+            expect(wrapper.vm.cancel).toHaveBeenCalledTimes(1)
+        })
+
         it('emit events on close', () => {
             wrapper.vm.close()
             expect(wrapper.emitted()['close']).toBeTruthy()

--- a/src/components/loading/Loading.vue
+++ b/src/components/loading/Loading.vue
@@ -82,9 +82,7 @@ export default {
         /**
         * Keypress event that is bound to the document.
         */
-        keyPress(event) {
-            // Esc key
-            const { key } = event
+        keyPress({ key }) {
             if (key === 'Escape' || key === 'Esc') this.cancel()
         }
     },

--- a/src/components/loading/Loading.vue
+++ b/src/components/loading/Loading.vue
@@ -84,7 +84,8 @@ export default {
         */
         keyPress(event) {
             // Esc key
-            if (event.keyCode === 27) this.cancel()
+            const { key } = event
+            if (key === 'Escape' || key === 'Esc') this.cancel()
         }
     },
     created() {

--- a/src/components/modal/Modal.spec.js
+++ b/src/components/modal/Modal.spec.js
@@ -65,6 +65,16 @@ describe('BModal', () => {
         expect(wrapper.vm.close).toHaveBeenCalledTimes(1)
     })
 
+    it('close on escape', () => {
+        wrapper.setProps({canCancel: true})
+        wrapper.setProps({active: true})
+        wrapper.vm.cancel = jest.fn(() => wrapper.vm.cancel)
+        const event = new KeyboardEvent('keyup', {'key': 'Escape'})
+        wrapper.vm.keyPress({})
+        wrapper.vm.keyPress(event)
+        expect(wrapper.vm.cancel).toHaveBeenCalledTimes(1)
+    })
+
     it('emit events on close', () => {
         jest.useFakeTimers()
 

--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -230,7 +230,8 @@ export default {
         */
         keyPress(event) {
             // Esc key
-            if (this.isActive && event.keyCode === 27) this.cancel('escape')
+            const { key } = event
+            if (this.isActive && (key === 'Escape' || key === 'Esc')) this.cancel('escape')
         },
 
         /**

--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -228,9 +228,7 @@ export default {
         /**
         * Keypress event that is bound to the document.
         */
-        keyPress(event) {
-            // Esc key
-            const { key } = event
+        keyPress({ key }) {
             if (this.isActive && (key === 'Escape' || key === 'Esc')) this.cancel('escape')
         },
 

--- a/src/components/navbar/NavBarItem.spec.js
+++ b/src/components/navbar/NavBarItem.spec.js
@@ -60,7 +60,7 @@ describe('BNavbarItem', () => {
             parentComponent: stubBNavBar
         })
         wrapper.vm.$parent.closeMenu = jest.fn()
-        const event = new KeyboardEvent('keyup', {'keyCode': 27})
+        const event = new KeyboardEvent('keyup', {'key': 'Escape'})
         wrapper.vm.keyPress({})
         wrapper.vm.keyPress(event)
         expect(wrapper.vm.$parent.closeMenu).toHaveBeenCalledTimes(1)

--- a/src/components/navbar/NavbarItem.vue
+++ b/src/components/navbar/NavbarItem.vue
@@ -30,9 +30,8 @@ export default {
          */
         keyPress(event) {
             // Esc key
-            // TODO: use code instead (because keyCode is actually deprecated)
-            // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
-            if (event.keyCode === 27) {
+            const { key } = event
+            if (key === 'Escape' || key === 'Esc') {
                 this.closeMenuRecursive(this, ['NavBar'])
             }
         },

--- a/src/components/navbar/NavbarItem.vue
+++ b/src/components/navbar/NavbarItem.vue
@@ -28,9 +28,7 @@ export default {
         /**
          * Keypress event that is bound to the document
          */
-        keyPress(event) {
-            // Esc key
-            const { key } = event
+        keyPress({ key }) {
             if (key === 'Escape' || key === 'Esc') {
                 this.closeMenuRecursive(this, ['NavBar'])
             }

--- a/src/components/sidebar/Sidebar.spec.js
+++ b/src/components/sidebar/Sidebar.spec.js
@@ -40,15 +40,29 @@ describe('BSidebar', () => {
             expect(wrapper.vm.transitionName).toBe('slide-next')
         })
 
-        it('close on cancel', (done) => {
+        it('close on cancel', () => {
             wrapper.setProps({canCancel: true})
             wrapper.vm.isOpen = true
-            wrapper.vm.close = jest.fn()
+            wrapper.vm.close = jest.fn(() => wrapper.vm.close)
             wrapper.vm.cancel('outside')
-            wrapper.vm.$nextTick(() => {
-                expect(wrapper.vm.close).toHaveBeenCalled()
-                done()
-            })
+
+            wrapper.setProps({canCancel: false})
+            wrapper.vm.cancel('outside')
+
+            expect(wrapper.vm.close).toHaveBeenCalledTimes(1)
+        })
+
+        it('close on escape', () => {
+            wrapper.setProps({open: true})
+            wrapper.vm.cancel = jest.fn(() => wrapper.vm.cancel)
+            const event = new KeyboardEvent('keyup', {'key': 'Escape'})
+            wrapper.vm.keyPress({})
+            wrapper.vm.keyPress(event)
+
+            wrapper.setProps({position: 'static'})
+            wrapper.vm.keyPress(event)
+
+            expect(wrapper.vm.cancel).toHaveBeenCalledTimes(1)
         })
 
         it('emit events on close', () => {

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -122,10 +122,9 @@ export default {
         /**
         * Keypress event that is bound to the document.
         */
-        keyPress(event) {
-            // Esc key
+        keyPress({ key }) {
             if (this.isFixed) {
-                if (this.isOpen && event.keyCode === 27) this.cancel('escape')
+                if (this.isOpen && (key === 'Escape' || key === 'Esc')) this.cancel('escape')
             }
         },
 

--- a/src/components/taginput/Taginput.vue
+++ b/src/components/taginput/Taginput.vue
@@ -330,8 +330,7 @@ export default {
             }
         },
 
-        keydown(event) {
-            const { key } = event
+        keydown({ key, preventDefault }) {
             if (this.removeOnKeys.indexOf(key) !== -1 && !this.newTag.length) {
                 this.removeLastTag()
             }
@@ -339,7 +338,7 @@ export default {
             if (this.autocomplete && !this.allowNew) return
 
             if (this.confirmKeys.indexOf(key) >= 0) {
-                event.preventDefault()
+                preventDefault()
                 this.addTag()
             }
         },

--- a/src/components/taginput/Taginput.vue
+++ b/src/components/taginput/Taginput.vue
@@ -136,13 +136,13 @@ export default {
             type: Boolean,
             default: true
         },
-        confirmKeyCodes: {
+        confirmKeys: {
             type: Array,
-            default: () => [13, 188]
+            default: () => [',', 'Enter']
         },
         removeOnKeys: {
             type: Array,
-            default: () => [8]
+            default: () => ['Backspace']
         },
         allowNew: Boolean,
         onPasteSeparators: {
@@ -331,13 +331,14 @@ export default {
         },
 
         keydown(event) {
-            if (this.removeOnKeys.indexOf(event.keyCode) !== -1 && !this.newTag.length) {
+            const { key } = event
+            if (this.removeOnKeys.indexOf(key) !== -1 && !this.newTag.length) {
                 this.removeLastTag()
             }
             // Stop if is to accept select only
             if (this.autocomplete && !this.allowNew) return
 
-            if (this.confirmKeyCodes.indexOf(event.keyCode) >= 0) {
+            if (this.confirmKeys.indexOf(key) >= 0) {
                 event.preventDefault()
                 this.addTag()
             }

--- a/src/utils/TimepickerMixin.js
+++ b/src/utils/TimepickerMixin.js
@@ -562,7 +562,8 @@ export default {
          */
         keyPress(event) {
             // Esc key
-            if (this.$refs.dropdown && this.$refs.dropdown.isActive && event.keyCode === 27) {
+            const { key } = event
+            if (this.$refs.dropdown && this.$refs.dropdown.isActive && (key === 'Escape' || key === 'Esc')) {
                 this.toggle(false)
             }
         },

--- a/src/utils/TimepickerMixin.js
+++ b/src/utils/TimepickerMixin.js
@@ -560,9 +560,7 @@ export default {
         /**
          * Keypress event that is bound to the document.
          */
-        keyPress(event) {
-            // Esc key
-            const { key } = event
+        keyPress({ key }) {
             if (this.$refs.dropdown && this.$refs.dropdown.isActive && (key === 'Escape' || key === 'Esc')) {
                 this.toggle(false)
             }


### PR DESCRIPTION
**BREAKING CHANGE**

- Fixes #1485
- Fixes #1915 

