### PR TITLE
navbar - remove body fixed class on destroy

### DIFF
--- a/src/components/navbar/Navbar.vue
+++ b/src/components/navbar/Navbar.vue
@@ -206,8 +206,15 @@ export default {
         }
     },
     beforeDestroy() {
-        this.removeBodyClass(FIXED_BOTTOM_CLASS)
-        this.removeBodyClass(FIXED_TOP_CLASS)
+        let className = ''
+        if (this.fixedTop) {
+            className = this.spaced
+                ? BODY_SPACED_FIXED_TOP_CLASS : BODY_FIXED_TOP_CLASS
+        } else if (this.fixedBottom) {
+            className = this.spaced
+                ? BODY_SPACED_FIXED_BOTTOM_CLASS : BODY_FIXED_BOTTOM_CLASS
+        }
+        this.removeBodyClass(className)
     },
     render(createElement, fn) {
         return this.genNavbar(createElement)


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- when `navbar` is fixed and is destroyed it leaves space at top (or bottom) because of not removed class, e.g. `.has-navbar-fixed-top`
- example - when clicks on "Logout" and it is needed to hide (by v-if) top-fixed navbar = space will be on top
-  `<b-navbar fixed-top v-if="isNavBarVisible" />`

![image](https://user-images.githubusercontent.com/14335816/72118767-e1683e80-335a-11ea-8eeb-89d43f7d3732.png)


