### PR TITLE
Feature: passive-type prop for b-switch component

### DIFF
--- a/docs/pages/components/switch/api/switch.js
+++ b/docs/pages/components/switch/api/switch.js
@@ -12,6 +12,16 @@ export default [
                 default: '—'
             },
             {
+                name: '<code>passive-type</code>',
+                description: 'Type (color) of the switch when switch is passive, optional',
+                type: 'String',
+                values: `<code>is-white</code>, <code>is-black</code>, <code>is-light</code>,
+                    <code>is-dark</code>, <code>is-primary</code>, <code>is-info</code>, <code>is-success</code>,
+                    <code>is-warning</code>, <code>is-danger</code>,
+                    and any other colors you've set in the <code>$colors</code> list on Sass`,
+                default: '—'
+            },
+            {
                 name: '<code>v-model</code>',
                 description: 'Binding value',
                 type: 'Any',

--- a/docs/pages/components/switch/examples/ExStyles.vue
+++ b/docs/pages/components/switch/examples/ExStyles.vue
@@ -4,30 +4,38 @@
             <b-switch v-model="isRounded">Rounded</b-switch>
             <b-switch v-model="isOutlined">Outlined</b-switch>
         </b-field>
-        <b-field grouped>
-            <b-field label="Type">
-                <b-select v-model="type" placeholder="Type">
-                    <option value="null">Default</option>
-                    <option value="is-primary">Primary</option>
-                    <option value="is-success">Success</option>
-                    <option value="is-warning">Warning</option>
-                    <option value="is-danger">Danger</option>
-                </b-select>
-            </b-field>
-            <b-field label="Size">
-                <b-select v-model="size">
-                    <option value="">Default</option>
-                    <option value="is-small">is-small</option>
-                    <option value="is-medium">is-medium</option>
-                    <option value="is-large">is-large</option>
-                </b-select>
-            </b-field>
+        <b-field label="Type">
+            <b-select expanded v-model="type" placeholder="Type">
+                <option value="null">Default</option>
+                <option value="is-primary">Primary</option>
+                <option value="is-success">Success</option>
+                <option value="is-warning">Warning</option>
+                <option value="is-danger">Danger</option>
+            </b-select>
+        </b-field>
+        <b-field label="Passive Type">
+            <b-select expanded v-model="passiveType" placeholder="Passive Type">
+                <option value="null">Default</option>
+                <option value="is-primary">Primary</option>
+                <option value="is-success">Success</option>
+                <option value="is-warning">Warning</option>
+                <option value="is-danger">Danger</option>
+            </b-select>
+        </b-field>
+        <b-field label="Size">
+            <b-select expanded v-model="size">
+                <option value="">Default</option>
+                <option value="is-small">is-small</option>
+                <option value="is-medium">is-medium</option>
+                <option value="is-large">is-large</option>
+            </b-select>
         </b-field>
         <b-switch
             :rounded="isRounded"
             :outlined="isOutlined"
             :size="size"
-            :type="type">Sample</b-switch>
+            :type="type"
+            :passive-type='passiveType'>Sample</b-switch>
     </section>
 </template>
 
@@ -37,6 +45,7 @@
             return {
                 size: '',
                 type: null,
+                passiveType: null,
                 isRounded: false,
                 isOutlined: false,
             }

--- a/docs/pages/components/switch/examples/ExTypes.vue
+++ b/docs/pages/components/switch/examples/ExTypes.vue
@@ -31,10 +31,21 @@
         </div>
         <div class="field">
             <b-switch 
-                :value="false"
-                passive-type='is-danger'>
-                Danger(Passive)
+                v-model="lightMode"
+                passive-type='is-dark'
+                type='is-warning'>
+                {{ lightMode ? "Light Mode" : "Dark Mode" }}
             </b-switch>
         </div>
     </section>
 </template>
+
+<script>
+export default {
+    data() {
+        return {
+            lightMode: false
+        }
+    }
+}
+</script>

--- a/docs/pages/components/switch/examples/ExTypes.vue
+++ b/docs/pages/components/switch/examples/ExTypes.vue
@@ -29,5 +29,12 @@
                 Warning
             </b-switch>
         </div>
+        <div class="field">
+            <b-switch 
+                :value="false"
+                passive-type='is-danger'>
+                Danger(Passive)
+            </b-switch>
+        </div>
     </section>
 </template>

--- a/src/components/switch/Switch.spec.js
+++ b/src/components/switch/Switch.spec.js
@@ -44,4 +44,12 @@ describe('BSwitch', () => {
             done()
         })
     })
+
+    it('applies passiveType prop properly', () => {
+        const passiveType = 'is-danger'
+        const value = false
+        wrapper.setProps({ passiveType, value })
+        const switchElement = wrapper.find('.check')
+        expect(switchElement.classes()).toContain('is-danger-passive')
+    })
 })

--- a/src/components/switch/Switch.vue
+++ b/src/components/switch/Switch.vue
@@ -21,7 +21,12 @@
             :value="nativeValue"
             :true-value="trueValue"
             :false-value="falseValue">
-        <span class="check" :class="[{ 'is-elastic': isMouseDown && !disabled }, type]"/>
+        <span
+            class="check"
+            :class="[
+                { 'is-elastic': isMouseDown && !disabled },
+                (passiveType &&`${passiveType}-passive`),
+                type]"/>
         <span class="control-label"><slot/></span>
     </label>
 </template>
@@ -34,6 +39,7 @@ export default {
         nativeValue: [String, Number, Boolean, Function, Object, Array, Date],
         disabled: Boolean,
         type: String,
+        passiveType: String,
         name: String,
         required: Boolean,
         size: String,

--- a/src/scss/components/_switch.scss
+++ b/src/scss/components/_switch.scss
@@ -76,6 +76,12 @@ $switch-active-background-color: $primary !default;
             outline: none;
             + .check {
                 box-shadow: 0 0 0.5em rgba($grey, 0.6);
+                @each $name, $pair in $colors {
+                    $color: nth($pair, 1);
+                    &.is-#{$name}-passive {
+                        box-shadow: 0 0 0.5em rgba($color, 0.8);
+                    }
+                }
             }
             &:checked + .check {
                 box-shadow: 0 0 0.5em rgba($switch-active-background-color, 0.8);

--- a/src/scss/components/_switch.scss
+++ b/src/scss/components/_switch.scss
@@ -30,6 +30,15 @@ $switch-active-background-color: $primary !default;
             background: $grey-light;
             border-radius: $radius;
             transition: background $speed-slow $easing, box-shadow $speed-slow $easing;
+            @each $name, $pair in $colors {
+                $color: nth($pair, 1);
+                &.is-#{$name}-passive, &:hover {
+                    background: $color;
+                }
+                &.input[type=checkbox] + &.check {
+                    background: 'pink';
+                }
+            }    
             &:before {
                 content: "";
                 display: block;
@@ -85,6 +94,12 @@ $switch-active-background-color: $primary !default;
     &:hover {
         input[type=checkbox] + .check {
             background: rgba($grey-light, 0.9);
+            @each $name, $pair in $colors {
+                $color: nth($pair, 1);
+                &.is-#{$name}-passive {
+                    background: rgba($color, 0.9);
+                }
+            }
         }
         input[type=checkbox]:checked + .check {
             background: rgba($switch-active-background-color, 0.9);
@@ -115,6 +130,18 @@ $switch-active-background-color: $primary !default;
             + .check {
                 background: transparent;
                 border: .1rem solid $grey-light;
+                @each $name, $pair in $colors {
+                    $color: nth($pair, 1);
+                    &.is-#{$name}-passive {
+                        border: .1rem solid rgba($color, 0.9);
+                        &:before {
+                            background: $color
+                        }
+                        &:hover {
+                            border-color: rgba($color, 0.9);
+                        }
+                    }
+                }
                 &:before {
                     background: $grey-light;
                 }


### PR DESCRIPTION
## Description
This Pull Requests adds `passive-type` prop into `b-switch` component to allow customize type of close icon.

## Why Buefy needs this?
Currently Buefy is using $grey-light variable for all switchs while they are passive. Developers who wants to seperate passive type of their switch components and grey-light variables are need to write some custom CSS to make them different. This prop would mostly used by while building a 
modern Light Mode / Dark Mode switch.

## Examples
![gif1](https://user-images.githubusercontent.com/51219535/82121851-ca1ddf80-9798-11ea-922a-03963a9ebe4c.gif)

![gif2](https://user-images.githubusercontent.com/51219535/82121873-f2a5d980-9798-11ea-9843-25f680c81168.gif)


## Documentation
<img width="911" alt="documentation" src="https://user-images.githubusercontent.com/51219535/82121907-15d08900-9799-11ea-910e-933f8431c205.png">

## Checklist
- [x] Unit Test added for new prop

