### PR TITLE
Fix: handleDetailKey null index case

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -903,7 +903,7 @@ export default {
             */
         handleDetailKey(index) {
             const key = this.detailKey
-            return !key.length
+            return !key.length || !index
                 ? index
                 : index[key]
         },


### PR DESCRIPTION
This fix a bug that appears when you delete an element from the table data, in conjunction with a custom `detail-key` property.


In that case, the `index` param of the `handleDetail` method is `null` while we try to return `index[key]`

<!-- Thank you for helping Buefy! -->

## Proposed Changes

- handle index param null case in handleDetailKey method
