### PR TITLE
Fix typo for activeStep

### DIFF
--- a/src/components/steps/Steps.vue
+++ b/src/components/steps/Steps.vue
@@ -344,7 +344,7 @@ export default {
         }
     },
     mounted() {
-        this.activeTab = this.getIndexByValue(this.value || 0)
+        this.activeStep = this.getIndexByValue(this.value || 0)
         if (this.activeStep < this.stepItems.length) {
             this.stepItems[this.activeStep].isActive = true
         }


### PR DESCRIPTION
Fixes #
Fix typo from copied code
activeStep wasn't being set on mount for Steps component

## Proposed Changes
Rename unused variable activeTab to activeStep