### PR TITLE
Fixed wrong default value on message component's API doc

### DIFF
--- a/docs/pages/components/message/api/message.js
+++ b/docs/pages/components/message/api/message.js
@@ -37,7 +37,7 @@ export default [
                 description: 'Visibility duration in miliseconds',
                 type: 'Number',
                 values: '—',
-                default: '<code>5000</code>'
+                default: '<code>2000</code>'
             },
             {
                 name: '<code>icon-pack</code>',


### PR DESCRIPTION
# Proposed Changes

Fixed wrong default value on message's API documentation.
The default value is `2000` but `5000` on the doc.

https://github.com/buefy/buefy/blob/dev/src/utils/MessageMixin.js#L29
