### PR TITLE
Typings(components): Make defaultLinkTags an optional

### DIFF
--- a/types/components.d.ts
+++ b/types/components.d.ts
@@ -54,7 +54,7 @@ export declare type BuefyConfig = {
     defaultButtonRounded?: boolean;
     defaultCarouselInterval?: number;
     defaultTabsAnimated?: boolean;
-    defaultLinkTags: string[];
+    defaultLinkTags?: string[];
     customIconPacks?: any;
 };
 


### PR DESCRIPTION
Makes `defaultLinkTags` optional so ts allows you to set options without also having defaultLinkTags set with your options

## Proposed Changes

- Typings(components): Make defaultLinkTags an optional/undefined by default
-
-
