### PR TITLE
feature Horizontal layout for BDatetimePicker

### DIFF
--- a/docs/pages/components/datetimepicker/api/datetimepicker.js
+++ b/docs/pages/components/datetimepicker/api/datetimepicker.js
@@ -121,6 +121,13 @@ export default [
                 default: '<code>true</code>'
             },
             {
+                name: '<code>horizontalTimePicker</code>',
+                description: 'Changes the time picker layout to a horizontal position',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
                 name: 'Any native attribute',
                 description: '—',
                 type: '—',

--- a/docs/pages/components/datetimepicker/examples/ExSimple.vue
+++ b/docs/pages/components/datetimepicker/examples/ExSimple.vue
@@ -17,7 +17,8 @@
                 placeholder="Click to select..."
                 icon="calendar-today"
                 :datepicker="{ showWeekNumber }"
-                :timepicker="{ enableSeconds, hourFormat: format }">
+                :timepicker="{ enableSeconds, hourFormat: format }"
+                horizontalTimePicker>
             </b-datetimepicker>
         </b-field>
     </section>

--- a/src/components/datepicker/Datepicker.spec.js
+++ b/src/components/datepicker/Datepicker.spec.js
@@ -284,4 +284,35 @@ describe('BDatepicker', () => {
             expect(mockDateFormatter.mock.calls.length).toEqual(0)
         })
     })
+
+    describe('when horizontalTimePicker is true', () => {
+        beforeEach(() => {
+            wrapper = shallowMount(BDatepicker, {
+                stubs: {
+                    transition: false
+                },
+                slots: {
+                    default: ['<div>Custom footer</div>']
+                },
+                propsData: {
+                    horizontalTimePicker: true
+                }
+            })
+        })
+
+        it('renders a component with .dropdown-horizonal-timepicker class', () => {
+            const subject = wrapper.find('.dropdown-horizonal-timepicker')
+            expect(subject.exists()).toBeTruthy()
+        })
+
+        it('renders a component with .content-horizonal-timepicker class', () => {
+            const subject = wrapper.find('.content-horizonal-timepicker')
+            expect(subject.exists()).toBeTruthy()
+        })
+
+        it('renders a component with .footer-horizontal-timepicker class', () => {
+            const subject = wrapper.find('.footer-horizontal-timepicker')
+            expect(subject.exists()).toBeTruthy()
+        })
+    })
 })

--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -33,128 +33,133 @@
             <b-dropdown-item
                 :disabled="disabled"
                 :focusable="focusable"
-                custom>
-                <header class="datepicker-header">
-                    <template v-if="$slots.header !== undefined && $slots.header.length">
-                        <slot name="header" />
-                    </template>
-                    <div
-                        v-else
-                        class="pagination field is-centered"
-                        :class="size">
-                        <a
-                            v-show="!showPrev && !disabled"
-                            class="pagination-previous"
-                            role="button"
-                            href="#"
-                            :disabled="disabled"
-                            @click.prevent="prev"
-                            @keydown.enter.prevent="prev"
-                            @keydown.space.prevent="prev">
+                custom
+                :class="{'dropdown-horizonal-timepicker': horizontalTimePicker}">
+                <div>
+                    <header class="datepicker-header">
+                        <template v-if="$slots.header !== undefined && $slots.header.length">
+                            <slot name="header" />
+                        </template>
+                        <div
+                            v-else
+                            class="pagination field is-centered"
+                            :class="size">
+                            <a
+                                v-show="!showPrev && !disabled"
+                                class="pagination-previous"
+                                role="button"
+                                href="#"
+                                :disabled="disabled"
+                                @click.prevent="prev"
+                                @keydown.enter.prevent="prev"
+                                @keydown.space.prevent="prev">
 
-                            <b-icon
-                                :icon="iconPrev"
-                                :pack="iconPack"
-                                both
-                                type="is-primary is-clickable"/>
-                        </a>
-                        <a
-                            v-show="!showNext && !disabled"
-                            class="pagination-next"
-                            role="button"
-                            href="#"
-                            :disabled="disabled"
-                            @click.prevent="next"
-                            @keydown.enter.prevent="next"
-                            @keydown.space.prevent="next">
+                                <b-icon
+                                    :icon="iconPrev"
+                                    :pack="iconPack"
+                                    both
+                                    type="is-primary is-clickable"/>
+                            </a>
+                            <a
+                                v-show="!showNext && !disabled"
+                                class="pagination-next"
+                                role="button"
+                                href="#"
+                                :disabled="disabled"
+                                @click.prevent="next"
+                                @keydown.enter.prevent="next"
+                                @keydown.space.prevent="next">
 
-                            <b-icon
-                                :icon="iconNext"
-                                :pack="iconPack"
-                                both
-                                type="is-primary is-clickable"/>
-                        </a>
-                        <div class="pagination-list">
-                            <b-field>
-                                <b-select
-                                    v-if="!isTypeMonth"
-                                    v-model="focusedDateData.month"
-                                    :disabled="disabled"
-                                    :size="size">
-                                    <option
-                                        v-for="month in listOfMonths"
-                                        :value="month.index"
-                                        :key="month.name"
-                                        :disabled="month.disabled">
-                                        {{ month.name }}
-                                    </option>
-                                </b-select>
-                                <b-select
-                                    v-model="focusedDateData.year"
-                                    :disabled="disabled"
-                                    :size="size">
-                                    <option
-                                        v-for="year in listOfYears"
-                                        :value="year"
-                                        :key="year">
-                                        {{ year }}
-                                    </option>
-                                </b-select>
-                            </b-field>
+                                <b-icon
+                                    :icon="iconNext"
+                                    :pack="iconPack"
+                                    both
+                                    type="is-primary is-clickable"/>
+                            </a>
+                            <div class="pagination-list">
+                                <b-field>
+                                    <b-select
+                                        v-if="!isTypeMonth"
+                                        v-model="focusedDateData.month"
+                                        :disabled="disabled"
+                                        :size="size">
+                                        <option
+                                            v-for="month in listOfMonths"
+                                            :value="month.index"
+                                            :key="month.name"
+                                            :disabled="month.disabled">
+                                            {{ month.name }}
+                                        </option>
+                                    </b-select>
+                                    <b-select
+                                        v-model="focusedDateData.year"
+                                        :disabled="disabled"
+                                        :size="size">
+                                        <option
+                                            v-for="year in listOfYears"
+                                            :value="year"
+                                            :key="year">
+                                            {{ year }}
+                                        </option>
+                                    </b-select>
+                                </b-field>
+                            </div>
                         </div>
+                    </header>
+                    <div
+                        v-if="!isTypeMonth"
+                        class="datepicker-content"
+                        :class="{'content-horizonal-timepicker': horizontalTimePicker}">
+                        <b-datepicker-table
+                            v-model="computedValue"
+                            :day-names="dayNames"
+                            :month-names="monthNames"
+                            :first-day-of-week="firstDayOfWeek"
+                            :rules-for-first-week="rulesForFirstWeek"
+                            :min-date="minDate"
+                            :max-date="maxDate"
+                            :focused="focusedDateData"
+                            :disabled="disabled"
+                            :unselectable-dates="unselectableDates"
+                            :unselectable-days-of-week="unselectableDaysOfWeek"
+                            :selectable-dates="selectableDates"
+                            :events="events"
+                            :indicators="indicators"
+                            :date-creator="dateCreator"
+                            :type-month="isTypeMonth"
+                            :nearby-month-days="nearbyMonthDays"
+                            :nearby-selectable-month-days="nearbySelectableMonthDays"
+                            :show-week-number="showWeekNumber"
+                            :range="range"
+                            :multiple="multiple"
+                            @range-start="date => $emit('range-start', date)"
+                            @range-end="date => $emit('range-end', date)"
+                            @close="togglePicker(false)"/>
                     </div>
-                </header>
 
-                <div
-                    v-if="!isTypeMonth"
-                    class="datepicker-content">
-                    <b-datepicker-table
-                        v-model="computedValue"
-                        :day-names="dayNames"
-                        :month-names="monthNames"
-                        :first-day-of-week="firstDayOfWeek"
-                        :rules-for-first-week="rulesForFirstWeek"
-                        :min-date="minDate"
-                        :max-date="maxDate"
-                        :focused="focusedDateData"
-                        :disabled="disabled"
-                        :unselectable-dates="unselectableDates"
-                        :unselectable-days-of-week="unselectableDaysOfWeek"
-                        :selectable-dates="selectableDates"
-                        :events="events"
-                        :indicators="indicators"
-                        :date-creator="dateCreator"
-                        :type-month="isTypeMonth"
-                        :nearby-month-days="nearbyMonthDays"
-                        :nearby-selectable-month-days="nearbySelectableMonthDays"
-                        :show-week-number="showWeekNumber"
-                        :range="range"
-                        :multiple="multiple"
-                        @range-start="date => $emit('range-start', date)"
-                        @range-end="date => $emit('range-end', date)"
-                        @close="togglePicker(false)"/>
-                </div>
-                <div v-else>
-                    <b-datepicker-month
-                        v-model="computedValue"
-                        :month-names="monthNames"
-                        :min-date="minDate"
-                        :max-date="maxDate"
-                        :focused="focusedDateData"
-                        :disabled="disabled"
-                        :unselectable-dates="unselectableDates"
-                        :unselectable-days-of-week="unselectableDaysOfWeek"
-                        :selectable-dates="selectableDates"
-                        :events="events"
-                        :indicators="indicators"
-                        :date-creator="dateCreator"
-                        :multiple="multiple"
-                        @close="togglePicker(false)"/>
+                    <div v-else>
+                        <b-datepicker-month
+                            v-model="computedValue"
+                            :month-names="monthNames"
+                            :min-date="minDate"
+                            :max-date="maxDate"
+                            :focused="focusedDateData"
+                            :disabled="disabled"
+                            :unselectable-dates="unselectableDates"
+                            :unselectable-days-of-week="unselectableDaysOfWeek"
+                            :selectable-dates="selectableDates"
+                            :events="events"
+                            :indicators="indicators"
+                            :date-creator="dateCreator"
+                            :multiple="multiple"
+                            @close="togglePicker(false)"/>
+                    </div>
                 </div>
 
                 <footer
                     v-if="$slots.default !== undefined && $slots.default.length"
-                    class="datepicker-footer">
+                    class="datepicker-footer"
+                    :class="{'footer-horizontal-timepicker': horizontalTimePicker}">
                     <slot/>
                 </footer>
             </b-dropdown-item>
@@ -300,6 +305,7 @@ export default {
         placeholder: String,
         editable: Boolean,
         disabled: Boolean,
+        horizontalTimePicker: Boolean,
         unselectableDates: Array,
         unselectableDaysOfWeek: {
             type: Array,

--- a/src/components/datepicker/__snapshots__/Datepicker.spec.js.snap
+++ b/src/components/datepicker/__snapshots__/Datepicker.spec.js.snap
@@ -4,373 +4,375 @@ exports[`BDatepicker render correctly 1`] = `
 <div class="datepicker control">
     <b-dropdown-stub mobilemodal="true" ariarole="" animation="fade" closeonclick="true" canclose="true">
         <b-input-stub autocomplete="off" usehtml5validation="true" type="text" hascounter="true" customclass="" readonly="true"></b-input-stub>
-        <b-dropdown-item-stub custom="true" focusable="true" ariarole="">
-            <header class="datepicker-header">
-                <div class="pagination field is-centered"><a role="button" href="#" class="pagination-previous">
-                        <b-icon-stub type="is-primary is-clickable" icon="chevron-left" both="true"></b-icon-stub>
-                    </a> <a role="button" href="#" class="pagination-next">
-                        <b-icon-stub type="is-primary is-clickable" icon="chevron-right" both="true"></b-icon-stub>
-                    </a>
-                    <div class="pagination-list">
-                        <b-field-stub addons="true">
-                            <b-select-stub usehtml5validation="true" value="7">
-                                <option value="0">
-                                    January
-                                </option>
-                                <option value="1">
-                                    February
-                                </option>
-                                <option value="2">
-                                    March
-                                </option>
-                                <option value="3">
-                                    April
-                                </option>
-                                <option value="4">
-                                    May
-                                </option>
-                                <option value="5">
-                                    June
-                                </option>
-                                <option value="6">
-                                    July
-                                </option>
-                                <option value="7">
-                                    August
-                                </option>
-                                <option value="8">
-                                    September
-                                </option>
-                                <option value="9">
-                                    October
-                                </option>
-                                <option value="10">
-                                    November
-                                </option>
-                                <option value="11">
-                                    December
-                                </option>
-                            </b-select-stub>
-                            <b-select-stub usehtml5validation="true" value="2018">
-                                <option value="2021">
-                                    2021
-                                </option>
-                                <option value="2020">
-                                    2020
-                                </option>
-                                <option value="2019">
-                                    2019
-                                </option>
-                                <option value="2018">
-                                    2018
-                                </option>
-                                <option value="2017">
-                                    2017
-                                </option>
-                                <option value="2016">
-                                    2016
-                                </option>
-                                <option value="2015">
-                                    2015
-                                </option>
-                                <option value="2014">
-                                    2014
-                                </option>
-                                <option value="2013">
-                                    2013
-                                </option>
-                                <option value="2012">
-                                    2012
-                                </option>
-                                <option value="2011">
-                                    2011
-                                </option>
-                                <option value="2010">
-                                    2010
-                                </option>
-                                <option value="2009">
-                                    2009
-                                </option>
-                                <option value="2008">
-                                    2008
-                                </option>
-                                <option value="2007">
-                                    2007
-                                </option>
-                                <option value="2006">
-                                    2006
-                                </option>
-                                <option value="2005">
-                                    2005
-                                </option>
-                                <option value="2004">
-                                    2004
-                                </option>
-                                <option value="2003">
-                                    2003
-                                </option>
-                                <option value="2002">
-                                    2002
-                                </option>
-                                <option value="2001">
-                                    2001
-                                </option>
-                                <option value="2000">
-                                    2000
-                                </option>
-                                <option value="1999">
-                                    1999
-                                </option>
-                                <option value="1998">
-                                    1998
-                                </option>
-                                <option value="1997">
-                                    1997
-                                </option>
-                                <option value="1996">
-                                    1996
-                                </option>
-                                <option value="1995">
-                                    1995
-                                </option>
-                                <option value="1994">
-                                    1994
-                                </option>
-                                <option value="1993">
-                                    1993
-                                </option>
-                                <option value="1992">
-                                    1992
-                                </option>
-                                <option value="1991">
-                                    1991
-                                </option>
-                                <option value="1990">
-                                    1990
-                                </option>
-                                <option value="1989">
-                                    1989
-                                </option>
-                                <option value="1988">
-                                    1988
-                                </option>
-                                <option value="1987">
-                                    1987
-                                </option>
-                                <option value="1986">
-                                    1986
-                                </option>
-                                <option value="1985">
-                                    1985
-                                </option>
-                                <option value="1984">
-                                    1984
-                                </option>
-                                <option value="1983">
-                                    1983
-                                </option>
-                                <option value="1982">
-                                    1982
-                                </option>
-                                <option value="1981">
-                                    1981
-                                </option>
-                                <option value="1980">
-                                    1980
-                                </option>
-                                <option value="1979">
-                                    1979
-                                </option>
-                                <option value="1978">
-                                    1978
-                                </option>
-                                <option value="1977">
-                                    1977
-                                </option>
-                                <option value="1976">
-                                    1976
-                                </option>
-                                <option value="1975">
-                                    1975
-                                </option>
-                                <option value="1974">
-                                    1974
-                                </option>
-                                <option value="1973">
-                                    1973
-                                </option>
-                                <option value="1972">
-                                    1972
-                                </option>
-                                <option value="1971">
-                                    1971
-                                </option>
-                                <option value="1970">
-                                    1970
-                                </option>
-                                <option value="1969">
-                                    1969
-                                </option>
-                                <option value="1968">
-                                    1968
-                                </option>
-                                <option value="1967">
-                                    1967
-                                </option>
-                                <option value="1966">
-                                    1966
-                                </option>
-                                <option value="1965">
-                                    1965
-                                </option>
-                                <option value="1964">
-                                    1964
-                                </option>
-                                <option value="1963">
-                                    1963
-                                </option>
-                                <option value="1962">
-                                    1962
-                                </option>
-                                <option value="1961">
-                                    1961
-                                </option>
-                                <option value="1960">
-                                    1960
-                                </option>
-                                <option value="1959">
-                                    1959
-                                </option>
-                                <option value="1958">
-                                    1958
-                                </option>
-                                <option value="1957">
-                                    1957
-                                </option>
-                                <option value="1956">
-                                    1956
-                                </option>
-                                <option value="1955">
-                                    1955
-                                </option>
-                                <option value="1954">
-                                    1954
-                                </option>
-                                <option value="1953">
-                                    1953
-                                </option>
-                                <option value="1952">
-                                    1952
-                                </option>
-                                <option value="1951">
-                                    1951
-                                </option>
-                                <option value="1950">
-                                    1950
-                                </option>
-                                <option value="1949">
-                                    1949
-                                </option>
-                                <option value="1948">
-                                    1948
-                                </option>
-                                <option value="1947">
-                                    1947
-                                </option>
-                                <option value="1946">
-                                    1946
-                                </option>
-                                <option value="1945">
-                                    1945
-                                </option>
-                                <option value="1944">
-                                    1944
-                                </option>
-                                <option value="1943">
-                                    1943
-                                </option>
-                                <option value="1942">
-                                    1942
-                                </option>
-                                <option value="1941">
-                                    1941
-                                </option>
-                                <option value="1940">
-                                    1940
-                                </option>
-                                <option value="1939">
-                                    1939
-                                </option>
-                                <option value="1938">
-                                    1938
-                                </option>
-                                <option value="1937">
-                                    1937
-                                </option>
-                                <option value="1936">
-                                    1936
-                                </option>
-                                <option value="1935">
-                                    1935
-                                </option>
-                                <option value="1934">
-                                    1934
-                                </option>
-                                <option value="1933">
-                                    1933
-                                </option>
-                                <option value="1932">
-                                    1932
-                                </option>
-                                <option value="1931">
-                                    1931
-                                </option>
-                                <option value="1930">
-                                    1930
-                                </option>
-                                <option value="1929">
-                                    1929
-                                </option>
-                                <option value="1928">
-                                    1928
-                                </option>
-                                <option value="1927">
-                                    1927
-                                </option>
-                                <option value="1926">
-                                    1926
-                                </option>
-                                <option value="1925">
-                                    1925
-                                </option>
-                                <option value="1924">
-                                    1924
-                                </option>
-                                <option value="1923">
-                                    1923
-                                </option>
-                                <option value="1922">
-                                    1922
-                                </option>
-                                <option value="1921">
-                                    1921
-                                </option>
-                                <option value="1920">
-                                    1920
-                                </option>
-                                <option value="1919">
-                                    1919
-                                </option>
-                                <option value="1918">
-                                    1918
-                                </option>
-                            </b-select-stub>
-                        </b-field-stub>
+        <b-dropdown-item-stub custom="true" focusable="true" ariarole="" class="">
+            <div>
+                <header class="datepicker-header">
+                    <div class="pagination field is-centered"><a role="button" href="#" class="pagination-previous">
+                            <b-icon-stub type="is-primary is-clickable" icon="chevron-left" both="true"></b-icon-stub>
+                        </a> <a role="button" href="#" class="pagination-next">
+                            <b-icon-stub type="is-primary is-clickable" icon="chevron-right" both="true"></b-icon-stub>
+                        </a>
+                        <div class="pagination-list">
+                            <b-field-stub addons="true">
+                                <b-select-stub usehtml5validation="true" value="7">
+                                    <option value="0">
+                                        January
+                                    </option>
+                                    <option value="1">
+                                        February
+                                    </option>
+                                    <option value="2">
+                                        March
+                                    </option>
+                                    <option value="3">
+                                        April
+                                    </option>
+                                    <option value="4">
+                                        May
+                                    </option>
+                                    <option value="5">
+                                        June
+                                    </option>
+                                    <option value="6">
+                                        July
+                                    </option>
+                                    <option value="7">
+                                        August
+                                    </option>
+                                    <option value="8">
+                                        September
+                                    </option>
+                                    <option value="9">
+                                        October
+                                    </option>
+                                    <option value="10">
+                                        November
+                                    </option>
+                                    <option value="11">
+                                        December
+                                    </option>
+                                </b-select-stub>
+                                <b-select-stub usehtml5validation="true" value="2018">
+                                    <option value="2021">
+                                        2021
+                                    </option>
+                                    <option value="2020">
+                                        2020
+                                    </option>
+                                    <option value="2019">
+                                        2019
+                                    </option>
+                                    <option value="2018">
+                                        2018
+                                    </option>
+                                    <option value="2017">
+                                        2017
+                                    </option>
+                                    <option value="2016">
+                                        2016
+                                    </option>
+                                    <option value="2015">
+                                        2015
+                                    </option>
+                                    <option value="2014">
+                                        2014
+                                    </option>
+                                    <option value="2013">
+                                        2013
+                                    </option>
+                                    <option value="2012">
+                                        2012
+                                    </option>
+                                    <option value="2011">
+                                        2011
+                                    </option>
+                                    <option value="2010">
+                                        2010
+                                    </option>
+                                    <option value="2009">
+                                        2009
+                                    </option>
+                                    <option value="2008">
+                                        2008
+                                    </option>
+                                    <option value="2007">
+                                        2007
+                                    </option>
+                                    <option value="2006">
+                                        2006
+                                    </option>
+                                    <option value="2005">
+                                        2005
+                                    </option>
+                                    <option value="2004">
+                                        2004
+                                    </option>
+                                    <option value="2003">
+                                        2003
+                                    </option>
+                                    <option value="2002">
+                                        2002
+                                    </option>
+                                    <option value="2001">
+                                        2001
+                                    </option>
+                                    <option value="2000">
+                                        2000
+                                    </option>
+                                    <option value="1999">
+                                        1999
+                                    </option>
+                                    <option value="1998">
+                                        1998
+                                    </option>
+                                    <option value="1997">
+                                        1997
+                                    </option>
+                                    <option value="1996">
+                                        1996
+                                    </option>
+                                    <option value="1995">
+                                        1995
+                                    </option>
+                                    <option value="1994">
+                                        1994
+                                    </option>
+                                    <option value="1993">
+                                        1993
+                                    </option>
+                                    <option value="1992">
+                                        1992
+                                    </option>
+                                    <option value="1991">
+                                        1991
+                                    </option>
+                                    <option value="1990">
+                                        1990
+                                    </option>
+                                    <option value="1989">
+                                        1989
+                                    </option>
+                                    <option value="1988">
+                                        1988
+                                    </option>
+                                    <option value="1987">
+                                        1987
+                                    </option>
+                                    <option value="1986">
+                                        1986
+                                    </option>
+                                    <option value="1985">
+                                        1985
+                                    </option>
+                                    <option value="1984">
+                                        1984
+                                    </option>
+                                    <option value="1983">
+                                        1983
+                                    </option>
+                                    <option value="1982">
+                                        1982
+                                    </option>
+                                    <option value="1981">
+                                        1981
+                                    </option>
+                                    <option value="1980">
+                                        1980
+                                    </option>
+                                    <option value="1979">
+                                        1979
+                                    </option>
+                                    <option value="1978">
+                                        1978
+                                    </option>
+                                    <option value="1977">
+                                        1977
+                                    </option>
+                                    <option value="1976">
+                                        1976
+                                    </option>
+                                    <option value="1975">
+                                        1975
+                                    </option>
+                                    <option value="1974">
+                                        1974
+                                    </option>
+                                    <option value="1973">
+                                        1973
+                                    </option>
+                                    <option value="1972">
+                                        1972
+                                    </option>
+                                    <option value="1971">
+                                        1971
+                                    </option>
+                                    <option value="1970">
+                                        1970
+                                    </option>
+                                    <option value="1969">
+                                        1969
+                                    </option>
+                                    <option value="1968">
+                                        1968
+                                    </option>
+                                    <option value="1967">
+                                        1967
+                                    </option>
+                                    <option value="1966">
+                                        1966
+                                    </option>
+                                    <option value="1965">
+                                        1965
+                                    </option>
+                                    <option value="1964">
+                                        1964
+                                    </option>
+                                    <option value="1963">
+                                        1963
+                                    </option>
+                                    <option value="1962">
+                                        1962
+                                    </option>
+                                    <option value="1961">
+                                        1961
+                                    </option>
+                                    <option value="1960">
+                                        1960
+                                    </option>
+                                    <option value="1959">
+                                        1959
+                                    </option>
+                                    <option value="1958">
+                                        1958
+                                    </option>
+                                    <option value="1957">
+                                        1957
+                                    </option>
+                                    <option value="1956">
+                                        1956
+                                    </option>
+                                    <option value="1955">
+                                        1955
+                                    </option>
+                                    <option value="1954">
+                                        1954
+                                    </option>
+                                    <option value="1953">
+                                        1953
+                                    </option>
+                                    <option value="1952">
+                                        1952
+                                    </option>
+                                    <option value="1951">
+                                        1951
+                                    </option>
+                                    <option value="1950">
+                                        1950
+                                    </option>
+                                    <option value="1949">
+                                        1949
+                                    </option>
+                                    <option value="1948">
+                                        1948
+                                    </option>
+                                    <option value="1947">
+                                        1947
+                                    </option>
+                                    <option value="1946">
+                                        1946
+                                    </option>
+                                    <option value="1945">
+                                        1945
+                                    </option>
+                                    <option value="1944">
+                                        1944
+                                    </option>
+                                    <option value="1943">
+                                        1943
+                                    </option>
+                                    <option value="1942">
+                                        1942
+                                    </option>
+                                    <option value="1941">
+                                        1941
+                                    </option>
+                                    <option value="1940">
+                                        1940
+                                    </option>
+                                    <option value="1939">
+                                        1939
+                                    </option>
+                                    <option value="1938">
+                                        1938
+                                    </option>
+                                    <option value="1937">
+                                        1937
+                                    </option>
+                                    <option value="1936">
+                                        1936
+                                    </option>
+                                    <option value="1935">
+                                        1935
+                                    </option>
+                                    <option value="1934">
+                                        1934
+                                    </option>
+                                    <option value="1933">
+                                        1933
+                                    </option>
+                                    <option value="1932">
+                                        1932
+                                    </option>
+                                    <option value="1931">
+                                        1931
+                                    </option>
+                                    <option value="1930">
+                                        1930
+                                    </option>
+                                    <option value="1929">
+                                        1929
+                                    </option>
+                                    <option value="1928">
+                                        1928
+                                    </option>
+                                    <option value="1927">
+                                        1927
+                                    </option>
+                                    <option value="1926">
+                                        1926
+                                    </option>
+                                    <option value="1925">
+                                        1925
+                                    </option>
+                                    <option value="1924">
+                                        1924
+                                    </option>
+                                    <option value="1923">
+                                        1923
+                                    </option>
+                                    <option value="1922">
+                                        1922
+                                    </option>
+                                    <option value="1921">
+                                        1921
+                                    </option>
+                                    <option value="1920">
+                                        1920
+                                    </option>
+                                    <option value="1919">
+                                        1919
+                                    </option>
+                                    <option value="1918">
+                                        1918
+                                    </option>
+                                </b-select-stub>
+                            </b-field-stub>
+                        </div>
                     </div>
+                </header>
+                <div class="datepicker-content">
+                    <b-datepicker-table-stub daynames="Su,M,Tu,W,Th,F,S" monthnames="January,February,March,April,May,June,July,August,September,October,November,December" firstdayofweek="0" indicators="dots" focused="[object Object]" datecreator="function dateCreator() {}" nearbymonthdays="true" rulesforfirstweek="4"></b-datepicker-table-stub>
                 </div>
-            </header>
-            <div class="datepicker-content">
-                <b-datepicker-table-stub daynames="Su,M,Tu,W,Th,F,S" monthnames="January,February,March,April,May,June,July,August,September,October,November,December" firstdayofweek="0" indicators="dots" focused="[object Object]" datecreator="function dateCreator() {}" nearbymonthdays="true" rulesforfirstweek="4"></b-datepicker-table-stub>
             </div>
             <!---->
         </b-dropdown-item-stub>

--- a/src/components/datetimepicker/Datetimepicker.vue
+++ b/src/components/datetimepicker/Datetimepicker.vue
@@ -19,6 +19,7 @@
         :icon-pack="iconPack"
         :size="datepickerSize"
         :placeholder="placeholder"
+        :horizontal-time-picker = "horizontalTimePicker"
         :range="false"
         :disabled="disabled"
         :mobile-native="isMobileNative"
@@ -102,6 +103,7 @@ export default {
             default: false
         },
         placeholder: String,
+        horizontalTimePicker: Boolean,
         disabled: Boolean,
         icon: String,
         iconPack: String,

--- a/src/scss/components/_datepicker.scss
+++ b/src/scss/components/_datepicker.scss
@@ -193,4 +193,18 @@ $datepicker-item-selected-background-color: $primary !default;
     &.is-large {
         @include control-large;
     }
+    @media screen and (min-width: $desktop){
+        .footer-horizontal-timepicker {
+            border: none;
+            padding-left: 10px;
+            margin-left: 5px;
+            display: flex;
+        }
+        .dropdown-horizonal-timepicker {
+            display: flex;
+        }
+        .content-horizonal-timepicker {
+            border-right: 1px solid #dbdbdb;
+        }
+    }
 }


### PR DESCRIPTION
## Proposed Changes

- adds feature requested in #2253
- Implements prop horizontalTimePicker that when set to true will move the time picker from the bottom to the right side of the calendar.
- Whenever the size of the screen is to small that the pop up opens, the layout will move back to default.

## Preview
![Gravacao-de-Tela-2020-02-28-as-1](https://user-images.githubusercontent.com/49168228/75569739-77a01300-5a34-11ea-9ba1-358b46ec099e.gif)
