### PR TITLE
Feature Increase Focus On Slider

### DIFF
--- a/docs/pages/components/slider/api/slider.js
+++ b/docs/pages/components/slider/api/slider.js
@@ -98,6 +98,13 @@ export default [
                 type: 'String, Array',
                 values: '—',
                 default: '—'
+            },
+            {
+                name: '<code>bigger-slider-focus</code>',
+                description: 'Increase the clickable area',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
             }
         ],
         slots: [

--- a/src/components/slider/Slider.spec.js
+++ b/src/components/slider/Slider.spec.js
@@ -42,4 +42,12 @@ describe('BSlider', () => {
         wrapper.setProps({ step: 0.5 })
         expect(wrapper.vm.precision).toBe(1)
     })
+
+    describe('When biggerSliderFocus is set to true', () => {
+        it('renders a component with sliderFocus class', () => {
+            wrapper.setProps({biggerSliderFocus: true})
+            const subject = wrapper.find('.slider-focus')
+            expect(subject.exists()).toBeTruthy()
+        })
+    })
 })

--- a/src/components/slider/Slider.vue
+++ b/src/components/slider/Slider.vue
@@ -1,10 +1,10 @@
 <template>
     <div
         class="b-slider"
-        :class="[size, type, rootClasses]">
+        @click="onSliderClick"
+        :class="[size, type, rootClasses, {'slider-focus': biggerSliderFocus} ]">
         <div
             class="b-slider-track"
-            @click="onSliderClick"
             ref="slider">
             <div
                 class="b-slider-fill"
@@ -105,7 +105,11 @@ export default {
             default: false
         },
         customFormatter: Function,
-        ariaLabel: [String, Array]
+        ariaLabel: [String, Array],
+        biggerSliderFocus: {
+            type: Boolean,
+            default: false
+        }
     },
     data() {
         return {

--- a/src/scss/components/_slider.scss
+++ b/src/scss/components/_slider.scss
@@ -92,6 +92,14 @@ $slider-mark-size: 0.75rem !default;
         }
     }
 
+    &.slider-focus{
+        padding-top: 20px;
+        padding-bottom: 20px;
+        margin-top: -20px;
+        margin-bottom: -20px;
+        cursor: pointer;
+    }
+
     &.is-rounded {
         .b-slider-thumb {
             border-radius: $radius-rounded;


### PR DESCRIPTION
## Proposed Changes

- adds feature request in #2269 
- Implements prop biggerSliderFocus that will make the clickable area larger.
- The prop is default false, so if there is no need for making the click area bigger, it will be exactly the same as before

## Preview
![Gravacao-de-Tela-2020-03-05-as-1](https://user-images.githubusercontent.com/49168228/76020604-7d00d000-5f02-11ea-84d6-b2987c257de2.gif)
