### PR TITLE
Emit event on Input icon click

### DIFF
--- a/docs/pages/components/input/api/input.js
+++ b/docs/pages/components/input/api/input.js
@@ -58,6 +58,13 @@ export default [
                 default: '<code>mdi</code>'
             },
             {
+                name: '<code>icon-clickable</code>',
+                description: 'Make the icon clickable',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
                 name: '<code>maxlength</code>',
                 description: 'Same as native <code>maxlength</code>, plus character counter',
                 type: 'String, Number',
@@ -107,6 +114,11 @@ export default [
             {
                 name: '<code>blur</code>',
                 description: 'Triggers when input has lost focus',
+                parameters: '<code>event: $event</code>'
+            },
+            {
+                name: '<code>icon-click</code>',
+                description: 'Triggers when the icon is clickable and have been clicked',
                 parameters: '<code>event: $event</code>'
             },
             {

--- a/docs/pages/components/input/examples/ExIcons.vue
+++ b/docs/pages/components/input/examples/ExIcons.vue
@@ -4,7 +4,9 @@
         <b-field>
             <b-input placeholder="Search..."
                 type="search"
-                icon="magnify">
+                icon="magnify"
+                icon-clickable
+                @icon-click="searchIconClick">
             </b-input>
         </b-field>
 
@@ -46,3 +48,13 @@
         </b-field>
     </section>
 </template>
+
+<script>
+    export default {
+        methods: {
+            searchIconClick() {
+                alert('You wanna make a search?')
+            }
+        }
+    }
+</script>

--- a/src/components/input/Input.spec.js
+++ b/src/components/input/Input.spec.js
@@ -166,4 +166,24 @@ describe('BInput', () => {
         wrapper.setData({ newType: 'is-warning' })
         expect(input.vm.statusTypeIcon).toBe('alert')
     })
+
+    it('manage the click on icon', (done) => {
+        const wrapper = mount(BInput, {
+            propsData: {
+                icon: 'magnify',
+                iconClickable: true
+            }
+        })
+
+        expect(wrapper.find('input').exists()).toBeTruthy()
+
+        const visibilityIcon = wrapper.find('.icon.is-clickable')
+        expect(visibilityIcon.exists()).toBeTruthy()
+        visibilityIcon.trigger('click')
+
+        wrapper.vm.$nextTick(() => {
+            expect(wrapper.emitted()['icon-click']).toBeTruthy()
+            done()
+        })
+    })
 })

--- a/src/components/input/Input.vue
+++ b/src/components/input/Input.vue
@@ -29,9 +29,11 @@
         <b-icon
             v-if="icon"
             class="is-left"
+            :class="{'is-clickable': iconClickable}"
             :icon="icon"
             :pack="iconPack"
-            :size="iconSize"/>
+            :size="iconSize"
+            @click.native="iconClick"/>
 
         <b-icon
             v-if="!loading && (passwordReveal || statusTypeIcon)"
@@ -72,6 +74,7 @@ export default {
             default: 'text'
         },
         passwordReveal: Boolean,
+        iconClickable: Boolean,
         hasCounter: {
             type: Boolean,
             default: () => config.defaultInputHasCounter
@@ -207,6 +210,13 @@ export default {
                 if (event.target) {
                     this.computedValue = event.target.value
                 }
+            })
+        },
+
+        iconClick(event) {
+            this.$emit('icon-click', event)
+            this.$nextTick(() => {
+                this.$refs.input.focus()
             })
         }
     }


### PR DESCRIPTION
From a Discord comment

## Proposed Changes

- Add a new prop  `icon-clickable` that makes the icon clickable
- Emit `icon-click` event on click
