### PR TITLE
Handle events for customElement components

### DIFF
--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -80,7 +80,7 @@
 </template>
 
 <script>
-import { getValueByPath, removeElement, createAbsoluteElement } from '../../utils/helpers'
+import { getValueByPath, removeElement, createAbsoluteElement, isCustomElement } from '../../utils/helpers'
 import FormElementMixin from '../../utils/FormElementMixin'
 import Input from '../input/Input'
 
@@ -343,7 +343,8 @@ export default {
          * Close dropdown if clicked outside.
          */
         clickedOutside(event) {
-            if (this.whiteList.indexOf(event.target) < 0) this.isActive = false
+            const target = isCustomElement(this) ? event.composedPath()[0] : event.target;
+            if (this.whiteList.indexOf(target) < 0) this.isActive = false
         },
 
         /**

--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -343,7 +343,7 @@ export default {
          * Close dropdown if clicked outside.
          */
         clickedOutside(event) {
-            const target = isCustomElement(this) ? event.composedPath()[0] : event.target;
+            const target = isCustomElement(this) ? event.composedPath()[0] : event.target
             if (this.whiteList.indexOf(target) < 0) this.isActive = false
         },
 

--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -248,7 +248,7 @@ export default {
             if (this.cancelOptions.indexOf('outside') < 0) return
             if (this.inline) return
 
-            const target = isCustomElement(this) ? event.composedPath()[0] : event.target;
+            const target = isCustomElement(this) ? event.composedPath()[0] : event.target
             if (!this.isInWhiteList(target)) this.isActive = false
         },
 

--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -45,7 +45,7 @@
 <script>
 import trapFocus from '../../directives/trapFocus'
 import config from '../../utils/config'
-import { removeElement, createAbsoluteElement } from '../../utils/helpers'
+import { removeElement, createAbsoluteElement, isCustomElement } from '../../utils/helpers'
 
 const DEFAULT_CLOSE_OPTIONS = ['escape', 'outside']
 
@@ -248,7 +248,8 @@ export default {
             if (this.cancelOptions.indexOf('outside') < 0) return
             if (this.inline) return
 
-            if (!this.isInWhiteList(event.target)) this.isActive = false
+            const target = isCustomElement(this) ? event.composedPath()[0] : event.target;
+            if (!this.isInWhiteList(target)) this.isActive = false
         },
 
         /**

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -162,7 +162,7 @@ export default {
         clickedOutside(event) {
             if (this.isFixed) {
                 if (this.isOpen && !this.animating) {
-                    const target = isCustomElement(this) ? event.composedPath()[0] : event.target;
+                    const target = isCustomElement(this) ? event.composedPath()[0] : event.target
                     if (this.whiteList.indexOf(target) < 0) {
                         this.cancel('outside')
                     }

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script>
-import { removeElement } from '../../utils/helpers'
+import { removeElement, isCustomElement } from '../../utils/helpers'
 
 export default {
     name: 'BSidebar',
@@ -162,7 +162,8 @@ export default {
         clickedOutside(event) {
             if (this.isFixed) {
                 if (this.isOpen && !this.animating) {
-                    if (this.whiteList.indexOf(event.target) < 0) {
+                    const target = isCustomElement(this) ? event.composedPath()[0] : event.target;
+                    if (this.whiteList.indexOf(target) < 0) {
                         this.cancel('outside')
                     }
                 }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -160,5 +160,5 @@ export function createNewEvent(eventName) {
 }
 
 export function isCustomElement(vm) {
-   return 'shadowRoot' in  vm.$root.$options
+    return 'shadowRoot' in vm.$root.$options
 }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -158,3 +158,7 @@ export function createNewEvent(eventName) {
     }
     return event
 }
+
+export function isCustomElement(vm) {
+   return 'shadowRoot' in  vm.$root.$options
+}


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Hi,

This PR adds support of handling auto-close feature in components that are wrapped in a HTML5 custom element created via @vue/web-component-wrapper. 

**Problem:** If we use components like dropdown and autocomplete, the handling of auto-close on clicking outside the element currently depends on `event.target`. In the case of customElement the `event.target` returns the customElement instead of the actual target element, due to which the component closes/toggles on clicking even on the element itself, which seems like a bug in the case of customElement.

**Solution:** [`Event.composePath()`](https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath) provide the event's path list. We can check if the Vue instance is wrapper in a customElement. And get the composedPath of the event and treat the first element as the target. This would solve the above problem. 


