### PR TITLE
Add range start and end events to datepicker component

### DIFF
--- a/docs/pages/components/datepicker/api/datepicker.js
+++ b/docs/pages/components/datepicker/api/datepicker.js
@@ -269,6 +269,16 @@ export default [
                 name: '<code>change-year</code>',
                 description: 'Triggers when calendar year is changed',
                 parameters: '<code>year: Number</code>'
+            },
+            {
+                name: '<code>range-start</code>',
+                description: 'Triggers when user starts selecting a date range (Only when <b>range</b> prop is set)',
+                parameters: '<code>date: Date</code>'
+            },
+            {
+                name: '<code>range-end</code>',
+                description: 'Triggers when user ends selecting a date range (Only when <b>range</b> prop is set)',
+                parameters: '<code>date: Date</code>'
             }
         ],
         methods: [

--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -124,6 +124,8 @@
                         :show-week-number="showWeekNumber"
                         :range="range"
                         :multiple="multiple"
+                        @range-start="date => $emit('range-start', date)"
+                        @range-end="date => $emit('range-end', date)"
                         @close="togglePicker(false)"/>
                 </div>
                 <div v-else>

--- a/src/components/datepicker/DatepickerTable.vue
+++ b/src/components/datepicker/DatepickerTable.vue
@@ -184,6 +184,7 @@ export default {
             if (this.selectedBeginDate && this.selectedEndDate) {
                 this.selectedBeginDate = date
                 this.selectedEndDate = undefined
+                this.$emit('range-start', date)
             } else if (this.selectedBeginDate && !this.selectedEndDate) {
                 if (this.selectedBeginDate > date) {
                     this.selectedEndDate = this.selectedBeginDate
@@ -191,9 +192,11 @@ export default {
                 } else {
                     this.selectedEndDate = date
                 }
+                this.$emit('range-end', date)
                 this.$emit('input', [this.selectedBeginDate, this.selectedEndDate])
             } else {
                 this.selectedBeginDate = date
+                this.$emit('range-start', date)
             }
         },
 


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->
## Overview

This is not a fix, it is an enhancement. This PR targets the datepicker component when used with the `range` prop only.

## Details

When the range prop is used, it will add 2 new events: range-start and range-end which will respectively correspond to when a user selects the first date of a date range and when he selects the second date. Each of the events will receive the selected date as a parameter (as stated in the updated documentation).

## Concerns

As far as I know, the values passed in the events are Date objects, which inherently are passed by reference. As of now (not tested), I could modify the internal state of the component through the date value from the events. Should we not emit `new Date(date.getTime())` instead? I'm asking because I used the pass-by-ref as the `input` event.

```
<b-datepicker @range-start="handleRangeStart" />

[methods]

handleRangeStart (date) {
   date.setDate(25) // This would change the internal state of the datepicker component
}
```