### PR TITLE
Fix #1951: Modal a11y improvements

### DIFF
--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -27,7 +27,8 @@
                 <slot v-else/>
                 <button
                     type="button"
-                    v-if="showX && !animating"
+                    v-if="showX"
+                    v-show="!animating"
                     class="modal-close is-large"
                     @click="cancel('x')"/>
             </div>

--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -8,6 +8,7 @@
             class="modal is-active"
             :class="[{'is-full-screen': fullScreen}, customClass]"
             v-trap-focus="trapFocus"
+            tabindex="-1"
             :role="ariaRole"
             :aria-modal="ariaModal">
             <div class="modal-background" @click="cancel('outside')"/>
@@ -134,6 +135,11 @@ export default {
     watch: {
         active(value) {
             this.isActive = value
+            this.$nextTick(() => {
+                if (value && this.$el && this.$el.focus) {
+                    this.$el.focus()
+                }
+            })
         },
         isActive() {
             this.handleScroll()

--- a/src/components/modal/__snapshots__/Modal.spec.js.snap
+++ b/src/components/modal/__snapshots__/Modal.spec.js.snap
@@ -2,11 +2,9 @@
 
 exports[`BModal render correctly 1`] = `
 <transition-stub name="zoom-out">
-    <div class="modal is-active">
+    <div tabindex="-1" class="modal is-active">
         <div class="modal-background"></div>
-        <div class="animation-content modal-content" style="max-width: 960px;">
-            <!---->
-        </div>
+        <div class="animation-content modal-content" style="max-width: 960px;"> <button type="button" class="modal-close is-large" style="display: none;"></button></div>
     </div>
 </transition-stub>
 `;

--- a/src/directives/trapFocus.js
+++ b/src/directives/trapFocus.js
@@ -35,7 +35,6 @@ const bind = (el, { value = true }) => {
                 }
             }
             el.addEventListener('keydown', onKeyDown)
-            firstFocusable.focus()
         }
     }
 }


### PR DESCRIPTION
Fixes #1951

## Proposed Changes

- Fix Modal close button to be focusable (using `v-show` instead of `v-if` so it exists when the directive is bind)
- Give focus to the modal element on open so focus is inside modal when tabbing
- Remove focus within bind function (element is not yet displayed when bind is called, so it is not useful)
