### PR TITLE
Bugfix - fix close menu func not found

### DIFF
--- a/src/components/navbar/NavBarItem.spec.js
+++ b/src/components/navbar/NavBarItem.spec.js
@@ -4,6 +4,18 @@ import sinon from 'sinon'
 
 let wrapper
 
+const stubBNavBar = {
+    data() {
+        return {
+            _isNavBar: true
+        }
+    },
+    template: `
+        <div>
+            <slot />
+        </div>`
+}
+
 describe('BNavbarItem', () => {
     const tag = 'div'
     beforeEach(() => {
@@ -44,6 +56,9 @@ describe('BNavbarItem', () => {
     })
 
     it('close on escape', () => {
+        wrapper = shallowMount(BNavbarItem, {
+            parentComponent: stubBNavBar
+        })
         wrapper.vm.$parent.closeMenu = jest.fn()
         const event = new KeyboardEvent('keyup', {'keyCode': 27})
         wrapper.vm.keyPress({})
@@ -52,12 +67,15 @@ describe('BNavbarItem', () => {
     })
 
     it('manage click as expected', () => {
+        wrapper = shallowMount(BNavbarItem, {
+            parentComponent: stubBNavBar
+        })
         wrapper.vm.$parent.closeMenu = jest.fn()
         const event = new KeyboardEvent('click')
         wrapper.vm.handleClickEvent({
             ...event,
             target: { localName: 'a' }
         })
-        expect(wrapper.vm.$parent.closeMenu).toHaveBeenCalled()
+        expect(wrapper.vm.$parent.closeMenu).toHaveBeenCalledTimes(1)
     })
 })

--- a/src/components/navbar/Navbar.vue
+++ b/src/components/navbar/Navbar.vue
@@ -53,7 +53,8 @@ export default {
     },
     data() {
         return {
-            internalIsActive: this.isActive
+            internalIsActive: this.isActive,
+            _isNavBar: true // Used internally by NavbarItem
         }
     },
     computed: {

--- a/src/components/navbar/NavbarDropdown.vue
+++ b/src/components/navbar/NavbarDropdown.vue
@@ -56,7 +56,7 @@ export default {
         return {
             newActive: this.active,
             isHoverable: this.hoverable,
-            _isNavDropdown: true // Used internally by NavbarItem
+            _isNavbarDropdown: true // Used internally by NavbarItem
         }
     },
     watch: {

--- a/src/components/navbar/NavbarItem.vue
+++ b/src/components/navbar/NavbarItem.vue
@@ -42,8 +42,8 @@ export default {
         handleClickEvent(event) {
             const isOnWhiteList = clickableWhiteList.some((item) => item === event.target.localName)
             if (!isOnWhiteList) {
-                const parent = this.closeMenuRecursive(this, ['NavDropdown', 'NavBar'])
-                if (parent.$data._isNavDropdown) this.closeMenuRecursive(parent, ['NavBar'])
+                const parent = this.closeMenuRecursive(this, ['NavbarDropdown', 'NavBar'])
+                if (parent.$data._isNavbarDropdown) this.closeMenuRecursive(parent, ['NavBar'])
             }
         },
         /**

--- a/src/components/navbar/NavbarItem.vue
+++ b/src/components/navbar/NavbarItem.vue
@@ -42,13 +42,20 @@ export default {
         handleClickEvent(event) {
             const isOnWhiteList = clickableWhiteList.some((item) => item === event.target.localName)
             if (!isOnWhiteList) {
-                if (this.$parent.$data._isNavDropdown) {
-                    this.$parent.closeMenu()
-                    this.$parent.$parent.closeMenu()
-                } else {
-                    this.$parent.closeMenu()
-                }
+                const navDropDown = this.closeMenuRecursive(this, 'NavDropdown')
+                if (navDropDown) this.closeMenuRecursive(navDropDown, 'NavBar')
             }
+        },
+        /**
+         * Close parent recursively
+         */
+        closeMenuRecursive(current, targetComponentType) {
+            if (!current.$parent) return null
+            if (current.$parent.$data[`_is${targetComponentType}`]) {
+                current.$parent.closeMenu()
+                return current.$parent
+            }
+            return this.closeMenuRecursive(current.$parent, targetComponentType)
         }
     },
     mounted() {

--- a/src/components/navbar/NavbarItem.vue
+++ b/src/components/navbar/NavbarItem.vue
@@ -33,7 +33,7 @@ export default {
             // TODO: use code instead (because keyCode is actually deprecated)
             // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
             if (event.keyCode === 27) {
-                this.$parent.closeMenu()
+                this.closeMenuRecursive(this, ['NavBar'])
             }
         },
         /**
@@ -42,20 +42,23 @@ export default {
         handleClickEvent(event) {
             const isOnWhiteList = clickableWhiteList.some((item) => item === event.target.localName)
             if (!isOnWhiteList) {
-                const navDropDown = this.closeMenuRecursive(this, 'NavDropdown')
-                if (navDropDown) this.closeMenuRecursive(navDropDown, 'NavBar')
+                const parent = this.closeMenuRecursive(this, ['NavDropdown', 'NavBar'])
+                if (parent.$data._isNavDropdown) this.closeMenuRecursive(parent, ['NavBar'])
             }
         },
         /**
          * Close parent recursively
          */
-        closeMenuRecursive(current, targetComponentType) {
+        closeMenuRecursive(current, targetComponents) {
             if (!current.$parent) return null
-            if (current.$parent.$data[`_is${targetComponentType}`]) {
-                current.$parent.closeMenu()
-                return current.$parent
-            }
-            return this.closeMenuRecursive(current.$parent, targetComponentType)
+            const foundItem = targetComponents.reduce((acc, item) => {
+                if (current.$parent.$data[`_is${item}`]) {
+                    current.$parent.closeMenu()
+                    return current.$parent
+                }
+                return acc
+            }, null)
+            return foundItem || this.closeMenuRecursive(current.$parent, targetComponents)
         }
     },
     mounted() {


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->
Hi, nice to meet you. I'm often using Buefy and thanks for maintainers.
Could you plz review this PR in your free time. Thank you.

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
I used b-navbar, b-navbar-dropdown and b-navbar-item like below.

```
  <b-navbar>
    <template v-slot:brand>
      <SlotBrand></SlotBrand> // my component which includes b-navbar-item
    </template>
    <template v-slot:end>
      <SlotEnd></SlotEnd> // my component which includes b-navbar-dropdown and b-navbar-item
    </template>
  </b-navbar>
```

And I met below error.
![image](https://user-images.githubusercontent.com/3145781/77992524-323b7200-7361-11ea-8eee-92623b84cd92.png)

I inspected the behavior and found that b-navbar-item component cannot find their parent beyond their own component.

## Proposed Changes
- Search recursively their parent.
- When the b-navbar component was found, finish search.
- When the b-navbar-dropdown component was found, restart search to find b-navbar component.
- Also when we could not find $parent, finish search.

It seems going well on my environment.