### PR TITLE
docs: buttons documentation improvements

### DIFF
--- a/docs/pages/components/button/api/button.js
+++ b/docs/pages/components/button/api/button.js
@@ -47,6 +47,41 @@ export default [
                 default: '<code>false</code>'
             },
             {
+                name: '<code>focused</code>',
+                description: 'Focused style',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
+                name: '<code>inverted</code>',
+                description: 'Inverted style',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
+                name: '<code>hovered</code>',
+                description: 'Hovered style',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
+                name: '<code>active</code>',
+                description: 'Active style',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
+                name: '<code>selected</code>',
+                description: 'Selected style',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
                 name: '<code>expanded</code>',
                 description: 'Button will be expanded (full-width)',
                 type: 'Boolean',

--- a/docs/pages/components/button/examples/ExTypesStates.vue
+++ b/docs/pages/components/button/examples/ExTypesStates.vue
@@ -14,9 +14,14 @@
         </div>
 
         <div class="buttons">
+            <b-button>Normal</b-button>
             <b-button disabled>Disabled</b-button>
             <b-button loading>Loading</b-button>
             <b-button rounded>Rounded</b-button>
+            <b-button focused>Focused</b-button>
+            <b-button hovered>Hovered</b-button>
+            <b-button selected>Selected</b-button>
+            <b-button active>Active</b-button>
         </div>
 
         <div class="buttons">


### PR DESCRIPTION
## Proposed Changes
- Missing API information added for `focused`, `hovered`, `selected`, `active` and `inverted` props for `b-button` component.
- Missing examples added for `focused`, `hovered`, `selected` and`active` props for `b-button` component.

<img width="1195" alt="ba" src="https://user-images.githubusercontent.com/51219535/83359377-845d3b80-a382-11ea-8f52-5ae1a02962a1.png">


