### PR TITLE
Fixed last tag spacing inside taginput

### DIFF
--- a/src/scss/components/_taginput.scss
+++ b/src/scss/components/_taginput.scss
@@ -17,6 +17,7 @@ $taginput-height: 1.7em !default;
 
         > .tag,
         > .tags {
+            margin-left: 0.275rem;
             margin-bottom: calc(0.275em - 1px);
             font-size: 0.9em;
             height: $taginput-height;
@@ -27,9 +28,6 @@ $taginput-height: 1.7em !default;
                 &.is-delete {
                     width: $taginput-height;
                 }
-            }
-            &:not(:last-child) {
-                margin-left: 0.275rem;
             }
         }
 


### PR DESCRIPTION
Fixes #2062 

## Proposed Changes
Remove conditional margin for last element in tag list.

![image](https://user-images.githubusercontent.com/1102117/70398064-27f71000-1a20-11ea-9318-81ef2ab1ed0e.png)
