### PR TITLE
Add scrollable and max-height to b-dropdown

### DIFF
--- a/docs/pages/components/dropdown/Dropdown.vue
+++ b/docs/pages/components/dropdown/Dropdown.vue
@@ -26,6 +26,15 @@
             <p>Add the <code>multiple</code> prop to select one or more item.</p>
         </Example>
 
+        <Example :component="ExCustomizeScrollable" :code="ExCustomizeScrollableCode" title="Scrollable">
+            <div class="tags has-addons">
+                <span class="tag is-success">Since</span>
+                <span class="tag is-info">0.x.x</span>
+            </div>
+            <p>Add the <code>scrollable</code> prop to make the list scollable.</p>
+            <p>When the <code>scrollable</code> prop is set to <code>true</code>, use the <code>max-height</code> prop to define the max height of the list.</p>
+        </Example>
+
         <ApiView :data="api"/>
         <VariablesView :data="variables"/>
     </div>
@@ -50,6 +59,9 @@
     import ExCustomizeMultiple from './examples/ExCustomizeMultiple'
     import ExCustomizeMultipleCode from '!!raw-loader!./examples/ExCustomizeMultiple'
 
+    import ExCustomizeScrollable from './examples/ExCustomizeScrollable'
+    import ExCustomizeScrollableCode from '!!raw-loader!./examples/ExCustomizeScrollable'
+
     export default {
         data() {
             return {
@@ -64,7 +76,9 @@
                 ExCustomize,
                 ExCustomizeCode,
                 ExCustomizeMultiple,
-                ExCustomizeMultipleCode
+                ExCustomizeMultipleCode,
+                ExCustomizeScrollable,
+                ExCustomizeScrollableCode
             }
         }
     }

--- a/docs/pages/components/dropdown/api/dropdown.js
+++ b/docs/pages/components/dropdown/api/dropdown.js
@@ -59,6 +59,20 @@ export default [
                 default: '<code>false</code>'
             },
             {
+                name: '<code>scrollable</code>',
+                description: 'Dropdown content will be scrollable',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
+                name: '<code>max-height</code>',
+                description: 'Max height of dropdown content',
+                type: 'String, Number',
+                values: '—',
+                default: '<code>200px</code>'
+            },
+            {
                 name: '<code>aria-role</code>',
                 description: 'Role attribute to be passed to list container for better accessibility. Use <code>menu</code> only in situations where your dropdown is related to navigation menus.',
                 type: 'String',

--- a/docs/pages/components/dropdown/examples/ExCustomizeScrollable.vue
+++ b/docs/pages/components/dropdown/examples/ExCustomizeScrollable.vue
@@ -1,0 +1,64 @@
+<template>
+    <section>
+        <b-field>
+            <div class="control">
+                <b-switch v-model="isScrollable">Scrollable</b-switch>
+            </div>
+        </b-field>
+        <b-field label="Max Height">
+            <b-slider v-model="maxHeight" size="is-medium" :min="50" :max="250" rounded :disabled="!isScrollable">
+                <template v-for="val in [100, 150, 200]">
+                    <b-slider-tick :value="val" :key="val">{{ val }}</b-slider-tick>
+                </template>
+            </b-slider>
+        </b-field>
+        
+        <b-dropdown
+            :scrollable="isScrollable"
+            :max-height="maxHeight"
+            v-model="currentMenu"
+            aria-role="list"
+        >
+            <button class="button is-primary" type="button" slot="trigger">
+                <template>
+                    <b-icon :icon="currentMenu.icon"></b-icon>
+                    <span>{{currentMenu.text}}</span>
+                </template>
+                <b-icon icon="menu-down"></b-icon>
+            </button>
+
+            <b-dropdown-item 
+                v-for="(menu, index) in menus"
+                :key="index"
+                :value="menu" aria-role="listitem">
+                <div class="media">
+                    <b-icon class="media-left" :icon="menu.icon"></b-icon>
+                    <div class="media-content">
+                        <h3>{{menu.text}}</h3>
+                    </div>
+                </div>
+            </b-dropdown-item>
+        </b-dropdown>
+    </section>
+</template>
+
+<script>
+    export default {
+        data() {
+            return {
+                isScrollable: false,
+                maxHeight: 200,
+                currentMenu: { icon: 'account-group', text: 'people' },
+                menus: [
+                    { icon: 'account-group', text: 'people' },
+                    { icon: 'shopping-search', text: 'Orders' },
+                    { icon: 'credit-card-multiple', text: 'Payments' },
+                    { icon: 'dolly', text: 'Logistics' },
+                    { icon: 'clock-check', text: 'Jobs' },
+                    { icon: 'cart-arrow-right', text: 'Cart' },
+                    { icon: 'settings', text: 'Configuration' }
+                ]
+            }
+        }
+    }
+</script>

--- a/src/components/clockpicker/__snapshots__/Clockpicker.spec.js.snap
+++ b/src/components/clockpicker/__snapshots__/Clockpicker.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BClockpicker render correctly 1`] = `
 <div class="b-clockpicker control is-primary">
-    <b-dropdown-stub mobilemodal="true" animation="fade" trapfocus="true" closeonclick="true" canclose="true" appendtobodycopyparent="true">
+    <b-dropdown-stub maxheight="200" mobilemodal="true" animation="fade" trapfocus="true" closeonclick="true" canclose="true" appendtobodycopyparent="true">
         <b-input-stub autocomplete="off" usehtml5validation="true" type="text" hascounter="true" customclass="" readonly="true"></b-input-stub>
         <div custom="" class="card">
             <!---->

--- a/src/components/datepicker/__snapshots__/Datepicker.spec.js.snap
+++ b/src/components/datepicker/__snapshots__/Datepicker.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BDatepicker render correctly 1`] = `
 <div class="datepicker control">
-    <b-dropdown-stub mobilemodal="true" ariarole="dialog" animation="fade" trapfocus="true" closeonclick="true" canclose="true" appendtobodycopyparent="true" aria-modal="true">
+    <b-dropdown-stub maxheight="200" mobilemodal="true" ariarole="dialog" animation="fade" trapfocus="true" closeonclick="true" canclose="true" appendtobodycopyparent="true" aria-modal="true">
         <b-input-stub autocomplete="off" type="text" hascounter="true" customclass="" readonly="true"></b-input-stub>
         <b-dropdown-item-stub custom="true" focusable="true" ariarole="" class="">
             <div>

--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -33,7 +33,9 @@
                 v-trap-focus="trapFocus">
                 <div
                     class="dropdown-content"
-                    :role="ariaRole">
+                    :role="ariaRole"
+                    :style="contentStyle"
+                >
                     <slot/>
                 </div>
             </div>
@@ -61,6 +63,8 @@ export default {
         disabled: Boolean,
         hoverable: Boolean,
         inline: Boolean,
+        scrollable: Boolean,
+        maxHeight: [String, Number],
         position: {
             type: String,
             validator(value) {
@@ -142,6 +146,14 @@ export default {
                     ? DEFAULT_CLOSE_OPTIONS
                     : []
                 : this.canClose
+        },
+        contentStyle() {
+            return {
+                maxHeight: this.scrollable
+                    ? this.maxHeight === undefined
+                        ? null : (isNaN(this.maxHeight) ? this.maxHeight : this.maxHeight + 'px') : null,
+                overflow: this.scrollable ? 'auto' : null
+            }
         }
     },
     watch: {
@@ -240,8 +252,9 @@ export default {
         /**
          * Keypress event that is bound to the document
          */
-        keyPress({ key }) {
-            if (this.isActive && (key === 'Escape' || key === 'Esc')) {
+        keyPress(event) {
+            // Esc key
+            if (this.isActive && event.keyCode === 27) {
                 if (this.cancelOptions.indexOf('escape') < 0) return
                 this.isActive = false
             }

--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -64,7 +64,10 @@ export default {
         hoverable: Boolean,
         inline: Boolean,
         scrollable: Boolean,
-        maxHeight: [String, Number],
+        maxHeight: {
+            type: [String, Number],
+            default: 200
+        },
         position: {
             type: String,
             validator(value) {
@@ -252,9 +255,8 @@ export default {
         /**
          * Keypress event that is bound to the document
          */
-        keyPress(event) {
-            // Esc key
-            if (this.isActive && event.keyCode === 27) {
+        keyPress({ key }) {
+            if (this.isActive && (key === 'Escape' || key === 'Esc')) {
                 if (this.cancelOptions.indexOf('escape') < 0) return
                 this.isActive = false
             }

--- a/src/components/timepicker/__snapshots__/Timepicker.spec.js.snap
+++ b/src/components/timepicker/__snapshots__/Timepicker.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BTimepicker render correctly 1`] = `
 <div class="timepicker control">
-    <b-dropdown-stub mobilemodal="true" animation="fade" trapfocus="true" closeonclick="true" canclose="true" appendtobodycopyparent="true">
+    <b-dropdown-stub maxheight="200" mobilemodal="true" animation="fade" trapfocus="true" closeonclick="true" canclose="true" appendtobodycopyparent="true">
         <b-input-stub autocomplete="off" usehtml5validation="true" type="text" hascounter="true" customclass="" readonly="true"></b-input-stub>
         <b-dropdown-item-stub custom="true" focusable="true" ariarole="">
             <b-field-stub grouped="true" position="is-centered" addons="true">


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Added Boolean prop scrollable to enable overflow on .dropdown-content.
- Added String/Number prop max-height to define the max height of .dropdown-content.
- Added Examples and Api description for the proposed props.
