### PR TITLE
Make $notices-box-shadow default in _notices.scss

### DIFF
--- a/src/scss/components/_notices.scss
+++ b/src/scss/components/_notices.scss
@@ -1,4 +1,4 @@
-$notices-box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12), 0 0 6px rgba(0, 0, 0, 0.04);
+$notices-box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12), 0 0 6px rgba(0, 0, 0, 0.04) !default;
 
 $toast-border-radius: 2em !default;
 $toast-opacity: 0.92 !default;


### PR DESCRIPTION
# Proposed Changes
This change allows to override a single variable when importing _notices.scss, so it's mostly a convenience change.

I don't this it will have any side-effect.