### PR TITLE
New feature: Table subheadings

### DIFF
--- a/docs/pages/components/table/Table.vue
+++ b/docs/pages/components/table/Table.vue
@@ -69,6 +69,15 @@
             </p>
         </Example>
 
+        <Example :component="ExSubheadings" :code="ExSubheadingsCode" title="Subheadings">
+            <p>
+                Use the <code>subheading</code> prop on columns to add subheadings. This is particularly useful to display a summary when dealing with long tables.
+            </p>
+            <p>
+                By adding a scoped slot named <code>subheading</code> in table component you can customize the subheadings.
+            </p>
+        </Example>
+
         <Example :component="ExToggleColumns" :code="ExToggleColumnsCode" title="Toggle columns">
             <b-message type="is-danger">
                 Always use the <code>visible</code> prop to hide/show columns, and <strong>NOT</strong> <code>v-if</code> or <code>v-show</code>.
@@ -129,6 +138,9 @@
     import ExCustomHeaders from './examples/ExCustomHeaders'
     import ExCustomHeadersCode from '!!raw-loader!./examples/ExCustomHeaders'
 
+    import ExSubheadings from './examples/ExSubheadings'
+    import ExSubheadingsCode from '!!raw-loader!./examples/ExSubheadings'
+
     import ExToggleColumns from './examples/ExToggleColumns'
     import ExToggleColumnsCode from '!!raw-loader!./examples/ExToggleColumns'
 
@@ -155,6 +167,7 @@
                 ExCustomDetailedRow,
                 ExRowStatus,
                 ExCustomHeaders,
+                ExSubheadings,
                 ExToggleColumns,
                 ExFooter,
                 ExAsyncData,
@@ -169,6 +182,7 @@
                 ExCustomDetailedRowCode,
                 ExRowStatusCode,
                 ExCustomHeadersCode,
+                ExSubheadingsCode,
                 ExToggleColumnsCode,
                 ExFooterCode,
                 ExAsyncDataCode,

--- a/docs/pages/components/table/api/table.js
+++ b/docs/pages/components/table/api/table.js
@@ -324,6 +324,11 @@ export default [
                 props: '<code>column: Vue Object</code>, <code>index: Number</code>'
             },
             {
+                name: '<code>subheading</code>',
+                description: 'Table subheading',
+                props: '<code>column: Vue Object</code>, <code>index: Number</code>'
+            },
+            {
                 name: '<code>detail</code>',
                 description: 'Row detail (collapsible)',
                 props: '<code>row: Object</code>, <code>index: Number</code>'
@@ -537,6 +542,13 @@ export default [
                 values: '—',
                 default: '<code>false</code>'
             },
+            {
+                name: '<code>subheading</code>',
+                description: 'Column subheading text',
+                type: 'String, Number',
+                values: '—',
+                default: '—'
+            },
         ],
         slots: [
             {
@@ -547,6 +559,11 @@ export default [
             {
                 name: '<code>header</code>',
                 description: 'Table column custom header',
+                props: '<code>column: Vue Object</code>, <code>index: Number</code>'
+            },
+            {
+                name: '<code>subheading</code>',
+                description: 'Table column custom subheading',
                 props: '<code>column: Vue Object</code>, <code>index: Number</code>'
             }
         ]

--- a/docs/pages/components/table/examples/ExSubheadings.vue
+++ b/docs/pages/components/table/examples/ExSubheadings.vue
@@ -1,0 +1,47 @@
+<template>
+    <section>
+        <b-table
+            :data="data"
+            :columns="columns">
+        </b-table>
+    </section>
+</template>
+
+ <script>
+    export default {
+        data() {
+            return {
+                data: [
+                    { 'id': 1, 'contributor': 'Jesse Simmons', 'posts': 2, 'comments': 5 },
+                    { 'id': 2, 'contributor': 'John Jacobs', 'posts': 11, 'comments': 42 },
+                    { 'id': 3, 'contributor': 'Tina Gilbert', 'posts': 0, 'comments': 7 },
+                    { 'id': 4, 'contributor': 'Clarence Flores', 'posts': 4, 'comments': 4 },
+                    { 'id': 5, 'contributor': 'Anne Lee', 'posts': 1, 'comments': 2 }
+                ],
+                columns: [
+                    {
+                        field: 'id',
+                        label: 'ID',
+                        width: '100',
+                        numeric: true,
+                        subheading: 'Total:'
+                    },
+                    {
+                        field: 'contributor',
+                        label: 'Contributor',
+                    },
+                    {
+                        field: 'posts',
+                        label: 'Posts',
+                        subheading: 18
+                    },
+                    {
+                        field: 'comments',
+                        label: 'Comments',
+                        subheading: 60
+                    }
+                ]
+            }
+        }
+    }
+</script>

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -109,6 +109,44 @@
                             </template>
                         </th>
                     </tr>
+                    <tr v-if="hasCustomSubheadings" class="is-subheading">
+                        <th v-if="showDetailRowIcon" width="40px"/>
+                        <th v-if="checkable && checkboxPosition === 'left'" />
+                        <th
+                            v-for="(column, index) in visibleColumns"
+                            :key="index"
+                            :style="{
+                                width: column.width === undefined ? null
+                            : (isNaN(column.width) ? column.width : column.width + 'px') }">
+                            <div
+                                class="th-wrap"
+                                :class="{
+                                    'is-numeric': column.numeric,
+                                    'is-centered': column.centered
+                            }">
+                                <template
+                                    v-if="column.$scopedSlots && column.$scopedSlots.subheading"
+                                >
+                                    <b-slot-component
+                                        :component="column"
+                                        :scoped="true"
+                                        name="subheading"
+                                        tag="span"
+                                        :props="{ column, index }"
+                                    />
+                                </template>
+                                <template v-else-if="$scopedSlots.subheading">
+                                    <slot
+                                        name="subheading"
+                                        :column="column"
+                                        :index="index"
+                                    />
+                                </template>
+                                <template v-else>{{ column.subheading }}</template>
+                            </div>
+                        </th>
+                        <th v-if="checkable && checkboxPosition === 'right'" />
+                    </tr>
                     <tr v-if="hasSearchablenewColumns">
                         <th v-if="showDetailRowIcon" width="40px"/>
                         <th v-if="checkable && checkboxPosition === 'left'" />
@@ -519,6 +557,16 @@ export default {
         hasSearchablenewColumns() {
             return this.newColumns.some((column) => {
                 return column.searchable
+            })
+        },
+
+        /**
+        * Check if has any column using subheading.
+        */
+        hasCustomSubheadings() {
+            if (this.$scopedSlots && this.$scopedSlots.subheading) return true
+            return this.newColumns.some((column) => {
+                return column.subheading || (column.$scopedSlots && column.$scopedSlots.subheading)
             })
         },
 

--- a/src/components/table/TableColumn.vue
+++ b/src/components/table/TableColumn.vue
@@ -24,6 +24,7 @@ export default {
             type: Boolean,
             default: true
         },
+        subheading: [String, Number],
         customSort: Function,
         internal: Boolean // Used internally by Table
     },


### PR DESCRIPTION
## Proposed Changes

- Adds a `subheading` prop to columns
- Adds a `subheading` scope to columns
- Adds a `subheading` scope to tables

When present, another row in `thead` is created with the value of `subheading`.

## Why?

When using Buefy tables with long tables you cannot rely on the footer to display the table summary (totals, averages, etc.).
You can now use subheadings!! 🎉 

I've been inspired by the Google Ads & Google Analytics tables. If someone knows about big data tables, it's them! ;)