### PR TITLE
Fixed typos in autocomplete and taginput docs

### DIFF
--- a/docs/pages/components/autocomplete/api/autocomplete.js
+++ b/docs/pages/components/autocomplete/api/autocomplete.js
@@ -101,7 +101,7 @@ export default [
             },
             {
                 name: '<code>check-infinite-scroll</code>',
-                description: 'Makes the component check if list reached scroll end and emit <code>infinite-sroll</code> event.',
+                description: 'Makes the component check if list reached scroll end and emit <code>infinite-scroll</code> event.',
                 type: 'Boolean',
                 values: '—',
                 default: '<code>false</code>'

--- a/docs/pages/components/taginput/api/taginput.js
+++ b/docs/pages/components/taginput/api/taginput.js
@@ -139,7 +139,7 @@ export default [
             },
             {
                 name: '<code>check-infinite-scroll</code>',
-                description: 'Makes the autocomplete component check if list reached scroll end and emit <code>infinite-sroll</code> event.',
+                description: 'Makes the autocomplete component check if list reached scroll end and emit <code>infinite-scroll</code> event.',
                 type: 'Boolean',
                 values: '—',
                 default: '<code>false</code>'


### PR DESCRIPTION
I have updated the spelling for the miss spelt event names in the two files below.
