### PR TITLE
chore(toast): get position from params if given

### DIFF
--- a/src/components/toast/index.js
+++ b/src/components/toast/index.js
@@ -16,7 +16,7 @@ const ToastProgrammatic = {
         }
 
         const defaultParam = {
-            position: config.defaultToastPosition || 'is-top'
+            position: params.position || config.defaultToastPosition || 'is-top'
         }
         if (params.parent) {
             parent = params.parent


### PR DESCRIPTION
## Proposed Changes

I didn't globally integrated Buefy on my project, instead, I use it's components only if needed, so as ToastProgramming. But, I can't set the position if I do not integrate Buefy fully by setting the default position.

This solution solves my issue and makes ToastProgramming more flexible to use.
