### PR TITLE
Fix #1909 Searchable table Header disappear or loses focus

### DIFF
--- a/src/components/table/TableColumn.vue
+++ b/src/components/table/TableColumn.vue
@@ -64,6 +64,7 @@ export default {
     },
     beforeDestroy() {
         if( !this.$parent.visibleData.length ) return
+        if ( this.$parent.$children.filter(vm => vm.$options._componentTag === 'b-table-column' && vm.$data.newKey===this.newKey).length !== 1 ) return
         const index = this.$parent.newColumns.map(
             (column) => column.newKey).indexOf(this.newKey)
         if (index >= 0) {

--- a/src/components/table/TableColumn.vue
+++ b/src/components/table/TableColumn.vue
@@ -63,6 +63,7 @@ export default {
         this.addRefToTable()
     },
     beforeDestroy() {
+        if( !this.$parent.visibleData.length ) return
         const index = this.$parent.newColumns.map(
             (column) => column.newKey).indexOf(this.newKey)
         if (index >= 0) {

--- a/src/components/table/TableColumn.vue
+++ b/src/components/table/TableColumn.vue
@@ -63,8 +63,8 @@ export default {
         this.addRefToTable()
     },
     beforeDestroy() {
-        if( !this.$parent.visibleData.length ) return
-        if ( this.$parent.$children.filter(vm => vm.$options._componentTag === 'b-table-column' && vm.$data.newKey===this.newKey).length !== 1 ) return
+        if (!this.$parent.visibleData.length) return
+        if (this.$parent.$children.filter((vm) => vm.$options._componentTag === 'b-table-column' && vm.$data.newKey === this.newKey).length !== 1) return
         const index = this.$parent.newColumns.map(
             (column) => column.newKey).indexOf(this.newKey)
         if (index >= 0) {


### PR DESCRIPTION
Fixes #1909

## Proposed Changes

While using custom template with searchable table : 
- Prevent column from being destroyed at each cell destruction but rather only at the last one of the column => prevent focus lose on header that are destroyed and recreated at each data change when rows are filtered
- Prevent column header removal when there is no data visible ( all rows filtered) 
