### PR TITLE
Update CSS link to most recent MDI version

### DIFF
--- a/docs/pages/installation/Start.vue
+++ b/docs/pages/installation/Start.vue
@@ -169,7 +169,7 @@
                     </\script>
                 </body>
                 </html>`,
-                materialIcons: '<link rel="stylesheet" href="https://cdn.materialdesignicons.com/2.5.94/css/materialdesignicons.min.css">',
+                materialIcons: '<link rel="stylesheet" href="https://cdn.materialdesignicons.com/5.3.45/css/materialdesignicons.min.css">',
                 fontAwesome5: '<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.2.0/css/all.css">'
             }
         }


### PR DESCRIPTION
## Proposed Changes
Hi,

I was just about to setup a new project with Buefy and noticed that recommended material design icons version is heavily outdated. Please see attached PR :)

All the best and good job on this project to anyone involved!!