### PR TITLE
fixes #2444: Use newline char w/ white-space:pre-wrap to avoid use of…

### DIFF
--- a/src/components/field/Field.spec.js
+++ b/src/components/field/Field.spec.js
@@ -91,7 +91,7 @@ describe('BField', () => {
             expect(wrapper.find('p.help').html()).toContain(message.join('\n'))
         })
 
-        it('given an object as message, it grabs the keys and joins them with new lines', () => {
+        it('given an object as message, it grabs the keys and joins them with newline characters', () => {
             const message = {
                 message1: 'Some string message 1',
                 message2: 'Some string message 2',

--- a/src/components/field/Field.spec.js
+++ b/src/components/field/Field.spec.js
@@ -78,7 +78,7 @@ describe('BField', () => {
             expect(wrapper.find('.field').find('p.help').text()).toEqual(message)
         })
 
-        it('given an array of string as message, it joins the messages with line breaks', () => {
+        it('given an array of string as message, it joins the messages with newline characters', () => {
             const message = [
                 'Some string message 1',
                 'Some string message 2',
@@ -88,10 +88,10 @@ describe('BField', () => {
             ]
             const mountOptions = generateMountOptions({message})
             const wrapper = shallowMount(BField, mountOptions)
-            expect(wrapper.find('p.help').html()).toContain(message.join(' <br> '))
+            expect(wrapper.find('p.help').html()).toContain(message.join('\n'))
         })
 
-        it('given an object as message, it grabs the keys and joins them with line breaks', () => {
+        it('given an object as message, it grabs the keys and joins them with new lines', () => {
             const message = {
                 message1: 'Some string message 1',
                 message2: 'Some string message 2',
@@ -101,11 +101,11 @@ describe('BField', () => {
             }
             const mountOptions = generateMountOptions({message})
             const wrapper = shallowMount(BField, mountOptions)
-            expect(wrapper.find('p.help').html()).toContain(Object.keys(message).join(' <br> '))
+            expect(wrapper.find('p.help').html()).toContain(Object.keys(message).join('\n'))
         })
 
         it(`given an array of string with an object as one of the elements as message, it grabs the
-        keys of the object and joins them with the messages with line breaks`, () => {
+        keys of the object and joins them with the messages with newline characters`, () => {
             const message = [
                 'Some string message 1',
                 {
@@ -123,7 +123,7 @@ describe('BField', () => {
                 'message3',
                 message[2],
                 message[3]
-            ].join(' <br> '))
+            ].join('\n'))
         })
     })
 

--- a/src/components/field/Field.vue
+++ b/src/components/field/Field.vue
@@ -34,10 +34,8 @@
         </template>
         <p
             v-if="newMessage && !horizontal"
-            v-html="formattedMessage"
             class="help"
-            :class="newType"
-        />
+            :class="newType">{{ formattedMessage }}</p>
     </div>
 </template>
 
@@ -112,7 +110,7 @@ export default {
         },
         /**
         * Formatted message in case it's an array
-        * (each element is separated by <br> tag)
+        * (each element is separated by new line)
         */
         formattedMessage() {
             if (typeof this.newMessage === 'string') {
@@ -138,7 +136,7 @@ export default {
                         }
                     }
                 }
-                return messages.filter((m) => { if (m) return m }).join(' <br> ')
+                return messages.filter((m) => { if (m) return m }).join('\n')
             }
         },
         hasLabel() {

--- a/src/scss/components/_form.scss
+++ b/src/scss/components/_form.scss
@@ -64,6 +64,10 @@ $floating-in-height: 3.25em !default;
             }
         }
     }
+
+    .help {
+        white-space: pre-wrap;
+    }
 }
 
 .field {
@@ -268,7 +272,6 @@ $floating-in-height: 3.25em !default;
     .help.counter {
         float: right;
         margin-left: 0.5em;
-        white-space: pre-wrap;
     }
     .icon {
         &.is-clickable {

--- a/src/scss/components/_form.scss
+++ b/src/scss/components/_form.scss
@@ -268,6 +268,7 @@ $floating-in-height: 3.25em !default;
     .help.counter {
         float: right;
         margin-left: 0.5em;
+        white-space: pre-wrap;
     }
     .icon {
         &.is-clickable {


### PR DESCRIPTION
Fixes #2444

## Proposed Changes

Using white-space: pre-wrap along with \n provides the same behavior as <br> without the need to parse the HTML. This eliminates the need for using v-html which is susceptible to XSS.

Thank you for the great work. My team and I love Buefy. :)