### PR TITLE
Prevented the regular sorting icon to appear if multi sorting is enab…

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -69,7 +69,7 @@
                             v-for="(column, index) in visibleColumns"
                             :key="index"
                             :class="[column.headerClass, {
-                                'is-current-sort': currentSortColumn === column,
+                                'is-current-sort': !sortMultiple && currentSortColumn === column,
                                 'is-sortable': column.sortable,
                                 'is-sticky': column.sticky,
                                 'is-unselectable': !column.headerSelectable
@@ -127,7 +127,7 @@
                                 </template>
 
                                 <b-icon
-                                    v-else-if="column.sortable"
+                                    v-else-if="column.sortable && !sortMultiple"
                                     :icon="sortIcon"
                                     :pack="iconPack"
                                     both


### PR DESCRIPTION
…led on tables

<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes an issue where an arrow would show up under the following condition:
When multi sort AND backend sorting is enabled
User presses column A, then column B and then pressing the delete button for column B, an arrow will show up because its the most recently sorted column.
This PR fixes that issue. 
## Proposed Changes

-
-
-
