### PR TITLE
Feature: Dialog closeOnConfirm prop

### DIFF
--- a/docs/pages/components/dialog/api/dialog.js
+++ b/docs/pages/components/dialog/api/dialog.js
@@ -91,9 +91,16 @@ export default [
             {
                 name: '<code>onConfirm</code>',
                 description: 'Callback function when the confirm button is clicked',
-                type: 'Function (value: String)',
+                type: 'Function (value: String, dialog: VueInstance)',
                 values: '—',
                 default: '—'
+            },
+            {
+                name: '<code>closeOnConfirm</code>',
+                description: 'Turning this prop into false allows to make async requests in <code>onConfirm</code> callback',
+                type: 'Boolean',
+                values: '<code>true</code>, <code>false</code>',
+                default: '<code>true</code>'
             },
             {
                 name: '<code>onCancel</code>',

--- a/docs/pages/components/dialog/examples/ExPromptDialog.vue
+++ b/docs/pages/components/dialog/examples/ExPromptDialog.vue
@@ -1,45 +1,66 @@
 <template>
     <section>
         <div class="buttons">
-            <button class="button is-medium is-dark" @click="prompt">
-                Launch prompt (default)
-            </button>
+            <button class="button is-medium is-dark" @click="prompt">Launch prompt (default)</button>
 
-            <button class="button is-medium is-dark" @click="promptNumber">
-                Launch prompt (number)
-            </button>
+            <button class="button is-medium is-dark" @click="promptNumber">Launch prompt (number)</button>
+
+            <button
+                class="button is-medium is-dark"
+                @click="promptNotClosed"
+            >Launch prompt (Not closing default)</button>
         </div>
     </section>
 </template>
 
 <script>
-    export default {
-        methods: {
-            prompt() {
-                this.$buefy.dialog.prompt({
-                    message: `What's your name?`,
-                    inputAttrs: {
-                        placeholder: 'e.g. Walter',
-                        maxlength: 10
-                    },
-                    trapFocus: true,
-                    onConfirm: (value) => this.$buefy.toast.open(`Your name is: ${value}`)
-                })
-            },
-            promptNumber() {
-                this.$buefy.dialog.prompt({
-                    message: `What's your age?`,
-                    inputAttrs: {
-                        type: 'number',
-                        placeholder: 'Type your age',
-                        value: '18',
-                        maxlength: 2,
-                        min: 18
-                    },
-                    trapFocus: true,
-                    onConfirm: (value) => this.$buefy.toast.open(`Your age is: ${value}`)
-                })
-            }
+export default {
+    methods: {
+        prompt() {
+            this.$buefy.dialog.prompt({
+                message: `What's your name?`,
+                inputAttrs: {
+                    placeholder: 'e.g. Walter',
+                    maxlength: 10
+                },
+                trapFocus: true,
+                onConfirm: (value) => this.$buefy.toast.open(`Your name is: ${value}`)
+            })
+        },
+        promptNumber() {
+            this.$buefy.dialog.prompt({
+                message: `What's your age?`,
+                inputAttrs: {
+                    type: 'number',
+                    placeholder: 'Type your age',
+                    value: '18',
+                    maxlength: 2,
+                    min: 18
+                },
+                trapFocus: true,
+                onConfirm: (value) => this.$buefy.toast.open(`Your age is: ${value}`)
+            })
+        },
+        promptNotClosed() {
+            this.$buefy.dialog.prompt({
+                message: 'Send your message to moon 🚀',
+                inputAttrs: {
+                    type: 'text',
+                    placeholder: 'My message is...',
+                    value: 'Hello moon!'
+                },
+                confirmText: 'Send',
+                trapFocus: true,
+                closeOnConfirm: false,
+                onConfirm: (value, {close}) => {
+                    this.$buefy.toast.open(`Your message is sending...`)
+                    setTimeout(() => {
+                        this.$buefy.toast.open(`Success message send!`)
+                        close()
+                    }, 2000);
+                }
+            })
         }
     }
+}
 </script>

--- a/docs/pages/components/dialog/examples/ExPromptDialog.vue
+++ b/docs/pages/components/dialog/examples/ExPromptDialog.vue
@@ -1,14 +1,23 @@
 <template>
     <section>
         <div class="buttons">
-            <button class="button is-medium is-dark" @click="prompt">Launch prompt (default)</button>
-
-            <button class="button is-medium is-dark" @click="promptNumber">Launch prompt (number)</button>
+            <button
+                class="button is-medium is-dark"
+                @click="prompt">
+                Launch prompt (default)
+            </button>
 
             <button
                 class="button is-medium is-dark"
-                @click="promptNotClosed"
-            >Launch prompt (Not closing default)</button>
+                @click="promptNumber">
+                Launch prompt (number)
+            </button>
+
+            <button
+                class="button is-medium is-dark"
+                @click="promptNotClosed">
+                Launch prompt (Not closing default)
+            </button>
         </div>
     </section>
 </template>
@@ -57,7 +66,7 @@ export default {
                     setTimeout(() => {
                         this.$buefy.toast.open(`Success message send!`)
                         close()
-                    }, 2000);
+                    }, 2000)
                 }
             })
         }

--- a/src/components/dialog/Dialog.spec.js
+++ b/src/components/dialog/Dialog.spec.js
@@ -68,4 +68,11 @@ describe('BDialog', () => {
         expect(wrapper.vm.isActive).toBeFalsy()
         expect(wrapper.vm.onConfirm).toHaveBeenCalled()
     })
+
+    it('closeOnConfirm prop equals false', () => {
+        wrapper.setProps({ onConfirm: jest.fn(), closeOnConfirm: false })
+        wrapper.vm.confirm()
+        expect(wrapper.vm.isActive).toBeTruthy()
+        expect(wrapper.vm.onConfirm).toHaveBeenCalled()
+    })
 })

--- a/src/components/dialog/Dialog.vue
+++ b/src/components/dialog/Dialog.vue
@@ -115,6 +115,10 @@ export default {
             type: Function,
             default: () => {}
         },
+        closeOnConfirm: {
+            type: Boolean,
+            default: true
+        },
         container: {
             type: String,
             default: () => {
@@ -193,9 +197,8 @@ export default {
                     return
                 }
             }
-
-            this.onConfirm(this.prompt)
-            this.close()
+            this.onConfirm(this.prompt, this)
+            if (this.closeOnConfirm) this.close()
         },
 
         /**


### PR DESCRIPTION
## Description
This Pull Requests adds `closeOnConfirm` prop into `b-dialog` component to allow async requests in dialog component and adds `dialog` param as second param of `onConfirm` hook to make close request easier.

## Why Buefy needs this?
Currently only way to handle async requests is using `b-modal` component. With that change, it would be possible to close dialog component depending on async responses.

## Related Issues
https://github.com/buefy/buefy/issues/1953
https://github.com/buefy/buefy/issues/2478
And maybe many more
## Simple Usage
```javascript
  checkPassword() {
    this.$buefy.dialog.prompt({
      message: "Your password",
      inputAttrs: {
        type: "password",
        placeholder: "Your password",
        value: ""
      },
      trapFocus: true,
      closeOnConfirm: false, // This prop is a must if we want keep dialog open.
      onConfirm: (value, { close }) => {
        fetch("my/api/login")
          .then(res => {
            if (res === value) {
              this.$buefy.toast.open("Password true!");
              close(); // Instead of auto-close, construct from onConfirm hook's second dialog param.
            } else {
              this.$buefy.toast.open("Password false!");
              // Dialog remains open
            }
          })
          .catch(err => this.$buefy.toast.open("Server error.."));
      }
    });
  }
```
## Changes at `onConfirm()`

```javascript
onConfirm(value) {} // Before
onConfirm(value, dialog) {} // Now could use dialog as second parameter.
onConfirm(value, { close }) // Better to destruct.
```
## Examples
![gif1](https://user-images.githubusercontent.com/51219535/82730868-99472880-9d0b-11ea-8b9b-63d3327e9ae9.gif)



## Documentation
<img width="1074" alt="documentation" src="https://user-images.githubusercontent.com/51219535/82730884-d1e70200-9d0b-11ea-9ca8-c52ba44b688d.png">


## Checklist
- [x] Unit Test added for new prop
- [x] Documentation updated
- [x] New Example added
