### PR TITLE
Skeleton fixes and improvements

### DIFF
--- a/docs/pages/components/skeleton/api/skeleton.js
+++ b/docs/pages/components/skeleton/api/skeleton.js
@@ -49,7 +49,14 @@ export default [
                 type: 'Number',
                 values: '—',
                 default: '<code>1</code>'
-            }
+						},
+            {
+                name: '<code>position</code>',
+                description: 'Position of the skeleton, optional',
+                type: 'String',
+                values: '<code>is-centered</code>, <code>is-right</code>',
+                default: '—'
+						},
         ]
     }
 ]

--- a/docs/pages/components/skeleton/variables/skeleton.js
+++ b/docs/pages/components/skeleton/variables/skeleton.js
@@ -1,7 +1,7 @@
 export default [
     {
         name: '<code>$skeleton-line-height</code>',
-        default: '<code>1</code>'
+        default: '<code>$body-line-height</code>'
     },
     {
         name: '<code>$skeleton-background</code>',

--- a/src/components/skeleton/Skeleton.vue
+++ b/src/components/skeleton/Skeleton.vue
@@ -21,6 +21,17 @@ export default {
         count: {
             type: Number,
             default: 1
+        },
+        position: {
+            type: String,
+            default: '',
+            validator(value) {
+                return [
+                    '',
+                    'is-centered',
+                    'is-right'
+                ].indexOf(value) > -1
+            }
         }
     },
     render(createElement, context) {
@@ -42,7 +53,7 @@ export default {
                 }
             }))
         }
-        return createElement('div', { staticClass: 'b-skeleton', class: { 'is-animated': context.props.animated } }, items)
+        return createElement('div', { staticClass: 'b-skeleton', class: { 'is-animated': context.props.animated, [context.props.position]: context.props.position } }, items)
     }
 }
 </script>

--- a/src/scss/components/_skeleton.scss
+++ b/src/scss/components/_skeleton.scss
@@ -1,17 +1,19 @@
 
-$skeleton-line-height: 1 !default;
+$skeleton-line-height: $body-line-height !default;
 $skeleton-background: linear-gradient(90deg, $grey-lighter 25%, rgba($grey-lighter, 0.5) 50%, $grey-lighter 75%);
 $skeleton-border-radius: $radius !default;
 $skeleton-duration: 1.5s !default;
 $skeleton-margin-top: .5rem !default;
 
 .b-skeleton {
+    display: inline-flex;
+    flex-direction: column;
+    vertical-align: middle;
     width: 100%;
+    line-height: $skeleton-line-height;
     > .b-skeleton-item {
         background: $skeleton-background;
         background-size: 400% 100%;
-        display: inline-flex;
-        line-height: $skeleton-line-height;
         width: 100%;
         &.is-rounded {
             border-radius: $skeleton-border-radius;
@@ -24,6 +26,12 @@ $skeleton-margin-top: .5rem !default;
         > .b-skeleton-item {
             animation: skeleton-loading $skeleton-duration infinite;
         }
+    }
+    &.is-centered {
+        align-items: center;
+    }
+    &.is-right {
+        align-items: flex-end;
     }
     + .b-skeleton {
         margin-top: $skeleton-margin-top;

--- a/src/scss/components/_skeleton.scss
+++ b/src/scss/components/_skeleton.scss
@@ -6,7 +6,6 @@ $skeleton-duration: 1.5s !default;
 $skeleton-margin-top: .5rem !default;
 
 .b-skeleton {
-    display: flex;
     width: 100%;
     > .b-skeleton-item {
         background: $skeleton-background;


### PR DESCRIPTION
## Proposed Changes
  
Here is my take on skeletons

- Changed `$skeleton-line-height` from `1` to `$body-line-height` so it matches the default line-height _(I don't think this variable is needed anymore)_
- Added `position` prop to align the skeleton
- Skeletons are now vertically centered

There is a small issue with `vertical-align: middle;` sometimes it'll add less than 1px to the total height of the skeleton div