### PR TITLE
Fix #2285: Navbar dropdown not expanding on IE11

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -8,6 +8,7 @@ import VueProgressBar from 'vue-progressbar'
 import VueAnalytics from 'vue-analytics'
 import Bluebird from 'bluebird'
 import hljs from 'highlight.js'
+import { createNewEvent } from '../src/utils/helpers'
 
 import ApiView from './components/ApiView'
 import CodeView from './components/CodeView'
@@ -95,7 +96,7 @@ const root = new Vue({
     router,
     components: { App },
     mounted() {
-        document.dispatchEvent(new Event('render-event'))
+        document.dispatchEvent(createNewEvent('render-event'))
     },
     template: '<App/>'
 })

--- a/src/directives/clickOutside.js
+++ b/src/directives/clickOutside.js
@@ -47,7 +47,8 @@ function bind(el, { value }) {
 
 function update(el, { value }) {
     const { handler, middleware, events } = processArgs(value)
-    const instance = instances.find((instance) => instance.el === el)
+    // `filter` instead of `find` for compat with IE
+    const instance = instances.filter((instance) => instance.el === el)[0]
 
     instance.eventHandlers.forEach(({ event, handler }) =>
         document.removeEventListener(event, handler)
@@ -63,7 +64,8 @@ function update(el, { value }) {
 }
 
 function unbind(el) {
-    const instance = instances.find((instance) => instance.el === el)
+    // `filter` instead of `find` for compat with IE
+    const instance = instances.filter((instance) => instance.el === el)[0]
     instance.eventHandlers.forEach(({ event, handler }) =>
         document.removeEventListener(event, handler)
     )

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -135,3 +135,14 @@ export function multiColumnSort(inputArray, sortingPriority) {
 
     return array.sort(fieldSorter(sortingPriority))
 }
+
+export function createNewEvent(eventName) {
+    var event
+    if (typeof Event === 'function') {
+        event = new Event(eventName)
+    } else {
+        event = document.createEvent('Event')
+        event.initEvent(eventName, true, true)
+    }
+    return event
+}


### PR DESCRIPTION
**WIP**

Fixes #2285.

- [X] Address `Object doesn't support this action` error in docs by falling back to `document.createEvent` when `window.Event` is unavailable.
- [X] Address `"Object doesn't support property or method 'find'"` error in clickOutside.js directive by relying on Array.filter instead of Array.find.
- [ ] Fix actual toggling, which still wasn't resolved after addressing all JS errors.
