### PR TITLE
Allow "tag" prop in PascalCase

### DIFF
--- a/src/components/button/Button.vue
+++ b/src/components/button/Button.vue
@@ -89,6 +89,7 @@ export default {
                     'router-link',
                     'nuxt-link',
                     'n-link',
+                    'RouterLink',
                     'NuxtLink',
                     'NLink'
                 ].indexOf(value) >= 0

--- a/src/components/menu/MenuItem.vue
+++ b/src/components/menu/MenuItem.vue
@@ -63,6 +63,7 @@ export default {
                     'router-link',
                     'nuxt-link',
                     'n-link',
+                    'RouterLink',
                     'NuxtLink',
                     'NLink'
                 ].indexOf(value) >= 0

--- a/src/components/pagination/PaginationButton.vue
+++ b/src/components/pagination/PaginationButton.vue
@@ -33,6 +33,7 @@ export default {
                     'router-link',
                     'nuxt-link',
                     'n-link',
+                    'RouterLink',
                     'NuxtLink',
                     'NLink'
                 ].indexOf(value) >= 0


### PR DESCRIPTION
Following [the naming convention](https://vuejs.org/v2/guide/components-registration.html#Name-Casing) and since it's implemented in [vue-router v3.0.2](https://github.com/vuejs/vue-router/releases/tag/v3.0.2) it should be possible to pass the value of "tag" property as "RouterLink".