### PR TITLE
Remove 'recommended' from Full Bundle

### DIFF
--- a/docs/pages/installation/Start.vue
+++ b/docs/pages/installation/Start.vue
@@ -45,7 +45,7 @@
                         </ul>
                     </div>
                 </b-message>
-                <CodeView title="Full bundle (recommended)" :code="importingBundle | pre" lang="javascript" expanded/>
+                <CodeView title="Full bundle" :code="importingBundle | pre" lang="javascript" expanded/>
                 <CodeView title="Individual components as Vue plugins" :code="importingComponentsAsVuePlugins | pre" lang="javascript" expanded/>
                 <b-message type="is-info">
                     To include individual styles, see <router-link to="/documentation/customization">Customization</router-link> section.


### PR DESCRIPTION
Hi Buefy, 

I don't really understand why you would recommend the full Buefy bundle just because it might be the easiest way of using Buefy. It's pretty bad practice to include full bundles, because CSS parsing is one of the most CPU-intensive tasks in the beginning of website paints.

Lighthouse states that the CSS parsing is one of the highest critically acclaimed components to avoid in order to optimize your website. Including SCSS/CSS on an individual component can definitely be preferable due to the modularity of Vue.js anyway.

If you don't agree no problem, just felt like 'recommended' shouldn't have been added just because it's the easiest way.