### PR TITLE
Fixes #2205

### DIFF
--- a/src/components/datepicker/DatepickerTable.vue
+++ b/src/components/datepicker/DatepickerTable.vue
@@ -5,7 +5,7 @@
                 v-for="(day, index) in visibleDayNames"
                 :key="index"
                 class="datepicker-cell">
-                {{ day }}
+                <span>{{ day }}</span>
             </div>
         </header>
         <div class="datepicker-body" :class="{'has-events':hasEvents}">

--- a/src/components/datepicker/DatepickerTableRow.vue
+++ b/src/components/datepicker/DatepickerTableRow.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="datepicker-row">
         <a class="datepicker-cell is-week-number" v-if="showWeekNumber">
-            {{ getWeekNumber(week[6]) }}
+            <span>{{ getWeekNumber(week[6]) }}</span>
         </a>
         <template v-for="(day, index) in week">
             <a
@@ -16,7 +16,7 @@
                 @keydown.enter.prevent="emitChosenDate(day)"
                 @keydown.space.prevent="emitChosenDate(day)"
                 @mouseenter="setRangeHoverEndDate(day)">
-                {{ day.getDate() }}
+                <span>{{ day.getDate() }}</span>
                 <div class="events" v-if="eventsDateMatch(day)">
                     <div
                         class="event"
@@ -30,7 +30,7 @@
                 :key="index"
                 :class="classObject(day)"
                 class="datepicker-cell">
-                {{ day.getDate() }}
+                <span>{{ day.getDate() }}</span>
             </div>
         </template>
     </div>

--- a/src/components/datepicker/__snapshots__/DatepickerTable.spec.js.snap
+++ b/src/components/datepicker/__snapshots__/DatepickerTable.spec.js.snap
@@ -3,27 +3,13 @@
 exports[`BDatepickerTable render correctly 1`] = `
 <section class="datepicker-table">
     <header class="datepicker-header">
-        <div class="datepicker-cell">
-            Su
-        </div>
-        <div class="datepicker-cell">
-            M
-        </div>
-        <div class="datepicker-cell">
-            Tu
-        </div>
-        <div class="datepicker-cell">
-            W
-        </div>
-        <div class="datepicker-cell">
-            Th
-        </div>
-        <div class="datepicker-cell">
-            F
-        </div>
-        <div class="datepicker-cell">
-            S
-        </div>
+        <div class="datepicker-cell"><span>Su</span></div>
+        <div class="datepicker-cell"><span>M</span></div>
+        <div class="datepicker-cell"><span>Tu</span></div>
+        <div class="datepicker-cell"><span>W</span></div>
+        <div class="datepicker-cell"><span>Th</span></div>
+        <div class="datepicker-cell"><span>F</span></div>
+        <div class="datepicker-cell"><span>S</span></div>
     </header>
     <div class="datepicker-body"></div>
 </section>

--- a/src/components/datepicker/__snapshots__/DatepickerTableRow.spec.js.snap
+++ b/src/components/datepicker/__snapshots__/DatepickerTableRow.spec.js.snap
@@ -2,19 +2,12 @@
 
 exports[`BDatepickerTableRow render correctly 1`] = `
 <div class="datepicker-row">
-    <!----> <a role="button" href="#" class="datepicker-cell is-selectable is-invisible">
-        31
-        <!----></a><a role="button" href="#" class="datepicker-cell is-selectable is-invisible">
-        1
-        <!----></a><a role="button" href="#" class="datepicker-cell is-selectable is-invisible">
-        2
-        <!----></a><a role="button" href="#" class="datepicker-cell is-selectable is-invisible">
-        3
-        <!----></a><a role="button" href="#" class="datepicker-cell is-selectable is-invisible">
-        4
-        <!----></a><a role="button" href="#" class="datepicker-cell is-selectable is-invisible">
-        5
-        <!----></a><a role="button" href="#" class="datepicker-cell is-selectable is-invisible">
-        6
+    <!----> <a role="button" href="#" class="datepicker-cell is-selectable is-invisible"><span>31</span>
+        <!----></a><a role="button" href="#" class="datepicker-cell is-selectable is-invisible"><span>1</span>
+        <!----></a><a role="button" href="#" class="datepicker-cell is-selectable is-invisible"><span>2</span>
+        <!----></a><a role="button" href="#" class="datepicker-cell is-selectable is-invisible"><span>3</span>
+        <!----></a><a role="button" href="#" class="datepicker-cell is-selectable is-invisible"><span>4</span>
+        <!----></a><a role="button" href="#" class="datepicker-cell is-selectable is-invisible"><span>5</span>
+        <!----></a><a role="button" href="#" class="datepicker-cell is-selectable is-invisible"><span>6</span>
         <!----></a></div>
 `;


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #2205
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes
This fixes the issue of Safari not showing the Datepicker correctly. Table cell content is now wrapped in span, which fixes the weird alignment on safari on mac and ios
