### PR TITLE
BUGFIX: Modal should overlay tooltip

### DIFF
--- a/src/scss/components/_tooltip.scss
+++ b/src/scss/components/_tooltip.scss
@@ -94,7 +94,7 @@ $tooltip-multiline-sizes: (
         pointer-events: none;
     }
     &:before {
-        z-index: 889;
+        z-index: 39;
     }
     &:after {
         content: attr(data-label);
@@ -104,7 +104,7 @@ $tooltip-multiline-sizes: (
         font-size: 0.85rem;
         font-weight: $weight-normal;
         box-shadow: 0px 1px 2px 1px rgba(0, 1, 0, 0.2);
-        z-index: 888;
+        z-index: 38;
         white-space: nowrap;
     }
     &:not([data-label=""]):hover:before,


### PR DESCRIPTION
Fixes #1473

## Proposed Changes

The `.b-tooltip` `z-index` should be lower than the `.modal` one.