### PR TITLE
Feature: close-type prop added into b-tag component

### DIFF
--- a/docs/pages/components/tag/api/tag.js
+++ b/docs/pages/components/tag/api/tag.js
@@ -4,7 +4,17 @@ export default [
         props: [
             {
                 name: '<code>type</code>',
-                description: 'Type (color) of the icon, optional',
+                description: 'Type (color) of the tag, optional',
+                type: 'String',
+                values: `<code>is-white</code>, <code>is-black</code>, <code>is-light</code>,
+                    <code>is-dark</code>, <code>is-primary</code>, <code>is-info</code>, <code>is-success</code>,
+                    <code>is-warning</code>, <code>is-danger</code>,
+                    and any other colors you've set in the <code>$colors</code> list on Sass`,
+                default: '—'
+            },
+            {
+                name: '<code>close-type</code>',
+                description: 'Type (color) of the cross button of tag, optional',
                 type: 'String',
                 values: `<code>is-white</code>, <code>is-black</code>, <code>is-light</code>,
                     <code>is-dark</code>, <code>is-primary</code>, <code>is-info</code>, <code>is-success</code>,

--- a/docs/pages/components/tag/examples/ExClosable.vue
+++ b/docs/pages/components/tag/examples/ExClosable.vue
@@ -9,25 +9,45 @@
                 Colored closable tag label
             </b-tag>
         </div>
-
         <div class="field">
             <b-tag v-if="isTag2Active"
-                attached
+                type="is-success"
                 closable
+                closeType='is-danger'
                 aria-close-label="Close tag"
                 @close="isTag2Active = false">
-                Attached closable tag label
+                Colored closable tag label with colored closed icon
             </b-tag>
         </div>
 
         <div class="field">
             <b-tag v-if="isTag3Active"
-                type="is-danger"
                 attached
                 closable
                 aria-close-label="Close tag"
                 @close="isTag3Active = false">
+                Attached closable tag label
+            </b-tag>
+        </div>
+
+        <div class="field">
+            <b-tag v-if="isTag4Active"
+                type="is-danger"
+                attached
+                closable
+                aria-close-label="Close tag"
+                @close="isTag4Active = false">
                 Colored attached closable tag label
+            </b-tag>
+        </div>
+        <div class="field">
+            <b-tag v-if="isTag5Active"
+                close-type='is-danger'
+                attached
+                closable
+                aria-close-label="Close tag"
+                @close="isTag5Active = false">
+                Attached tag label with colored close type
             </b-tag>
         </div>
     </section>
@@ -39,7 +59,9 @@
             return {
                 isTag1Active: true,
                 isTag2Active: true,
-                isTag3Active: true
+                isTag3Active: true,
+                isTag4Active: true,
+                isTag5Active: true,
             }
         }
     }

--- a/src/components/tag/Tag.vue
+++ b/src/components/tag/Tag.vue
@@ -31,7 +31,7 @@
             role="button"
             :aria-label="ariaCloseLabel"
             class="delete is-small"
-            :class="[{'tag is-paddingless is-rounded' : closeType}, closeType]"
+            :class="closeType"
             :disabled="disabled"
             :tabindex="tabstop ? 0 : false"
             @click="close"

--- a/src/components/tag/Tag.vue
+++ b/src/components/tag/Tag.vue
@@ -13,7 +13,7 @@
             :aria-label="ariaCloseLabel"
             :tabindex="tabstop ? 0 : false"
             :disabled="disabled"
-            :class="[size, { 'is-rounded': rounded }]"
+            :class="[size, closeType, { 'is-rounded': rounded }]"
             @click="close"
             @keyup.delete.prevent="close"
         />
@@ -31,6 +31,7 @@
             role="button"
             :aria-label="ariaCloseLabel"
             class="delete is-small"
+            :class="[{'tag is-paddingless is-rounded' : closeType}, closeType]"
             :disabled="disabled"
             :tabindex="tabstop ? 0 : false"
             @click="close"
@@ -54,7 +55,8 @@ export default {
             type: Boolean,
             default: true
         },
-        ariaCloseLabel: String
+        ariaCloseLabel: String,
+        closeType: String
     },
     methods: {
         /**

--- a/src/scss/components/_tag.scss
+++ b/src/scss/components/_tag.scss
@@ -5,4 +5,15 @@
         white-space: nowrap;
         text-overflow: ellipsis;
     }
+    .delete, &.is-delete {
+        @each $name, $pair in $colors {
+            $color: nth($pair, 1);
+            &.is-#{$name} {
+                background: $color;
+                &:hover {
+                    background-color: darken($color, 10%);
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Description
This Pull Requests adds `close-type` prop into `b-tag` component to allow customize type of close icon.

## Why Buefy needs this?
Sometimes developers should want to customize close button without writing custom classes. In most of situations, `is-danger` type preferred to increase accessibility and consistency instead of using a gray one.

## Examples
<img width="829" alt="Ekran Resmi 2020-05-09 13 41 09" src="https://user-images.githubusercontent.com/51219535/81471589-d6cf9000-91fa-11ea-9343-10990bcc1608.png">

## Documentation
<img width="1070" alt="Ekran Resmi 2020-05-09 13 42 53" src="https://user-images.githubusercontent.com/51219535/81471615-067e9800-91fb-11ea-8edf-eb42b2532dc1.png">
