### PR TITLE
Upgrade MDI to Latest Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@babel/plugin-syntax-dynamic-import": "7.2.0",
     "@babel/preset-env": "7.3.4",
     "@fortawesome/fontawesome-free": "5.3.1",
-    "@mdi/font": "2.7.94",
+    "@mdi/font": "4.8.95",
     "@vue/test-utils": "1.0.0-beta.25",
     "autoprefixer": "7.1.1",
     "axios": "0.18.1",


### PR DESCRIPTION
## Proposed Changes

In order to leverage latest MDI icon out of box, upgrade the version of MDI from `2.7.94` to `4.8.95`.