### PR TITLE
DatePicker fix for Safari

### DIFF
--- a/src/components/datepicker/Datepicker.spec.js
+++ b/src/components/datepicker/Datepicker.spec.js
@@ -114,7 +114,7 @@ describe('BDatepicker', () => {
         wrapper.vm.onChangeNativePicker({ target: { value: '' } })
         expect(wrapper.vm.updateInternalState).toHaveBeenCalledWith(null)
         expect(wrapper.vm.togglePicker).toHaveBeenCalled()
-        expect(wrapper.emitted()['input']).toBeFalsy()
+        expect(wrapper.emitted()['input']).toBeNull()
     })    
     
     it('react accordingly when changing v-model', () => {

--- a/src/components/datepicker/Datepicker.spec.js
+++ b/src/components/datepicker/Datepicker.spec.js
@@ -114,7 +114,7 @@ describe('BDatepicker', () => {
         wrapper.vm.onChangeNativePicker({ target: { value: '' } })
         expect(wrapper.vm.updateInternalState).toHaveBeenCalledWith(null)
         expect(wrapper.vm.togglePicker).toHaveBeenCalled()
-        expect(wrapper.emitted()['input']).toBeNull()
+        expect(wrapper.emitted()['input']).toEqual([null])
     })    
     
     it('react accordingly when changing v-model', () => {

--- a/src/components/datepicker/Datepicker.spec.js
+++ b/src/components/datepicker/Datepicker.spec.js
@@ -103,7 +103,7 @@ describe('BDatepicker', () => {
     })
 
     it('react accordingly when handling native picker', () => {
-        const date = new Date(2020, 0, 1, 12)
+        const date = new Date(2020, 0, 1)
         wrapper.vm.onChangeNativePicker({ target: { value: '2020-01-01' } })
         expect(wrapper.vm.updateInternalState).toHaveBeenCalledWith(date)
         expect(wrapper.vm.togglePicker).toHaveBeenCalled()

--- a/src/components/datepicker/Datepicker.spec.js
+++ b/src/components/datepicker/Datepicker.spec.js
@@ -115,8 +115,8 @@ describe('BDatepicker', () => {
         expect(wrapper.vm.updateInternalState).toHaveBeenCalledWith(null)
         expect(wrapper.vm.togglePicker).toHaveBeenCalled()
         expect(wrapper.emitted()['input']).toEqual([[null]])
-    })    
-    
+    })
+
     it('react accordingly when changing v-model', () => {
         const date = new Date()
         wrapper.setProps({

--- a/src/components/datepicker/Datepicker.spec.js
+++ b/src/components/datepicker/Datepicker.spec.js
@@ -114,7 +114,7 @@ describe('BDatepicker', () => {
         wrapper.vm.onChangeNativePicker({ target: { value: '' } })
         expect(wrapper.vm.updateInternalState).toHaveBeenCalledWith(null)
         expect(wrapper.vm.togglePicker).toHaveBeenCalled()
-        expect(wrapper.emitted()['input']).toEqual([null])
+        expect(wrapper.emitted()['input']).toEqual([[null]])
     })    
     
     it('react accordingly when changing v-model', () => {

--- a/src/components/datepicker/Datepicker.spec.js
+++ b/src/components/datepicker/Datepicker.spec.js
@@ -102,6 +102,21 @@ describe('BDatepicker', () => {
         expect(wrapper.emitted()['input']).toBeTruthy()
     })
 
+    it('react accordingly when handling native picker', () => {
+        const date = new Date(2020, 0, 1, 12)
+        wrapper.vm.onChangeNativePicker({ target: { value: '2020-01-01' } })
+        expect(wrapper.vm.updateInternalState).toHaveBeenCalledWith(date)
+        expect(wrapper.vm.togglePicker).toHaveBeenCalled()
+        expect(wrapper.emitted()['input']).toBeTruthy()
+    })
+
+    it('react accordingly when handling native picker clear', () => {
+        wrapper.vm.onChangeNativePicker({ target: { value: '' } })
+        expect(wrapper.vm.updateInternalState).toHaveBeenCalledWith(null)
+        expect(wrapper.vm.togglePicker).toHaveBeenCalled()
+        expect(wrapper.emitted()['input']).toBeFalsy()
+    })    
+    
     it('react accordingly when changing v-model', () => {
         const date = new Date()
         wrapper.setProps({

--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -682,7 +682,7 @@ export default {
                 const year = parseInt(s[0], 10)
                 const month = parseInt(s[1]) - 1
                 const day = parseInt(s[2])
-                this.computedValue = new Date(year, month, day, 12)
+                this.computedValue = new Date(year, month, day)
             } else {
                 this.computedValue = null
             }

--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -677,9 +677,16 @@ export default {
         */
         onChangeNativePicker(event) {
             const date = event.target.value
-            this.computedValue = date ? new Date(date + 'T00:00:00') : null
+            const s = date ? date.split('-') : []
+            if (s.length === 3) {
+                const year = parseInt(s[0], 10)
+                const month = parseInt(s[1]) - 1
+                const day = parseInt(s[2])
+                this.computedValue = new Date(year, month, day, 12)
+            } else {
+                this.computedValue = null
+            }
         },
-
         updateInternalState(value) {
             const currentDate = Array.isArray(value)
                 ? (!value.length ? this.dateCreator() : value[0])

--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -216,10 +216,7 @@ import DatepickerMonth from './DatepickerMonth'
 const defaultDateFormatter = (date, vm) => {
     const targetDates = Array.isArray(date) ? date : [date]
     const dates = targetDates.map((date) => {
-        const yyyyMMdd = date.getFullYear() +
-            '/' + (date.getMonth() + 1) +
-            '/' + date.getDate()
-        const d = new Date(yyyyMMdd)
+        const d = new Date(date.getFullYear(), date.getMonth(), date.getDate(), 12)
         return !vm.isTypeMonth ? d.toLocaleDateString()
             : d.toLocaleDateString(undefined, { year: 'numeric', month: '2-digit' })
     })


### PR DESCRIPTION
Update the defaultDateFormatter in the datepicker to handle dates far in the past on Safari (iOS and OS X). 

Fixes #1957

## Proposed Changes

- In DatePicker.vue:defaultDateFormatter - when constructing a new Date object for the purposes of locale formatting it, construct it against noon local time instead of midnight so that DST bugs in browser JS implementations (Safari currently) that cause the time to be off by an hour or so don't actually change the date. 
