### PR TITLE
Use $radius SASS variable for Step marker

### DIFF
--- a/docs/pages/components/steps/api/steps.js
+++ b/docs/pages/components/steps/api/steps.js
@@ -91,6 +91,13 @@ export default [
                 default: '<code>bottom</code>'
             },
             {
+                name: '<code>rounded</code>',
+                description: 'Rounded step markers',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>true</code>'
+            },
+            {
                 name: '<code>aria-page-label</code>',
                 description: 'Accessibility label for the page link. If passed, this text will be prepended to the number of the page.',
                 type: 'String',

--- a/docs/pages/components/steps/examples/ExSimple.vue
+++ b/docs/pages/components/steps/examples/ExSimple.vue
@@ -3,6 +3,7 @@
         <div class="block">
             <b-switch v-model="showSocial"> Show Social step </b-switch>
             <b-switch v-model="isAnimated"> Animated </b-switch>
+            <b-switch v-model="isRounded"> Rounded </b-switch>
             <b-switch v-model="isStepsClickable"> Clickable Marker </b-switch>
         </div>
         <div class="block">
@@ -34,6 +35,7 @@
         <b-steps
             v-model="activeStep"
             :animated="isAnimated"
+            :rounded="isRounded"
             :has-navigation="hasNavigation"
             :icon-prev="prevIcon"
             :icon-next="nextIcon"
@@ -90,15 +92,19 @@
         data() {
             return {
                 activeStep: 0,
+
                 showSocial: false,
                 isAnimated: true,
+                isRounded: true,
+                isStepsClickable: false,
+
                 hasNavigation: true,
                 customNavigation: false,
+                isProfileSuccess: false,
+
                 prevIcon: 'chevron-left',
                 nextIcon: 'chevron-right',
-                labelPosition: 'bottom',
-                isStepsClickable: false,
-                isProfileSuccess: false
+                labelPosition: 'bottom'
             }
         }
     }

--- a/docs/pages/components/switch/api/switch.js
+++ b/docs/pages/components/switch/api/switch.js
@@ -65,7 +65,7 @@ export default [
                 description: 'Rounded style',
                 type: 'Boolean',
                 values: '—',
-                default: '<code>false</code>'
+                default: '<code>true</code>'
             },
             {
                 name: '<code>outlined</code>',

--- a/src/components/steps/Steps.vue
+++ b/src/components/steps/Steps.vue
@@ -123,6 +123,10 @@ export default {
             },
             default: 'bottom'
         },
+        rounded: {
+            type: Boolean,
+            default: true
+        },
         ariaNextLabel: String,
         ariaPreviousLabel: String
     },
@@ -151,7 +155,8 @@ export default {
                 {
                     'has-label-right': this.labelPosition === 'right',
                     'has-label-left': this.labelPosition === 'left',
-                    'is-animated': this.animated
+                    'is-animated': this.animated,
+                    'is-rounded': this.rounded
                 }
             ]
         },

--- a/src/components/steps/__snapshots__/Steps.spec.js.snap
+++ b/src/components/steps/__snapshots__/Steps.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BSteps render correctly 1`] = `
 <div class="b-steps">
-    <nav class="steps is-animated">
+    <nav class="steps is-animated is-rounded">
         <ul class="step-items">
             <li class="step-item is-active"><a class="step-link is-clickable">
                     <div class="step-marker">

--- a/src/components/switch/Switch.vue
+++ b/src/components/switch/Switch.vue
@@ -73,9 +73,11 @@ export default {
         newClass() {
             return [
                 this.size,
-                { 'is-disabled': this.disabled },
-                { 'is-rounded': this.rounded },
-                { 'is-outlined': this.outlined }
+                {
+                    'is-disabled': this.disabled,
+                    'is-rounded': this.rounded,
+                    'is-outlined': this.outlined
+                }
             ]
         }
     },

--- a/src/scss/components/_steps.scss
+++ b/src/scss/components/_steps.scss
@@ -143,7 +143,7 @@ $steps-vertical-padding: 1em 0 !default;
                 .step-marker {
                     align-items: center;
                     display: flex;
-                    border-radius: 50%;
+                    border-radius: $radius;
                     font-weight: $weight-bold;
                     justify-content: center;
                     background: $steps-maker-default-color;
@@ -276,6 +276,14 @@ $steps-vertical-padding: 1em 0 !default;
             }
             &.is-transitioning {
                 overflow: hidden;
+            }
+        }
+
+        &.is-rounded {
+            .step-item {
+                .step-marker {
+                    border-radius: $radius-rounded;
+                }
             }
         }
 


### PR DESCRIPTION
## Proposed Changes

- Use $radius SASS variable for Step marker
- Add `rounded` prop (default `true`)
- This adds a squared markers variant

![captured (1)](https://user-images.githubusercontent.com/12817388/78800894-fff5ca00-7989-11ea-9bc5-20b71222381d.gif)

