### PR TITLE
shallow copy in watcher

### DIFF
--- a/src/components/taginput/Taginput.vue
+++ b/src/components/taginput/Taginput.vue
@@ -249,7 +249,7 @@ export default {
          * When v-model is changed set internal value.
          */
         value(value) {
-            this.tags = value
+            this.tags = Array.isArray(value) ? value.slice(0) : (value || [])
         },
 
         hasInput() {


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #1598 
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

It fixes the mutation of vuex stores when using TagInput along with Vuex. As mentioned in this PR by ManUtopiK, it did not entirely solved the problem the first time. I had missed the watcher for cloning the array. Now I am fixing the last part.

* Make a shallow copy of the tags array when the watcher of the v-model is triggered
