### PR TITLE
Fixing Icon type to account for colors that are hyphenated. (Ex. "is-…

### DIFF
--- a/src/components/icon/Icon.vue
+++ b/src/components/icon/Icon.vue
@@ -67,7 +67,8 @@ export default {
             }
             if (splitType.length <= 1) return
 
-            return `has-text-${splitType[1]}`
+            const [, ...type] = splitType
+            return `has-text-${type.join('-')}`
         },
         newCustomSize() {
             return this.customSize || this.customSizeByPack


### PR DESCRIPTION
…grey-dark")

<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #2395 

## Proposed Changes

- Use ES6 spread operator to get all parts of `splitType` except "is" prefix.
- Join resulting parts into return value for Icon type.
