### PR TITLE
Allow Vue Router to function cleanly with Navbar

### DIFF
--- a/docs/pages/components/navbar/Navbar.vue
+++ b/docs/pages/components/navbar/Navbar.vue
@@ -2,6 +2,13 @@
     <div>
         <Example :component="ExSimple" :code="ExSimpleCode"/>
 
+
+        <Example title="Vue Router">
+            <p>To work with Vue Router properly, you will need to pass <code>parent</code> to each navbar item</p>
+            <p>You can then safely wrap <code>b-navbar-item</code>s in <code>router-link</code> tags</p>
+            <Example :component="ExRouter" :code="ExRouterCode"/>
+        </Example>
+
         <ApiView :data="api"/>
     </div>
 </template>
@@ -11,13 +18,17 @@
     import api from './api/navbar'
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from '!!raw-loader!./examples/ExSimple'
+    import ExRouter from './examples/ExRouter'
+    import ExRouterCode from '!!raw-loader!./examples/ExRouter'
     
     export default {
         data() {
             return {
                 api,
                 ExSimple,
-                ExSimpleCode
+                ExSimpleCode,
+                ExRouter,
+                ExRouterCode
             }
         },
     }

--- a/docs/pages/components/navbar/api/navbar.js
+++ b/docs/pages/components/navbar/api/navbar.js
@@ -115,6 +115,13 @@ export default [
             type: 'Boolean',
             values: '-',
             default: 'false'
+        },
+        {
+            name: '<code>parent</code>',
+            description: 'ref to navbar (useful with Vue Router)',
+            type: 'Object',
+            values: 'VueComponent to navbar',
+            default: 'null'
         }
     ]
   },

--- a/docs/pages/components/navbar/examples/ExRouter.vue
+++ b/docs/pages/components/navbar/examples/ExRouter.vue
@@ -1,0 +1,55 @@
+<template>
+    <b-navbar ref="navbar">
+        <template slot="brand">
+            <b-navbar-item tag="router-link" :to="{ path: '/' }" :parent="navbar">
+                <img
+                    src="https://raw.githubusercontent.com/buefy/buefy/dev/static/img/buefy-logo.png"
+                    alt="Lightweight UI components for Vue.js based on Bulma"
+                >
+            </b-navbar-item>
+        </template>
+        <template slot="start">
+            <b-navbar-item href="#" :parent="navbar">
+                Home
+            </b-navbar-item>
+            <b-navbar-item href="#" :parent="navbar">
+                Documentation
+            </b-navbar-item>
+            <b-navbar-dropdown label="Info">
+                <b-navbar-item href="#" :parent="navbar">
+                    About
+                </b-navbar-item>
+                <b-navbar-item href="#" :parent="navbar">
+                    Contact
+                </b-navbar-item>
+            </b-navbar-dropdown>
+        </template>
+
+        <template slot="end">
+            <b-navbar-item tag="div" :parent="navbar">
+                <div class="buttons">
+                    <a class="button is-primary">
+                        <strong>Sign up</strong>
+                    </a>
+                    <a class="button is-light">
+                        Log in
+                    </a>
+                </div>
+            </b-navbar-item>
+        </template>
+    </b-navbar>
+</template>
+
+
+<script>
+export default {
+    data() {
+        return {
+            navbar: null
+        }
+    },
+    mounted() {
+        this.navbar = this.$refs.navbar
+    }
+}
+</script>

--- a/src/components/navbar/NavBarItem.spec.js
+++ b/src/components/navbar/NavBarItem.spec.js
@@ -42,4 +42,17 @@ describe('BNavbarItem', () => {
         inner.trigger('test_event')
         expect(testStub.called).toBe(true)
     })
+
+    it('runs closeMenu from a passed component reference', () => {
+        let closeMenu = sinon.stub()
+
+        let emitCloseMenu = shallowMount(BNavbarItem, {
+            propsData: {
+                parent: { closeMenu }
+            }
+        })
+
+        emitCloseMenu.trigger('click')
+        expect(closeMenu.called).toBe(true)
+    })
 })

--- a/src/components/navbar/NavbarItem.vue
+++ b/src/components/navbar/NavbarItem.vue
@@ -1,6 +1,7 @@
 <template>
     <component
         :is="tag"
+        :nav-ref="navRef"
         class="navbar-item"
         :class="{
             'is-active': active
@@ -22,6 +23,10 @@ export default {
             type: String,
             default: 'a'
         },
+        parent: {
+            type: Object,
+            default: null
+        },
         active: Boolean
     },
     methods: {
@@ -33,7 +38,7 @@ export default {
             // TODO: use code instead (because keyCode is actually deprecated)
             // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
             if (event.keyCode === 27) {
-                this.$parent.closeMenu()
+                this.closeMenu()
             }
         },
         /**
@@ -43,12 +48,20 @@ export default {
             const isOnWhiteList = clickableWhiteList.some((item) => item === event.target.localName)
             if (!isOnWhiteList) {
                 if (this.$parent.$data._isNavDropdown) {
-                    this.$parent.closeMenu()
+                    this.closeMenu()
                     this.$parent.$parent.closeMenu()
                 } else {
-                    this.$parent.closeMenu()
+                    this.closeMenu()
                 }
             }
+        },
+        /**
+         * Determine which closemenu to run
+         */
+        closeMenu() {
+            const parent = this.parent === null ? this.$parent : this.parent
+
+            parent.closeMenu()
         }
     },
     mounted() {

--- a/src/components/navbar/NavbarItem.vue
+++ b/src/components/navbar/NavbarItem.vue
@@ -45,11 +45,13 @@ export default {
          * Close parent if clicked outside.
          */
         handleClickEvent(event) {
+            const parent = this.parent === null ? this.$parent : this.parent
+
             const isOnWhiteList = clickableWhiteList.some((item) => item === event.target.localName)
             if (!isOnWhiteList) {
-                if (this.$parent.$data._isNavDropdown) {
+                if (parent.$data._isNavDropdown) {
                     this.closeMenu()
-                    this.$parent.$parent.closeMenu()
+                    parent.$parent.closeMenu()
                 } else {
                     this.closeMenu()
                 }

--- a/src/components/navbar/NavbarItem.vue
+++ b/src/components/navbar/NavbarItem.vue
@@ -49,7 +49,7 @@ export default {
 
             const isOnWhiteList = clickableWhiteList.some((item) => item === event.target.localName)
             if (!isOnWhiteList) {
-                if (parent.$data._isNavDropdown) {
+                if (parent.$data && parent.$data._isNavDropdown) {
                     this.closeMenu()
                     parent.$parent.closeMenu()
                 } else {


### PR DESCRIPTION
## Proposed Changes

- Allows Vue Router to be used with Navbar
Currently, as a NavbarItem directly uses `this.$parent`, it breaks when wrapped in a `<router-item>` when trying to call `this.$parent.closeMenu` which it obviously lacks.
I could have just done a lazy `this.$parent.$parent` but I felt this is more future-proofed in case another level of indentation occurs.
This PR attempts to resolve this by passing a direct reference to the navbar as props to each navbar item. I'm relatively new to the Vuejs ecosystem so if there's a more preferable way to do this I'd be happy to amend.

