### PR TITLE
Fix #595 : Add dropdownPosition prop to Autocomplete

### DIFF
--- a/docs/pages/components/autocomplete/api/autocomplete.js
+++ b/docs/pages/components/autocomplete/api/autocomplete.js
@@ -114,6 +114,13 @@ export default [
                 default: '<code>200px</code>'
             },
             {
+                name: '<code>dropdown-position</code>',
+                description: 'Position of dropdown',
+                type: 'String',
+                values: '<code>top</code>, <code>bottom</code>, <code>auto</code>',
+                default: '<code>auto</code>'
+            },
+            {
                 name: 'Any native attribute',
                 description: '—',
                 type: '—',

--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -32,7 +32,8 @@
         <transition name="fade">
             <div
                 class="dropdown-menu"
-                :class="{ 'is-opened-top': !isListInViewportVertically }"
+                :class="{ 'is-opened-top': dropdownPosition==='top' ||
+                (dropdownPosition==='auto' && !isListInViewportVertically ) }"
                 v-show="isActive && (data.length > 0 || hasEmptySlot || hasHeaderSlot)"
                 ref="dropdown">
                 <div
@@ -106,7 +107,11 @@ export default {
         checkInfiniteScroll: Boolean,
         keepOpen: Boolean,
         clearable: Boolean,
-        maxHeight: [String, Number]
+        maxHeight: [String, Number],
+        dropdownPosition: {
+            type: String,
+            default: 'auto'
+        }
     },
     data() {
         return {
@@ -198,15 +203,17 @@ export default {
          * to open upwards.
          */
         isActive(active) {
-            if (active) {
-                this.calcDropdownInViewportVertical()
-            } else {
-                this.$nextTick(() => this.setHovered(null))
-                // Timeout to wait for the animation to finish before recalculating
-                setTimeout(() => {
+            if (this.dropdownPosition === 'auto') {
+                if (active) {
                     this.calcDropdownInViewportVertical()
-                }, 100)
+                } else {
+                    // Timeout to wait for the animation to finish before recalculating
+                    setTimeout(() => {
+                        this.calcDropdownInViewportVertical()
+                    }, 100)
+                }
             }
+            if (active) this.$nextTick(() => this.setHovered(null))
         },
 
         /**
@@ -438,7 +445,7 @@ export default {
     created() {
         if (typeof window !== 'undefined') {
             document.addEventListener('click', this.clickedOutside)
-            window.addEventListener('resize', this.calcDropdownInViewportVertical)
+            if (this.dropdownPosition === 'auto') window.addEventListener('resize', this.calcDropdownInViewportVertical)
         }
     },
     mounted() {
@@ -450,7 +457,7 @@ export default {
     beforeDestroy() {
         if (typeof window !== 'undefined') {
             document.removeEventListener('click', this.clickedOutside)
-            window.removeEventListener('resize', this.calcDropdownInViewportVertical)
+            if (this.dropdownPosition === 'auto') window.removeEventListener('resize', this.calcDropdownInViewportVertical)
         }
         if (this.checkInfiniteScroll && this.$refs.dropdown && this.$refs.dropdown.querySelector('.dropdown-content')) {
             const list = this.$refs.dropdown.querySelector('.dropdown-content')

--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -32,8 +32,7 @@
         <transition name="fade">
             <div
                 class="dropdown-menu"
-                :class="{ 'is-opened-top': dropdownPosition==='top' ||
-                (dropdownPosition==='auto' && !isListInViewportVertically ) }"
+                :class="{ 'is-opened-top': isOpenedTop }"
                 v-show="isActive && (data.length > 0 || hasEmptySlot || hasHeaderSlot)"
                 ref="dropdown">
                 <div
@@ -195,6 +194,13 @@ export default {
                 maxHeight: this.maxHeight === undefined
                     ? null : (isNaN(this.maxHeight) ? this.maxHeight : this.maxHeight + 'px')
             }
+        },
+
+        /**
+         * Apply dropdownPosition property
+         */
+        isOpenedTop() {
+            return this.dropdownPosition === 'top' || (this.dropdownPosition === 'auto' && !this.isListInViewportVertically)
         }
     },
     watch: {

--- a/src/components/taginput/__snapshots__/Taginput.spec.js.snap
+++ b/src/components/taginput/__snapshots__/Taginput.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`BTaginput render correctly 1`] = `
 <div class="taginput control">
     <div class="taginput-container is-focusable">
-        <b-autocomplete-stub usehtml5validation="true" value="" data="" field="value" keepfirst="true"><template></template> <template></template> <template></template></b-autocomplete-stub>
+        <b-autocomplete-stub usehtml5validation="true" value="" data="" field="value" keepfirst="true" dropdownposition="auto"><template></template> <template></template> <template></template></b-autocomplete-stub>
     </div>
     <!---->
 </div>


### PR DESCRIPTION
Fixes #595 

## Proposed Changes
Add a `dropdown-position` prop to Autocomplete
Value can be set to `top`, `bottom `or `auto` with a default to current behavior `auto`

Sidenote: the current implementation (and not modified with this PR) of the calculated behavior would move the dropdown up if there is no room downside, but will not move it back down if the window is resized bigger