### PR TITLE
Configure Jest testURL to prevent SecurityError

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,5 +18,6 @@ module.exports = {
         '<rootDir>/node_modules/jest-serializer-vue'
     ],
     coverageDirectory: './coverage/',
-    collectCoverage: true
+    collectCoverage: true,
+    testURL: 'http://localhost/'
 }


### PR DESCRIPTION
Previously when running "npm run unit" all tests failed with:

```
Test suite failed to run
    SecurityError: localStorage is not available for opaque origins
      at Window.get localStorage [as localStorage] (../../../../node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
          at Array.forEach (<anonymous>)
```

Fixed by defining a testURL: https://stackoverflow.com/a/51554619/244068

This fix was previously submitted in PR #1044 but not merged.