### PR TITLE
Fixed typo in carousel API documentation

### DIFF
--- a/docs/pages/components/carousel/api/carousel.js
+++ b/docs/pages/components/carousel/api/carousel.js
@@ -81,7 +81,7 @@ export default [
             },
             {
                 name: '<code>icon-prev</code>',
-                description: 'pause <code>autoplay</code> if the mouse enters the slide.',
+                description: 'Icon to use for previous arrow',
                 type: 'String',
                 values: '—',
                 default: '<code>chevron-left</code>'


### PR DESCRIPTION
Fixes

# Fixed typo in documentation for carousel component API on previous icon props description
