### PR TITLE
docs: correct input event param type in datepicker

### DIFF
--- a/docs/pages/components/datepicker/api/datepicker.js
+++ b/docs/pages/components/datepicker/api/datepicker.js
@@ -277,7 +277,7 @@ export default [
             {
                 name: '<code>input</code>',
                 description: 'Triggers when the value of datepicker is changed',
-                parameters: '<code>value: Number</code>'
+                parameters: '<code>value: Date</code>'
             },
             {
                 name: '<code>change-month</code>',


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- change parameters in docs (api/datepicker.js) 
-
-
