### PR TITLE
Fixed carousel slide animation

### DIFF
--- a/src/components/carousel/Carousel.vue
+++ b/src/components/carousel/Carousel.vue
@@ -238,7 +238,7 @@ export default {
         modeChange(trigger, value) {
             if (this.indicatorMode === trigger) {
                 this.$emit('input', value)
-                value < this.activeItem 
+                value < this.activeItem
                     ? this.changeItem(value, true)
                     : this.changeItem(value, false)
             }

--- a/src/components/carousel/Carousel.vue
+++ b/src/components/carousel/Carousel.vue
@@ -239,8 +239,8 @@ export default {
             if (this.indicatorMode === trigger) {
                 this.$emit('input', value)
                 value < this.activeItem 
-                  ? this.changeItem(value, true)
-                  : this.changeItem(value, false)
+                    ? this.changeItem(value, true)
+                    : this.changeItem(value, false)
             }
         },
         prev() {


### PR DESCRIPTION
Fixed the animation always sliding left regardless of position relative to the current slide.

<!-- Thank you for helping Buefy! -->

<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #2047 (re)

## Proposed Changes

-Add check logic when the input event is emitted, the watcher does not change the behaviour of the animation

## Notes

-A fix was presented (issue #2047 [closed]) and merged into dev by adding a check in a watcher for value but, this does not fix the carousel animation on my use case. 

Specs:
Buefy 0.8.8, Vue 2.6.10, Chrome 79.0.3945.88, macOS 10.14.6.
