### PR TITLE
Rename value indicator-style on Carousel

### DIFF
--- a/docs/pages/components/carousel/api/carousel.js
+++ b/docs/pages/components/carousel/api/carousel.js
@@ -153,7 +153,7 @@ export default [
                 name: '<code>indicator-style</code>',
                 description: 'Style for indicator of carousel',
                 type: 'String',
-                values: '<code>is-boxs</code>, <code>is-dots</code>, <code>is-lines</code>',
+                values: '<code>is-boxes</code>, <code>is-dots</code>, <code>is-lines</code>',
                 default: '<code>is-dots</code>'
             },
             {

--- a/src/scss/components/_carousel.scss
+++ b/src/scss/components/_carousel.scss
@@ -133,7 +133,7 @@ $carousel-overlay-z: 40 !default;
                 background: $carousel-indicator-border;
                 outline: none;
                 transition: .3s $easing;
-                &.is-boxs {
+                &.is-boxes {
                     height: 10px;
                     width: 10px;
                 }


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Feature request #2049

## Proposed Changes

- Rename value  **indicator-style** from `is-box` to `is-boxes`