### PR TITLE
docs: correct notification default position

### DIFF
--- a/docs/pages/components/notification/api/notification.js
+++ b/docs/pages/components/notification/api/notification.js
@@ -86,7 +86,7 @@ export default [
                 description: 'Which position the notification will appear when programmatically',
                 type: 'String',
                 values: '<code>is-top-right</code>, <code>is-top</code>, <code>is-top-left</code>, <code>is-bottom-right</code>, <code>is-bottom</code>, <code>is-bottom-left</code>',
-                default: '<code>is-bottom-right</code>'
+                default: '<code>is-top-right</code>'
             },
             {
                 name: '<code>queue</code>',


### PR DESCRIPTION
in [notification/index.js](https://github.com/buefy/buefy/blob/dev/src/components/notification/index.js#L20) is `is-top-right`

<!-- Thank you for helping Buefy! -->

<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- change props in api/notification.js
