### PR TITLE
Add missing `fullScreen?` property on `ModalDialog` type

### DIFF
--- a/types/components.d.ts
+++ b/types/components.d.ts
@@ -134,6 +134,11 @@ declare type ModalConfig = {
     scroll?: 'clip' | 'keep';
 
     /**
+     * Display modal as full screen
+     */
+    fullScreen?: boolean;
+
+    /**
      * Trap focus inside the dialog.
      */
     trapFocus?: boolean;


### PR DESCRIPTION
The `ModalDialog` TypeScript type was missing the `fullScreen?` property.
