### PR TITLE
refactor: prevent table thead jumping when sorting is changed

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -92,12 +92,12 @@
                                 <template v-else>{{ column.label }}</template>
 
                                 <b-icon
-                                    v-show="currentSortColumn === column"
                                     :icon="sortIcon"
                                     :pack="iconPack"
                                     both
                                     :size="sortIconSize"
-                                    :class="{ 'is-desc': !isAsc }"/>
+                                    :class="{'is-desc': !isAsc,
+                                             'is-invisible': currentSortColumn !== column }" />
                             </div>
                         </th>
                         <th class="checkbox-cell" v-if="checkable && checkboxPosition === 'right'">


### PR DESCRIPTION
**Prevent the 'thead' items to jump when changing the sorting.**

Instead of remove the icon using 'v-show', it change visibility. So the icon is not removed with display none causing the jumping of the elements

**Preview of the problem:**
![table-problem](https://user-images.githubusercontent.com/2920357/74230736-4817a980-4cc5-11ea-82d8-6cd063cd747b.gif)

**Preview of the fix:**
![table-fixed](https://user-images.githubusercontent.com/2920357/74230744-4bab3080-4cc5-11ea-86b2-4128f2287791.gif)
