### PR TITLE
Fix typos in tooltip multilined example

### DIFF
--- a/docs/pages/components/tooltip/examples/ExMultilined.vue
+++ b/docs/pages/components/tooltip/examples/ExMultilined.vue
@@ -9,7 +9,7 @@
         </b-tooltip>
 
         <b-tooltip
-            label="It's not briefy, but also not long enough"
+            label="It's not brief, but it's also not long"
             size="is-small"
             multilined>
             <button class="button is-dark">
@@ -18,7 +18,7 @@
         </b-tooltip>
 
         <b-tooltip
-            label="Tooltip large multilined, because it's really long to be on a medium size. Did I tell you it's really long? Yes, it is — I asure you!"
+            label="Tooltip large multilined, because it's too long to be on a medium size. Did I tell you it's really long? Yes, it is — I assure you!"
             position="is-bottom"
             size="is-large"
             multilined>


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

-Fix typos in tooltip multilined example

### Before

![tooltipsmall](https://user-images.githubusercontent.com/13753033/76031100-df9aa180-5eeb-11ea-9257-378c136d5d61.png)
![tooltiplarge](https://user-images.githubusercontent.com/13753033/76031109-e3c6bf00-5eeb-11ea-8886-cfc3940bbf9c.png)

### After

I wasn't able to get the docs server running on my local machine so I tried it on the codepen.

![tooltipsmallafter](https://user-images.githubusercontent.com/13753033/76031085-dad5ed80-5eeb-11ea-945c-ee0aae8e1ba7.png)
![tooltiplargafter](https://user-images.githubusercontent.com/13753033/76031093-dc9fb100-5eeb-11ea-9936-70cab4f9ca16.png)
