### PR TITLE
item.first_name is undefined

### DIFF
--- a/docs/pages/extensions/sortablejs/examples/ExSimple.vue
+++ b/docs/pages/extensions/sortablejs/examples/ExSimple.vue
@@ -36,7 +36,7 @@
                 }
                 data[evt.newIndex] = item
                 vnode.componentInstance.$emit('input', data)
-                vnode.context.$buefy.toast.open(`Moved ${item.first_name} from row ${evt.oldIndex + 1} to ${evt.newIndex + 1}`)
+                vnode.context.$buefy.toast.open(`Moved ${item} from row ${evt.oldIndex + 1} to ${evt.newIndex + 1}`)
             }
         })
     }


### PR DESCRIPTION
Change item.first_name to item as data[evt.newIndex] returns a string of the moved object instead of an object

<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Instead of toast saying undefined moved from 1 to 2 , it will say the name of the item you are moving
## Proposed Changes
Change item.first_name to item as data[evt.newIndex] returns a string of the moved object instead of an object
-
-
-
