### PR TITLE
Fix: Datetimepicker ignores expanded prop

### DIFF
--- a/src/components/datetimepicker/Datetimepicker.vue
+++ b/src/components/datetimepicker/Datetimepicker.vue
@@ -9,6 +9,7 @@
         :loading="loading"
         :inline="inline"
         :editable="editable"
+        :expanded="expanded"
         :close-on-click="false"
         :date-formatter="defaultDatetimeFormatter"
         :date-parser="defaultDatetimeParser"


### PR DESCRIPTION
## Proposed Changes

- Pass `expanded` prop to Datepicker
