### PR TITLE
Fix null column in sorting data on sortable multiple table update data

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -871,7 +871,11 @@ export default {
                 this.sortMultiple &&
                 ((this.sortMultipleKey && event[this.sortMultipleKey]) || !this.sortMultipleKey)
             ) {
-                this.sortMultiColumn(column)
+                if (updatingData) {
+                    this.doSortMultiColumn()
+                } else {
+                    this.sortMultiColumn(column)
+                }
             } else {
                 if (!column || !column.sortable) return
 


### PR DESCRIPTION
# Step to reproduce this bug

1. Have a table with `:sort-multiple="true"`.
2. Push new item into the data of the table.
3. Sort some columns. You can see that the number starts from 2, 3, ... not 1, 2, ...

Also, you can try by sorting one or two before, add the data, sort some others and the number order will mess up.
 
# What is the cause of this bug?

When sortable multiple table was updated, the watcher of `data` data will call `sort` method with an argument of `currentSortColumn` data.

https://github.com/buefy/buefy/blob/81842887228d0a0686ca69e337e3f34ae8facef5/src/components/table/Table.vue#L696-L708

2. But in sortable multiple table, `currentSortColumn` data is always an empty object after added to `sortMultipleDataLocal` data. So, when the `sort` method call `sortMultiColumn` method, `sortMultiColumn` method will not find the column of `currentSortColumn` data (that get passed by `sort` method) and make it thought that "this column is a new entry" and try to push into `sortMultipleDataLocal` data.

https://github.com/buefy/buefy/blob/81842887228d0a0686ca69e337e3f34ae8facef5/src/components/table/Table.vue#L838-L852

Thus, an "undefined" column is now get sorting with others and cannot be remove - mess up with the number when rendered.

# Solution

Add a conditional check whether the data was updated. If it was, just sort. If not (user click other more columns, etc.), use the original method.