### PR TITLE
Add a prop `step` to use string in markers

### DIFF
--- a/docs/pages/components/steps/api/steps.js
+++ b/docs/pages/components/steps/api/steps.js
@@ -134,6 +134,13 @@ export default [
         title: 'Step Item',
         props: [
             {
+                name: '<code>step</code>',
+                description: 'Step marker content (when there is no icon)',
+                type: 'String',
+                values: '—',
+                default: '—'
+            },
+            {
                 name: '<code>label</code>',
                 description: 'Step label',
                 type: 'String',

--- a/docs/pages/components/steps/examples/ExSimple.vue
+++ b/docs/pages/components/steps/examples/ExSimple.vue
@@ -38,22 +38,22 @@
             :icon-prev="prevIcon"
             :icon-next="nextIcon"
             :label-position="labelPosition">
-            <b-step-item label="Account" :clickable="isStepsClickable">
+            <b-step-item step="1" label="Account" :clickable="isStepsClickable">
                 <h1 class="title has-text-centered">Account</h1>
                 Lorem ipsum dolor sit amet.
             </b-step-item>
 
-            <b-step-item label="Profile" :clickable="isStepsClickable" :type="{'is-success': isProfileSuccess}">
+            <b-step-item step="2" label="Profile" :clickable="isStepsClickable" :type="{'is-success': isProfileSuccess}">
                 <h1 class="title has-text-centered">Profile</h1>
                 Lorem ipsum dolor sit amet.
             </b-step-item>
 
-            <b-step-item :visible="showSocial" label="Social" :clickable="isStepsClickable">
+            <b-step-item step="3" :visible="showSocial" label="Social" :clickable="isStepsClickable">
                 <h1 class="title has-text-centered">Social</h1>
                 Lorem ipsum dolor sit amet.
             </b-step-item>
 
-            <b-step-item label="Finish" :clickable="isStepsClickable" disabled>
+            <b-step-item :step="showSocial ? 4 : 3" label="Finish" :clickable="isStepsClickable" disabled>
                 <h1 class="title has-text-centered">Finish</h1>
                 Lorem ipsum dolor sit amet.
             </b-step-item>

--- a/src/components/steps/StepItem.vue
+++ b/src/components/steps/StepItem.vue
@@ -2,6 +2,7 @@
 export default {
     name: 'BStepItem',
     props: {
+        step: String,
         label: String,
         type: String | Object,
         icon: String,

--- a/src/components/steps/Steps.vue
+++ b/src/components/steps/Steps.vue
@@ -21,6 +21,7 @@
                                 :icon="stepItem.icon"
                                 :pack="stepItem.iconPack"
                                 :size="size"/>
+                            <span v-else-if="stepItem.step">{{ stepItem.step }}</span>
                         </div>
                         <div class="step-details">
                             <span class="step-title">{{ stepItem.label }}</span>

--- a/src/scss/components/_steps.scss
+++ b/src/scss/components/_steps.scss
@@ -150,6 +150,7 @@ $steps-vertical-padding: 1em 0 !default;
                     color: $white;
                     border: $steps-marker-default-border;
                     z-index: 1;
+                    overflow: hidden;
                 }
 
                 // Override marker color per step


### PR DESCRIPTION

## Proposed Changes

- Add a prop `step` to use string in markers
- Can use numeric or alphabetical values as step marker content

### Example
![image](https://user-images.githubusercontent.com/12817388/78569397-92af3100-77f1-11ea-844e-25c36c87d612.png)
