### PR TITLE
Keep table search filtering when data are updated

### DIFF
--- a/src/components/table/Table.spec.js
+++ b/src/components/table/Table.spec.js
@@ -1,4 +1,5 @@
 import { shallowMount } from '@vue/test-utils'
+import BInput from '@components/input/Input'
 import BTable from '@components/table/Table'
 
 describe('BTable', () => {
@@ -10,10 +11,10 @@ describe('BTable', () => {
     let tableCols = shallowMount(BTable, {
         propsData: {
             columns: [
-                {label: 'default', width: '100px'},
-                {label: 'pecent', width: '50%'},
-                {label: 'fixed_num', width: 100},
-                {label: 'fixed_str', width: '100'}
+                { label: 'default', width: '100px' },
+                { label: 'pecent', width: '50%' },
+                { label: 'fixed_num', width: 100 },
+                { label: 'fixed_str', width: '100' }
             ]
         }
     })
@@ -74,5 +75,68 @@ describe('BTable', () => {
         expect(cols.at(1).attributes('style')).toBe('width: 50%;')
         expect(cols.at(2).attributes('style')).toBe('width: 100px;')
         expect(cols.at(3).attributes('style')).toBe('width: 100px;')
+    })
+
+    describe('Searchable', () => {
+        const data = [
+            { id: 1, name: 'Jesse' },
+            { id: 2, name: 'John' },
+            { id: 3, name: 'Tina' },
+            { id: 4, name: 'Anne' },
+            { id: 5, name: 'Clarence' }
+        ]
+        let headRows
+        let bodyRows
+        let searchInput
+
+        beforeEach(() => {
+            wrapper = shallowMount(BTable, {
+                propsData: {
+                    columns: [
+                        { label: 'ID', field: 'id', numeric: true },
+                        { label: 'Name', field: 'name', searchable: true }
+                    ],
+                    data
+                }
+            })
+            headRows = wrapper.findAll('thead tr')
+            bodyRows = wrapper.findAll('tbody tr')
+            searchInput = wrapper.find(BInput)
+        })
+
+        it('displays filter row when at least one column is searchable', () => {
+            expect(headRows).toHaveLength(2)
+        })
+
+        it('displays filter input only on searchable columns', () => {
+            const filterCells = headRows.at(1).findAll('.th-wrap')
+
+            expect(filterCells.at(0).isEmpty()).toBe(true) // ID column is not searchable
+            expect(filterCells.at(1).contains(BInput)).toBe(true) // Name column is searchable
+        })
+
+        it('displays all data', () => {
+            expect(bodyRows).toHaveLength(5)
+        })
+
+        it('displays filtered data when searching', () => {
+            searchInput.vm.$emit('input', 'J')
+            bodyRows = wrapper.findAll('tbody tr')
+
+            expect(bodyRows).toHaveLength(2) // Jesse and John
+        })
+
+        it('displays filtered data when searching and updating data', () => {
+            searchInput.vm.$emit('input', 'J')
+            wrapper.setProps({
+                data: [
+                    ...data,
+                    { id: 6, name: 'Justin' }
+                ]
+            })
+            bodyRows = wrapper.findAll('tbody tr')
+
+            expect(bodyRows).toHaveLength(3) // Jesse, John and Justin
+        })
     })
 })

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -689,16 +689,21 @@ export default {
         /**
         * When data prop change:
         *   1. Update internal value.
-        *   2. Sort again if it's not backend-sort.
-        *   3. Set new total if it's not backend-paginated.
+        *   2. Filter data if it's not backend-filtered.
+        *   3. Sort again if it's not backend-sorted.
+        *   4. Set new total if it's not backend-paginated.
         */
         data(value) {
             this.newData = value
+            if (!this.backendFiltering) {
+                this.newData = value.filter(
+                    (row) => this.isRowFiltered(row))
+            }
             if (!this.backendSorting) {
                 this.sort(this.currentSortColumn, true)
             }
             if (!this.backendPagination) {
-                this.newDataTotal = value.length
+                this.newDataTotal = this.newData.length
             }
         },
 


### PR DESCRIPTION
Fixes #2509

## Proposed Changes

- Apply filtering before sorting and pagination when `data` prop changes
