### PR TITLE
Fixed typo in datepicker api

### DIFF
--- a/docs/pages/components/datepicker/api/datepicker.js
+++ b/docs/pages/components/datepicker/api/datepicker.js
@@ -212,7 +212,7 @@ export default [
                 default: '<code>false</code>'
             },
             {
-                name: '<code>show-number-week</code>',
+                name: '<code>show-week-number</code>',
                 description: 'Display week number',
                 type: 'Boolean',
                 values: '-',


### PR DESCRIPTION
Example and api doc diverge on `show-week-number` and `show-number-week`, only former works.