### PR TITLE
Fix #1889: Body padding for fixed spaced navbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Buefy is an open source MIT project if you are interested in supporting this pro
   </a>
 </p>
 
+## Contributing
+
+Please refer to the contribution guidelines [here](.github/CONTRIBUTING.md).
+
 ## License
 
 Code released under [MIT](https://github.com/buefy/buefy/blob/master/LICENSE) license.

--- a/src/components/navbar/Navbar.vue
+++ b/src/components/navbar/Navbar.vue
@@ -83,24 +83,30 @@ export default {
         fixedTop: {
             handler(isSet) {
                 this.checkIfFixedPropertiesAreColliding()
-                const className = this.spaced
-                    ? BODY_SPACED_FIXED_TOP_CLASS : BODY_FIXED_TOP_CLASS
                 if (isSet) {
-                    return this.setBodyClass(className)
+                    // TODO Apply only one of the classes once PR is merged in Bulma:
+                    // https://github.com/jgthms/bulma/pull/2737
+                    this.setBodyClass(BODY_FIXED_TOP_CLASS)
+                    this.spaced && this.setBodyClass(BODY_SPACED_FIXED_TOP_CLASS)
+                } else {
+                    this.removeBodyClass(BODY_FIXED_TOP_CLASS)
+                    this.removeBodyClass(BODY_SPACED_FIXED_TOP_CLASS)
                 }
-                this.removeBodyClass(className)
             },
             immediate: true
         },
         fixedBottom: {
             handler(isSet) {
                 this.checkIfFixedPropertiesAreColliding()
-                const className = this.spaced
-                    ? BODY_SPACED_FIXED_BOTTOM_CLASS : BODY_FIXED_BOTTOM_CLASS
                 if (isSet) {
-                    return this.setBodyClass(className)
+                    // TODO Apply only one of the classes once PR is merged in Bulma:
+                    // https://github.com/jgthms/bulma/pull/2737
+                    this.setBodyClass(BODY_FIXED_BOTTOM_CLASS)
+                    this.spaced && this.setBodyClass(BODY_SPACED_FIXED_BOTTOM_CLASS)
+                } else {
+                    this.removeBodyClass(BODY_FIXED_BOTTOM_CLASS)
+                    this.removeBodyClass(BODY_SPACED_FIXED_BOTTOM_CLASS)
                 }
-                this.removeBodyClass(className)
             },
             immediate: true
         }


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #1889 for tablets and under.

## Proposed Changes

- Apply padding on the body for tablets and below when using a fixed spaced navbar. See the gif demoing the issue in jgthms/bulma#2737. It seems @jgthms intends for the two classes to be applied to html/body to set appropriate padding for all viewport widths.
- Add a link to the contributing guidelines in the main README.