### PR TITLE
Button text is centered

### DIFF
--- a/src/components/dialog/Dialog.vue
+++ b/src/components/dialog/Dialog.vue
@@ -51,16 +51,12 @@
                         v-if="showCancel"
                         class="button"
                         ref="cancelButton"
-                        @click="cancel('button')">
-                        {{ cancelText }}
-                    </button>
+                        @click="cancel('button')">{{ cancelText }}</button>
                     <button
                         class="button"
                         :class="type"
                         ref="confirmButton"
-                        @click="confirm">
-                        {{ confirmText }}
-                    </button>
+                        @click="confirm">{{ confirmText }}</button>
                 </footer>
             </div>
         </div>


### PR DESCRIPTION
Fixes #
https://github.com/buefy/buefy/issues/2259

## Proposed Changes
Changed the HTML for the dialog prompt buttons according the bulma documentation.
(Open and close tag in one line)

![Screenshot_32](https://user-images.githubusercontent.com/1067634/75114449-2ff54200-5656-11ea-8bd4-4ba1b8dfb55a.jpg)
