### PR TITLE
Add a new display mode for step in mobile

### DIFF
--- a/docs/pages/components/steps/api/steps.js
+++ b/docs/pages/components/steps/api/steps.js
@@ -98,6 +98,15 @@ export default [
                 default: '<code>true</code>'
             },
             {
+                name: '<code>mobile mode</code>',
+                description: 'How Steps will be displayed for mobile user',
+                type: 'String',
+                values: `<code>minimalist</code>: Only the active Step is displayed,
+                    <code>compact</code>: Step label is displayed only for the active,
+                    <code>null</code>: Will keep the same behavior as desktop`,
+                default: '<code>minimalist</code>'
+            },
+            {
                 name: '<code>aria-page-label</code>',
                 description: 'Accessibility label for the page link. If passed, this text will be prepended to the number of the page.',
                 type: 'String',

--- a/docs/pages/components/steps/examples/ExSimple.vue
+++ b/docs/pages/components/steps/examples/ExSimple.vue
@@ -45,6 +45,13 @@
                     <option value="left">Left</option>
                 </b-select>
             </b-field>
+            <b-field label="Mobile mode" class="is-hidden-desktop">
+                <b-select v-model="mobileMode">
+                    <option :value="null">-</option>
+                    <option value="minimalist">Minimalist</option>
+                    <option value="compact">Compact</option>
+                </b-select>
+            </b-field>
         </b-field>
         <b-steps
             v-model="activeStep"
@@ -53,7 +60,8 @@
             :has-navigation="hasNavigation"
             :icon-prev="prevIcon"
             :icon-next="nextIcon"
-            :label-position="labelPosition">
+            :label-position="labelPosition"
+            :mobile-mode="mobileMode">
             <b-step-item step="1" label="Account" :clickable="isStepsClickable">
                 <h1 class="title has-text-centered">Account</h1>
                 Lorem ipsum dolor sit amet.
@@ -118,7 +126,9 @@
 
                 prevIcon: 'chevron-left',
                 nextIcon: 'chevron-right',
-                labelPosition: 'bottom'
+                labelPosition: 'bottom',
+
+                mobileMode: 'minimalist'
             }
         }
     }

--- a/src/components/steps/Steps.vue
+++ b/src/components/steps/Steps.vue
@@ -107,6 +107,16 @@ export default {
             type: Boolean,
             default: true
         },
+        mobileMode: {
+            type: String,
+            validator(value) {
+                return [
+                    'minimalist',
+                    'compact'
+                ].indexOf(value) > -1
+            },
+            default: 'minimalist'
+        },
         ariaNextLabel: String,
         ariaPreviousLabel: String
     },
@@ -132,7 +142,8 @@ export default {
                     'has-label-right': this.labelPosition === 'right',
                     'has-label-left': this.labelPosition === 'left',
                     'is-animated': this.animated,
-                    'is-rounded': this.rounded
+                    'is-rounded': this.rounded,
+                    [`mobile-${this.mobileMode}`]: this.mobileMode !== null
                 }
             ]
         },

--- a/src/components/steps/__snapshots__/Steps.spec.js.snap
+++ b/src/components/steps/__snapshots__/Steps.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BSteps render correctly 1`] = `
 <div class="b-steps">
-    <nav class="steps is-animated is-rounded">
+    <nav class="steps is-animated is-rounded mobile-minimalist">
         <ul class="step-items">
             <li class="step-item is-active"><a class="step-link is-clickable">
                     <div class="step-marker">

--- a/src/scss/components/_steps.scss
+++ b/src/scss/components/_steps.scss
@@ -12,6 +12,7 @@ $steps-previous-color: $primary !default;
 $steps-active-color: $primary !default;
 $steps-divider-height: .2em !default;
 $steps-vertical-padding: 1em 0 !default;
+$steps-mobile-max-width: $tablet !default;
 
 @mixin steps-size($size) {
     .steps {
@@ -50,7 +51,7 @@ $steps-vertical-padding: 1em 0 !default;
                     }
                 }
 
-                @include until($tablet) {
+                @include until($steps-mobile-max-width) {
                     &::before, &::after, &:not(:first-child)::before {
                         top: #{$size};
                     }
@@ -417,26 +418,39 @@ $steps-vertical-padding: 1em 0 !default;
     }
     &:not(.is-vertical) {
         .steps {
-            .step-items {
-                .step-item{
-                    @include until($tablet) {
-                        &:not(.is-active) {
-                            display: none;
-                        }
+            @include until($steps-mobile-max-width) {
+                &.mobile-minimalist {
+                    .step-items {
+                        .step-item {
+                            &:not(.is-active) {
+                                display: none;
+                            }
 
-                        &::before, &::after, &:not(:first-child)::before {
-                            // This will contain the divider
-                            content: " ";
-                            display: block;
-                            position: absolute;
-                            height: $steps-divider-height;
-                            width: 25%;
-                            bottom: 0;
-                            left: 50%;
+                            &::before, &::after, &:not(:first-child)::before {
+                                // This will contain the divider
+                                content: " ";
+                                display: block;
+                                position: absolute;
+                                height: $steps-divider-height;
+                                width: 25%;
+                                bottom: 0;
+                                left: 50%;
+                            }
+                            &::before, &:not(:first-child)::before {
+                                right: 50%;
+                                left: auto;
+                            }
                         }
-                        &::before, &:not(:first-child)::before {
-                            right: 50%;
-                            left: auto;
+                    }
+                }
+                &.mobile-compact {
+                    .step-items {
+                        .step-item {
+                            &:not(.is-active) {
+                                .step-details {
+                                    display: none;
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #2434
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- minimalist: the current way of displaying mobile steps
- compact: display every step, but keep only the active label
- null: will not apply any specific style for mobile
