### PR TITLE
Document that table column width could use any unit, not only pixels

### DIFF
--- a/docs/pages/components/table/api/table.js
+++ b/docs/pages/components/table/api/table.js
@@ -573,7 +573,7 @@ export default [
             },
             {
                 name: '<code>width</code>',
-                description: 'Column fixed width in pixels',
+                description: 'Column fixed width in any unit, or pixels when none is provided',
                 type: 'Number, String',
                 values: '—',
                 default: '—'


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Documents the improvement added on https://github.com/buefy/buefy/pull/1827