### PR TITLE
fix "Avoid mutating a prop directly"

### DIFF
--- a/src/components/loading/Loading.spec.js
+++ b/src/components/loading/Loading.spec.js
@@ -53,18 +53,65 @@ describe('BLoading', () => {
             expect(wrapper.emitted()['close']).toBeTruthy()
             expect(wrapper.emitted()['update:active']).toBeTruthy()
         })
+    })
 
-        it('manage close when programmatic', () => {
+    describe('programmatic without container', () => {
+        beforeEach(() => {
+            window.document.body.appendChild = jest.fn()
+            wrapper = shallowMount(BLoading, {
+                propsData: {
+                    programmatic: true
+                },
+                stubs: {
+                    transition: false
+                },
+                attachToDocument: true
+            })
+        })
+
+        it('Is called', () => {
+            expect(wrapper.name()).toBe('BLoading')
+            expect(wrapper.isVueInstance()).toBeTruthy()
+            expect(window.document.body.appendChild).toHaveBeenCalled()
+        })
+
+        it('manage close', () => {
             jest.useFakeTimers()
 
-            wrapper.vm.$destroy = jest.fn()
-            wrapper.setProps({programmatic: true})
+            wrapper.vm.$destroy = jest.fn(() => wrapper.vm.$destroy)
             wrapper.vm.close()
 
             expect(wrapper.vm.isActive).toBeFalsy()
             expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 150)
             jest.advanceTimersByTime(150)
             expect(wrapper.vm.$destroy).toHaveBeenCalled()
+        })
+    })
+
+    const component = document.createElement('div')
+    describe('programmatic with a container', () => {
+        beforeEach(() => {
+            component.appendChild = jest.fn()
+            wrapper = shallowMount(BLoading, {
+                propsData: {
+                    programmatic: true,
+                    container: component
+                },
+                stubs: {
+                    transition: false
+                },
+                attachToDocument: true
+            })
+        })
+
+        it('Is called', () => {
+            expect(wrapper.name()).toBe('BLoading')
+            expect(wrapper.isVueInstance()).toBeTruthy()
+            expect(component.appendChild).toHaveBeenCalled()
+        })
+
+        it('Is not full page', () => {
+            expect(wrapper.vm.displayInFullPage).toBeFalsy()
         })
     })
 })

--- a/src/components/loading/Loading.vue
+++ b/src/components/loading/Loading.vue
@@ -2,7 +2,7 @@
     <transition :name="animation">
         <div
             class="loading-overlay is-active"
-            :class="{ 'is-full-page': isFullPage }"
+            :class="{ 'is-full-page': displayInFullPage }"
             v-if="isActive">
             <div class="loading-background" @click="cancel"/>
             <slot>
@@ -41,12 +41,16 @@ export default {
     },
     data() {
         return {
-            isActive: this.active || false
+            isActive: this.active || false,
+            displayInFullPage: this.isFullPage
         }
     },
     watch: {
         active(value) {
             this.isActive = value
+        },
+        isFullPage(value) {
+            this.displayInFullPage = value
         }
     },
     methods: {
@@ -95,7 +99,8 @@ export default {
             if (!this.container) {
                 document.body.appendChild(this.$el)
             } else {
-                this.isFullPage = false
+                this.displayInFullPage = false
+                this.$emit('update:is-full-page', false)
                 this.container.appendChild(this.$el)
             }
         }


### PR DESCRIPTION
Fixes the Vue warning ("Avoid mutating a prop directly") when using a container. The `isFullPage` prop was mutated directly.
