### PR TITLE
Autocomplete typo

### DIFF
--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -467,7 +467,7 @@ export default {
             if (this.clearable) {
                 this.newValue = ''
             } else {
-                this.$emi('icon-right-click', event)
+                this.$emit('icon-right-click', event)
             }
         },
         checkValidity() {


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->


## Proposed Changes

Just a typo I found.

in src/components/autocomplete/Autocomplete.vue:
`this.$emi('icon-right-click', event)`
