### PR TITLE
Fix node version in contribution guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -100,7 +100,7 @@ Sass example:
 
 # Development Setup
 
-You need [Node.js](http://nodejs.org/) **version 6+**.
+You need [Node.js](http://nodejs.org/) **version >= 6 and <= 11**.
 
 After cloning the repo, run:
 


### PR DESCRIPTION
Running `npm install` failed because I used node 12 and the version of `node-sass` dependency (4.11.0) [doesn't support node 12+](https://github.com/sass/node-sass#supported-nodejs-versions-vary-by-release-please-consult-the-releases-page-below-is-a-quick-guide-for-minimum-support).
