### PR TITLE
Add defaultDateRange prop

### DIFF
--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -306,6 +306,7 @@ export default {
             default: () => { return config.defaultUnselectableDaysOfWeek }
         },
         selectableDates: Array,
+        defaultDateRange: Array,
         dateFormatter: {
             type: Function,
             default: (date, vm) => {
@@ -417,6 +418,10 @@ export default {
     data() {
         const focusedDate = (Array.isArray(this.value) ? this.value[0] : (this.value)) ||
             this.focusedDate || this.dateCreator()
+
+        if (this.defaultDateRange && Array.isArray(this.defaultDateRange)) {
+            this.value = this.defaultDateRange
+        }
 
         return {
             dateSelected: this.value,

--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -420,7 +420,7 @@ export default {
             this.focusedDate || this.dateCreator()
 
         if (this.defaultDateRange && Array.isArray(this.defaultDateRange)) {
-            this.value = this.defaultDateRange
+            this.computedValue = this.defaultDateRange
         }
 
         return {


### PR DESCRIPTION
I was in a situation where I needed the date-picker to be rendered with a date already selected. I could workaround this by adding a `ref` to the `<b-datepicker ...>` component, and then set the `dateSelected`.

But, I feel this should be part of the component itself, since there are cases where you might have some data shown on the screen that are based on a date-range, but the date-picker shows the user haven't selected anything, so the user doesn't know about the "invisible" date-range.