### PR TITLE
close-icon has been added into b-tag component

### DIFF
--- a/docs/pages/components/tag/api/tag.js
+++ b/docs/pages/components/tag/api/tag.js
@@ -77,6 +77,30 @@ export default [
                 type: 'String',
                 values: '—',
                 default: '-'
+            },
+            {
+                name: '<code>close-icon</code>',
+                description: 'Replace times in close button with a customized icon. <code>closable</code> and <code>attached</code> props should be needed.',
+                type: 'String',
+                values: '—',
+                default: '-'
+            },
+            {
+                name: '<code>close-icon-pack</code>',
+                description: 'Icon pack to use',
+                type: 'String',
+                values: '<code>mdi</code>, <code>fa</code>, <code>fas</code>, <code>far</code>, <code>fab</code>,  <code>fad</code>, <code>fal</code>',
+                default: '<code>mdi</code>'
+            },
+            {
+                name: '<code>close-icon-type</code>',
+                description: 'Type (color) of the close icon of tag, optional',
+                type: 'String',
+                values: `<code>is-white</code>, <code>is-black</code>, <code>is-light</code>,
+                    <code>is-dark</code>, <code>is-primary</code>, <code>is-info</code>, <code>is-success</code>,
+                    <code>is-warning</code>, <code>is-danger</code>,
+                    and any other colors you've set in the <code>$colors</code> list on Sass`,
+                default: '—'
             }
         ],
         events: [

--- a/docs/pages/components/tag/examples/ExClosable.vue
+++ b/docs/pages/components/tag/examples/ExClosable.vue
@@ -50,6 +50,18 @@
                 Attached tag label with colored close type
             </b-tag>
         </div>
+        <div class="field">
+            <b-tag v-if="isTag6Active"
+                close-type='is-warning'
+                close-icon-type='is-dark'
+                attached
+                closable
+                close-icon='delete'
+                aria-close-label="Close tag"
+                @close="isTag6Active = false">
+                Attached tag label with custom and colored icon
+            </b-tag>
+        </div>
     </section>
 </template>
 
@@ -62,6 +74,7 @@
                 isTag3Active: true,
                 isTag4Active: true,
                 isTag5Active: true,
+                isTag6Active: true,
             }
         }
     }

--- a/src/components/tag/Tag.vue
+++ b/src/components/tag/Tag.vue
@@ -8,16 +8,26 @@
             </span>
         </span>
         <a
-            class="tag is-delete"
+            class="tag"
             role="button"
             :aria-label="ariaCloseLabel"
             :tabindex="tabstop ? 0 : false"
             :disabled="disabled"
-            :class="[size, closeType, { 'is-rounded': rounded }]"
+            :class="[size,
+                     closeType,
+                     {'is-rounded': rounded},
+                     closeIcon ? 'has-delete-icon' : 'is-delete']"
             @click="close"
-            @keyup.delete.prevent="close"
-        />
-    </div>
+            @keyup.delete.prevent="close">
+            <b-icon
+                custom-class=""
+                v-if="closeIcon"
+                :icon="closeIcon"
+                :size="size"
+                :type="closeIconType"
+            />
+            <a/>
+    </a></div>
     <span
         v-else
         class="tag"
@@ -56,7 +66,10 @@ export default {
             default: true
         },
         ariaCloseLabel: String,
-        closeType: String
+        closeType: String,
+        closeIcon: String,
+        closeIconPack: String,
+        closeIconType: String
     },
     methods: {
         /**

--- a/src/components/tag/Tag.vue
+++ b/src/components/tag/Tag.vue
@@ -25,6 +25,7 @@
                 :icon="closeIcon"
                 :size="size"
                 :type="closeIconType"
+                :pack="closeIconPack"
             />
             <a/>
     </a></div>

--- a/src/scss/components/_tag.scss
+++ b/src/scss/components/_tag.scss
@@ -5,7 +5,7 @@
         white-space: nowrap;
         text-overflow: ellipsis;
     }
-    .delete, &.is-delete {
+    .delete, &.is-delete, &.has-delete-icon {
         @each $name, $pair in $colors {
             $color: nth($pair, 1);
             &.is-#{$name} {
@@ -14,6 +14,13 @@
                     background-color: darken($color, 10%);
                 }
             }
+        }
+    }
+    &.has-delete-icon {
+        padding: 0px;
+        .icon:first-child:not(:last-child) {
+            margin-right: 0px;
+            margin-left: 0px;
         }
     }
 }

--- a/src/scss/components/_tag.scss
+++ b/src/scss/components/_tag.scss
@@ -12,6 +12,7 @@
                 background: $color;
                 &:hover {
                     background-color: darken($color, 10%);
+                    text-decoration: none;
                 }
             }
         }


### PR DESCRIPTION
## Summary
`close-icon`, `close-icon-type` and `close-icon-pack` props added into `b-tag` component.

## Why Buefy needs this?
Currently Buefy's tags were only using Bulma's cross to close a closable tag. With that feature, users could customize close button however they want. Inspired by Vuetify's `v-chip` component's `close-icon` prop.

## Examples
<img width="1090" alt="example" src="https://user-images.githubusercontent.com/51219535/84571837-b1f0ae80-ad9e-11ea-9546-1b0caa2235c0.png">



## Documentation
<img width="1091" alt="documentation" src="https://user-images.githubusercontent.com/51219535/84571842-bd43da00-ad9e-11ea-8de3-50d83c18e4ef.png">




## Checklist
- [x] Documentation updated
- [x] New Example added
