### PR TITLE
Fix #2014 : TagInput Autocomplete with latest Vue (2.6?)

### DIFF
--- a/src/components/taginput/Taginput.vue
+++ b/src/components/taginput/Taginput.vue
@@ -46,18 +46,18 @@
                 <template :slot="headerSlotName">
                     <slot name="header" />
                 </template>
+                <template :slot="emptySlotName">
+                    <slot name="empty" />
+                </template>
+                <template :slot="footerSlotName">
+                    <slot name="footer" />
+                </template>
                 <template
                     :slot="defaultSlotName"
                     slot-scope="props">
                     <slot
                         :option="props.option"
                         :index="props.index" />
-                </template>
-                <template :slot="emptySlotName">
-                    <slot name="empty" />
-                </template>
-                <template :slot="footerSlotName">
-                    <slot name="footer" />
                 </template>
             </b-autocomplete>
         </div>


### PR DESCRIPTION
Fixes #2014 

TagInput seems to be broken since recent Vue update ( around 2.6 ? )
Autocomplete component evaluate hasDefaultSlot as true even if there is none.

Looks like a bug with Vue 2.6 with the change of slot semantic but simply moving the default slot after the named slots (empty, header and footer) seems to fix the issue. 

It looks like the named templates declared after the default one stay as ghost and are found in $slots and then $scopedSlots, maybe during component creation when template name is not defined yet ?