### PR TITLE
[Fix] BTable Sort Icon - Change to is-hidden

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -123,7 +123,7 @@
                                     :size="sortIconSize"
                                     :class="{
                                         'is-desc': !isAsc,
-                                        'is-invisible': currentSortColumn !== column
+                                        'is-hidden': currentSortColumn !== column
                                     }"
                                 />
                             </div>

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -92,40 +92,45 @@
                                         :index="index"
                                     />
                                 </template>
-                                <template v-else>{{ column.label }}</template>
+                                <template v-else>
+                                    <span class="is-relative">
+                                        {{ column.label }}
+                                        <template
+                                            v-if="sortMultiple &&
+                                                sortMultipleDataComputed &&
+                                                sortMultipleDataComputed.length > 0 &&
+                                                sortMultipleDataComputed.filter(i =>
+                                            i.field === column.field).length > 0">
+                                            <b-icon
+                                                :icon="sortIcon"
+                                                :pack="iconPack"
+                                                both
+                                                :size="sortIconSize"
+                                                :class="{
+                                                    'is-desc': sortMultipleDataComputed.filter(i =>
+                                                i.field === column.field)[0].order === 'desc'}"
+                                            />
+                                            {{ findIndexOfSortData(column) }}
+                                            <button
+                                                class="delete is-small multi-sort-cancel-icon"
+                                                type="button"
+                                                @click.stop="removeSortingPriority(column)"/>
+                                        </template>
 
-                                <template
-                                    v-if="sortMultiple &&
-                                        sortMultipleDataComputed &&
-                                        sortMultipleDataComputed.length > 0 &&
-                                        sortMultipleDataComputed.filter(i =>
-                                    i.field === column.field).length > 0">
-                                    <b-icon
-                                        :icon="sortIcon"
-                                        :pack="iconPack"
-                                        both
-                                        :size="sortIconSize"
-                                        :class="{ 'is-desc': sortMultipleDataComputed.filter(i =>
-                                        i.field === column.field)[0].order === 'desc'}"
-                                    />
-                                    {{ findIndexOfSortData(column) }}
-                                    <button
-                                        class="delete is-small multi-sort-cancel-icon"
-                                        type="button"
-                                        @click.stop="removeSortingPriority(column)"/>
+                                        <b-icon
+                                            v-else
+                                            :icon="sortIcon"
+                                            :pack="iconPack"
+                                            both
+                                            :size="sortIconSize"
+                                            class="sort-icon"
+                                            :class="{
+                                                'is-desc': !isAsc,
+                                                'is-invisible': currentSortColumn !== column
+                                            }"
+                                        />
+                                    </span>
                                 </template>
-
-                                <b-icon
-                                    v-else
-                                    :icon="sortIcon"
-                                    :pack="iconPack"
-                                    both
-                                    :size="sortIconSize"
-                                    :class="{
-                                        'is-desc': !isAsc,
-                                        'is-hidden': currentSortColumn !== column
-                                    }"
-                                />
                             </div>
                         </th>
                         <th class="checkbox-cell" v-if="checkable && checkboxPosition === 'right'">

--- a/src/scss/components/_table.scss
+++ b/src/scss/components/_table.scss
@@ -67,6 +67,15 @@
             &.is-sortable,
             &.is-sortable .th-wrap {
                 cursor: pointer;
+
+                .is-relative {
+                    position: absolute;
+                }
+            }
+            .sort-icon, .multi-sort-cancel-icon {
+                position: absolute;
+                bottom: 50%;
+                transform: translateY(50%);
             }
             .multi-sort-cancel-icon {
                 margin-left: 10px;


### PR DESCRIPTION
## Scope of work
Change hiding table sort icon from `is-invisible` to `is-hidden`

## Proposed Changes
`is-invisible` will not let label of column to be centered because the area of sort icon would be displayed.
So, I change to `is-hidden` to hide sort icon.

If you have any feedback or suggestion, please let me know. 😎
