### PR TITLE
Fix for yarn pnp

### DIFF
--- a/src/scss/buefy-build.scss
+++ b/src/scss/buefy-build.scss
@@ -1,4 +1,4 @@
-@import "node_modules/bulma/sass/utilities/initial-variables";
+@import "~bulma/sass/utilities/initial-variables";
 @import "utils/_all";
-@import "node_modules/bulma/bulma";
+@import "~bulma/bulma";
 @import "buefy";


### PR DESCRIPTION
Changed hardcoded "node_modules" path to be compatible with yarn pnp.

<!-- Thank you for helping Buefy! -->
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Changes in buefy-build.scss for pnp compatibility.
