### PR TITLE
Pass isActive to dropdown trigger slot

### DIFF
--- a/docs/pages/components/dropdown/api/dropdown.js
+++ b/docs/pages/components/dropdown/api/dropdown.js
@@ -91,7 +91,7 @@ export default [
             {
                 name: 'default',
                 description: '',
-                props: ''
+                props: '<code>slot-scope="{ active }"</code> *Only works when not hoverable.'
             },
             {
                 name: '<code>trigger</code>',

--- a/docs/pages/components/dropdown/examples/ExSimple.vue
+++ b/docs/pages/components/dropdown/examples/ExSimple.vue
@@ -1,9 +1,9 @@
 <template>
     <section>
         <b-dropdown aria-role="list">
-            <button class="button is-primary" slot="trigger">
+            <button class="button is-primary" slot="trigger" slot-scope="{ active }">
                 <span>Click me!</span>
-                <b-icon icon="menu-down"></b-icon>
+                <b-icon :icon="active ? 'menu-up' : 'menu-down'"></b-icon>
             </button>
 
             <b-dropdown-item aria-role="listitem">Action</b-dropdown-item>

--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -8,7 +8,7 @@
             @click="toggle"
             @mouseenter="checkHoverable"
             aria-haspopup="true">
-            <slot name="trigger"/>
+            <slot name="trigger" :active="isActive"/>
         </div>
 
         <transition :name="animation">


### PR DESCRIPTION
Pass isActive to dropdown trigger slot

## Proposed Changes

- Send `:active="isActive"` to dropdown trigger slot
- Can be accessed like this `slot-scope="{ active }"`
- Does not work with `hoverable`
