### PR TITLE
closeType prop added into BTagInput

### DIFF
--- a/docs/pages/components/taginput/api/taginput.js
+++ b/docs/pages/components/taginput/api/taginput.js
@@ -40,6 +40,16 @@ export default [
                 default: '<code>is-light</code>'
             },
             {
+                name: '<code>closeType</code>',
+                description: 'Type (color) of the close icon, optional',
+                type: 'String',
+                values: `<code>is-white</code>, <code>is-black</code>, <code>is-light</code>,
+                    <code>is-dark</code>, <code>is-primary</code>, <code>is-info</code>, <code>is-success</code>,
+                    <code>is-warning</code>, <code>is-danger</code>,
+                    and any other colors you've set in the <code>$colors</code> list on Sass`,
+                default: '-'
+            },
+            {
                 name: '<code>size</code>',
                 description: 'Tag and input size, optional',
                 type: 'String',

--- a/docs/pages/components/taginput/examples/ExType.vue
+++ b/docs/pages/components/taginput/examples/ExType.vue
@@ -34,6 +34,14 @@
                 type="is-danger">
             </b-taginput>
         </b-field>
+
+        <b-field label="Close Type">
+            <b-taginput
+                v-model="tags"
+                type="is-dark"
+                close-type="is-danger">
+            </b-taginput>
+        </b-field>
     </section>
 </template>
 

--- a/src/components/taginput/Taginput.spec.js
+++ b/src/components/taginput/Taginput.spec.js
@@ -1,5 +1,6 @@
 import { shallowMount } from '@vue/test-utils'
 import BTaginput from '@components/taginput/Taginput'
+import BTag from '@components/tag/Tag'
 
 describe('BTaginput', () => {
     it('is called', () => {
@@ -21,5 +22,15 @@ describe('BTaginput', () => {
 
         wrapper.setProps({ hasCounter: false })
         expect(wrapper.find('small.counter').exists()).toBeFalsy()
+    })
+
+    it('should send close-type prop to BTag component properly', () => {
+        const value = ['Test Value']
+        const closeType = 'is-danger'
+        const wrapper = shallowMount(BTaginput, {
+            propsData: { value, closeType }
+        })
+        const Tag = wrapper.find(BTag)
+        expect(Tag.attributes('closetype')).toBe(closeType)
     })
 })

--- a/src/components/taginput/Taginput.vue
+++ b/src/components/taginput/Taginput.vue
@@ -10,6 +10,7 @@
                     v-for="(tag, index) in tags"
                     :key="getNormalizedTagText(tag) + index"
                     :type="type"
+                    :close-type="closeType"
                     :size="size"
                     :rounded="rounded"
                     :attached="attached"
@@ -107,6 +108,7 @@ export default {
             default: () => []
         },
         type: String,
+        closeType: String,
         rounded: {
             type: Boolean,
             default: false


### PR DESCRIPTION
## Description
With #2492, close icons in `tag` components were became customizable. This Pull Requests adds `close-type` prop into `b-taginput` component to allow customize type of close icon at Tags in b-taginput.

## Why Buefy needs this?
Sometimes developers should want to customize close button without writing custom classes. In most of situations, `is-danger` type preferred to increase accessibility and consistency instead of using a gray one.

## Examples
<img width="950" alt="examples" src="https://user-images.githubusercontent.com/51219535/83948475-169f8c80-a826-11ea-895b-e6c5d888c0ba.png">


## Documentation
<img width="950" alt="documentation" src="https://user-images.githubusercontent.com/51219535/83948478-1b644080-a826-11ea-8a53-d65554026bb6.png">



## Checklist
- [x] Unit Test added for new prop
- [x] Documentation updated
- [x] New Example added
