### PR TITLE
feature: expanded prop added into b-upload component

### DIFF
--- a/docs/pages/components/upload/Upload.vue
+++ b/docs/pages/components/upload/Upload.vue
@@ -3,6 +3,8 @@
         <Example :component="ExSimple" :code="ExSimpleCode" vertical/>
 
         <Example :component="ExDragDrop" :code="ExDragDropCode" title="Drag and drop" vertical/>
+        
+        <Example :component="ExExpanded" :code="ExExpandedCode" title="Expanded" vertical/>
 
         <ApiView :data="api"/>
     </div>
@@ -17,14 +19,19 @@
     import ExDragDrop from './examples/ExDragDrop'
     import ExDragDropCode from '!!raw-loader!./examples/ExDragDrop'
 
+    import ExExpanded from './examples/ExExpanded'
+    import ExExpandedCode from '!!raw-loader!./examples/ExExpanded'
+
     export default {
         data() {
             return {
                 api,
                 ExSimple,
                 ExDragDrop,
+                ExExpanded,
                 ExSimpleCode,
-                ExDragDropCode
+                ExDragDropCode,
+                ExExpandedCode
             }
         }
     }

--- a/docs/pages/components/upload/api/upload.js
+++ b/docs/pages/components/upload/api/upload.js
@@ -73,7 +73,14 @@ export default [
                 type: 'Boolean',
                 values: '—',
                 default: '<code>false</code>'
-            }
+            },
+            {
+                name: '<code>expanded</code>',
+                description: 'Upload will be expanded (full-width)',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
         ],
         events: [
             {

--- a/docs/pages/components/upload/examples/ExExpanded.vue
+++ b/docs/pages/components/upload/examples/ExExpanded.vue
@@ -1,0 +1,47 @@
+<template>
+  <section>
+    <b-field class="file">
+      <b-upload v-model="file" expanded>
+        <a class="button is-primary is-fullwidth">
+          <b-icon icon="upload"></b-icon>
+          <span>{{ file.name || "Click to upload"}}</span>
+        </a>
+      </b-upload>
+    </b-field>
+    <b-field>
+      <b-upload v-model="dropFiles" multiple drag-drop expanded>
+        <section class="section">
+          <div class="content has-text-centered">
+            <p>
+              <b-icon icon="upload" size="is-large"></b-icon>
+            </p>
+            <p>Drop your files here or click to upload</p>
+          </div>
+        </section>
+      </b-upload>
+    </b-field>
+
+    <div class="tags">
+      <span v-for="(file, index) in dropFiles" :key="index" class="tag is-primary">
+        {{file.name}}
+        <button class="delete is-small" type="button" @click="deleteDropFile(index)"></button>
+      </span>
+    </div>
+  </section>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      file: {},
+      dropFiles: []
+    };
+  },
+  methods: {
+    deleteDropFile(index) {
+      this.dropFiles.splice(index, 1);
+    }
+  }
+};
+</script>

--- a/src/components/upload/Upload.vue
+++ b/src/components/upload/Upload.vue
@@ -1,5 +1,5 @@
 <template>
-    <label class="upload control">
+    <label class="upload control" :class="{'is-expanded' : expanded}">
         <template v-if="!dragDrop">
             <slot/>
         </template>
@@ -10,7 +10,8 @@
             :class="[type, {
                 'is-loading': loading,
                 'is-disabled': disabled,
-                'is-hovered': dragDropFocus
+                'is-hovered': dragDropFocus,
+                'is-expanded': expanded,
             }]"
             @dragover.prevent="updateDragDropFocus(true)"
             @dragleave.prevent="updateDragDropFocus(false)"
@@ -51,6 +52,10 @@ export default {
             default: 'is-primary'
         },
         native: {
+            type: Boolean,
+            default: false
+        },
+        expanded: {
             type: Boolean,
             default: false
         }

--- a/src/scss/components/_upload.scss
+++ b/src/scss/components/_upload.scss
@@ -44,6 +44,12 @@
                 }
             }
         }
+        &.is-expanded {
+            width: 100%;
+        }
+    }
+    &.is-expanded {
+        width: 100%;
     }
 }
 // temporary IE 11 hack !!!


### PR DESCRIPTION
## Related Issue
Fixes #1804 

## Summary

`b-upload` was missing `expanded` prop like buttons, inputs. For that reason custom classes needed to make it expanded. 

## Proposed Changes
- `expanded` prop (false by default) added into `b-upload` component.
- New example with #Expanded title added into `/documentation/upload`
- #API documentation at `/documentation/upload` updated.

## Related Images
<img width="1128" alt="example" src="https://user-images.githubusercontent.com/51219535/80859439-bd15d200-8c69-11ea-874a-acce7961e0b1.png">

<img width="1128" alt="prop" src="https://user-images.githubusercontent.com/51219535/80859443-c4d57680-8c69-11ea-9e91-4d103bdeb84c.png">
