### PR TITLE
Make BTable sortable column header text non-selectable

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -71,7 +71,8 @@
                             :class="[column.headerClass, {
                                 'is-current-sort': currentSortColumn === column,
                                 'is-sortable': column.sortable,
-                                'is-sticky': column.sticky
+                                'is-sticky': column.sticky,
+                                'is-unselectable': !column.headerSelectable
                             }]"
                             :style="{
                                 width: column.width === undefined ? null :

--- a/src/components/table/TableColumn.vue
+++ b/src/components/table/TableColumn.vue
@@ -27,6 +27,10 @@ export default {
         subheading: [String, Number],
         customSort: Function,
         sticky: Boolean,
+        headerSelectable: {
+            type: Boolean,
+            default: true
+        },
         headerClass: String,
         cellClass: String,
         internal: Boolean // Used internally by Table

--- a/src/scss/components/_table.scss
+++ b/src/scss/components/_table.scss
@@ -69,6 +69,7 @@ $table-sticky-header-height: 300px !default;
             &.is-sortable,
             &.is-sortable .th-wrap {
                 cursor: pointer;
+                user-select: none;
             }
             .multi-sort-cancel-icon {
                 margin-left: 10px;

--- a/src/scss/components/_table.scss
+++ b/src/scss/components/_table.scss
@@ -69,7 +69,6 @@ $table-sticky-header-height: 300px !default;
             &.is-sortable,
             &.is-sortable .th-wrap {
                 cursor: pointer;
-                user-select: none;
             }
             .multi-sort-cancel-icon {
                 margin-left: 10px;


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #2301 

## Proposed Changes
Add `user-select: none;` to sortable table header to make it non-selectable.
