### PR TITLE
0.9.0 Improvements and bugfixes

### DIFF
--- a/docs/pages/components/carousel/api/carousel.js
+++ b/docs/pages/components/carousel/api/carousel.js
@@ -369,7 +369,7 @@ export default [
             {
                 name: '<code>item</code>',
                 description: 'Custom item',
-                props: '<code>list: Array</code>, <code>index: Number</code>, <code>active: Number</code>'
+                props: '<code>...item</code>, <code>index: Number</code>, <code>active: Number</code>, <code>scroll: Number</code>'
             }
         ],
         events: [

--- a/docs/pages/components/carousel/api/carousel.js
+++ b/docs/pages/components/carousel/api/carousel.js
@@ -46,7 +46,7 @@ export default [
             },
             {
                 name: '<code>pause-info</code>',
-                description: 'Show infomation pause when <code>autoplay</code> and <code>pause-hover</code>',
+                description: 'Show information pause when <code>autoplay</code> and <code>pause-hover</code>',
                 type: 'Boolean',
                 values: '—',
                 default: '<code>true</code>'
@@ -239,6 +239,19 @@ export default [
                 name: '<code>input</code>',
                 description: 'Triggers when <code>indicator-mode</code> value is changed',
                 parameters: '<code>value: Boolean</code>, <code>value: String</code>'
+            },
+            {
+                name: '<code>click</code>',
+                description: 'Non native click event, will trigger only when clicking an element that should normally not be clickable/focusable',
+            }
+        ]
+    },
+    {
+      title: 'CarouselItem',
+        events: [
+            {
+                name: '<code>click</code>',
+                description: 'Non native click event, will trigger only on an element that should normally not be clickable/focusable',
             }
         ]
     },
@@ -362,7 +375,7 @@ export default [
             {
                 name: '<code>item</code>',
                 description: 'Custom item',
-                props: '<code>...item</code>, <code>index: Number</code>, <code>active: Number</code>, <code>scroll: Number</code>'
+                props: '<code>...item</code> (all the properties of the item are bound at the root), <code>index: Number</code>, <code>active: Number</code>, <code>scroll: Number</code>'
             }
         ],
         events: [

--- a/docs/pages/components/carousel/api/carousel.js
+++ b/docs/pages/components/carousel/api/carousel.js
@@ -261,7 +261,7 @@ export default [
             },
             {
                 name: '<code>config</code>',
-                description: 'An object to pass all configs',
+                description: 'This property was removed, if you were using it, simply rename <code>:config</code> to <code>v-bind</code>',
                 type: 'Object',
                 values: '—',
                 default: '—'

--- a/docs/pages/components/carousel/api/carousel.js
+++ b/docs/pages/components/carousel/api/carousel.js
@@ -76,13 +76,6 @@ export default [
                 default: '<code>true</code>'
             },
             {
-                name: '<code>arrow-both</code>',
-                description: 'Display the "next" and "prev" action when first or last item',
-                type: 'Boolean',
-                values: '—',
-                default: '<code>true</code>'
-            },
-            {
                 name: '<code>arrow-hover</code>',
                 description: 'Display the "next" and "prev" action when hover, but hidden on mobile',
                 type: 'Boolean',

--- a/docs/pages/components/carousel/api/carousel.js
+++ b/docs/pages/components/carousel/api/carousel.js
@@ -260,13 +260,6 @@ export default [
                 default: '—'
             },
             {
-                name: '<code>config</code>',
-                description: 'This property was removed, if you were using it, simply rename <code>:config</code> to <code>v-bind</code>',
-                type: 'Object',
-                values: '—',
-                default: '—'
-            },
-            {
                 name: '<code>has-drag</code>',
                 description: 'Toggle touch dragging, when touch not detected. auto switch mouse dragging',
                 type: 'Boolean',

--- a/docs/pages/components/carousel/examples/ExArrow.vue
+++ b/docs/pages/components/carousel/examples/ExArrow.vue
@@ -35,7 +35,7 @@
 
         <b-carousel
             :arrow="arrow"
-            :arrow-both="arrowBoth"
+            :repeat="arrowBoth"
             :arrow-hover="arrowHover"
             :icon-pack="iconPack"
             :icon-prev="iconPrev"

--- a/docs/pages/components/carousel/examples/ExCarouselList.vue
+++ b/docs/pages/components/carousel/examples/ExCarouselList.vue
@@ -25,8 +25,11 @@
                 <b-field label="Value">
                     <b-numberinput v-model="values" min="0" :max="items.length - 1" controls-position="compact"/>
                 </b-field>
+                <b-field label="Items to Show">
+                    <b-numberinput v-model="perList" min="1" :max="items.length" controls-position="compact"/>
+                </b-field>
                 <b-field label="Items to List">
-                    <b-numberinput v-model="perList" min="0" :max="items.length - 1" controls-position="compact"/>
+                    <b-numberinput v-model="increment" min="1" :max="items.length - 1" controls-position="compact"/>
                 </b-field>
             </b-field>
         </div>
@@ -35,7 +38,8 @@
             :data="items"
             :arrow="arrow"
             :arrow-hover="arrowHover"
-            :items-to-list="perList"
+            :items-to-show="perList"
+            :items-to-list="increment"
             :repeat="repeat"
             :has-drag="drag"
             :has-grayscale="gray"
@@ -53,7 +57,8 @@ export default {
             gray: false,
             opacity: false,
             values: 1,
-            perList: 1,
+            perList: 4,
+            increment: 1,
             repeat: false,
             items: [
                 {

--- a/docs/pages/components/carousel/examples/ExFull.vue
+++ b/docs/pages/components/carousel/examples/ExFull.vue
@@ -64,6 +64,7 @@
                     <div class="hero-body has-text-centered">
                         <h1 class="title">{{carousel.title}}</h1>
                         <b-input :placeholder="carousel.title"></b-input>
+                        <p>A link that <a href="#arrow">goes to arrow</a></p>
                     </div>
                 </section>
             </b-carousel-item>

--- a/docs/pages/components/carousel/examples/ExFull.vue
+++ b/docs/pages/components/carousel/examples/ExFull.vue
@@ -63,6 +63,7 @@
                 <section :class="`hero is-medium is-${carousel.color} is-bold`">
                     <div class="hero-body has-text-centered">
                         <h1 class="title">{{carousel.title}}</h1>
+                        <b-input :placeholder="carousel.title"></b-input>
                     </div>
                 </section>
             </b-carousel-item>
@@ -71,7 +72,10 @@
 </template>
 
 <script>
+import BInput from "../../../../../src/components/input/Input";
+import BField from "../../../../../src/components/field/Field";
 export default {
+    components: {BField, BInput},
     data() {
         return {
             carousel: 0,

--- a/docs/pages/components/carousel/examples/ExFull.vue
+++ b/docs/pages/components/carousel/examples/ExFull.vue
@@ -73,10 +73,7 @@
 </template>
 
 <script>
-import BInput from "../../../../../src/components/input/Input";
-import BField from "../../../../../src/components/field/Field";
 export default {
-    components: {BField, BInput},
     data() {
         return {
             carousel: 0,

--- a/docs/pages/components/carousel/examples/ExGallery.vue
+++ b/docs/pages/components/carousel/examples/ExGallery.vue
@@ -1,7 +1,7 @@
 <template>
-    <b-carousel :autoplay="false" indicator-custom :indicator-inside="false" :overlay="gallery">
+    <b-carousel :autoplay="false" indicator-custom :indicator-inside="false" :overlay="gallery" @click="switchGallery(true)">
         <b-carousel-item v-for="(item, i) in 20" :key="i">
-            <a @click="switchGallery(true)" class="image ">
+            <a class="image ">
                 <img :src="getImgUrl(i)">
             </a>
         </b-carousel-item>

--- a/docs/pages/components/carousel/examples/ExWithCard.vue
+++ b/docs/pages/components/carousel/examples/ExWithCard.vue
@@ -1,20 +1,20 @@
 <template>
     <b-carousel-list v-model="test" :data="items" :items-to-show="2">
-        <template slot="item" slot-scope="props">
+        <template slot="item" slot-scope="list">
             <div class="card">
                 <div class="card-image">
                     <figure class="image is-5by4">
-                        <a @click="info(props.index)"><img :src="props.list.image"></a>
+                        <a @click="info(list.index)"><img :src="list.image"></a>
                     </figure>
                     <b-tag type="is-danger" rounded style="position: absolute; top: 0;"><b>50%</b></b-tag>
                 </div>
                 <div class="card-content">
                     <div class="content">
-                        <p class="title is-6">{{ props.list.title }}</p>
+                        <p class="title is-6">{{ list.title }}</p>
                         <p class="subtitle is-7">@johnsmith</p>
                         <div class="field is-grouped" >
-                            <p class="control" v-if="props.list.rating">
-                                <b-rate :value="props.list.rating" show-score disabled/>
+                            <p class="control" v-if="list.rating">
+                                <b-rate :value="list.rating" show-score disabled/>
                             </p>
                             <p class="control" style="margin-left: auto">
                                 <button class="button is-small is-danger is-outlined"><b-icon size="is-small" icon="heart"/></button>

--- a/docs/pages/components/carousel/examples/ExWithList.vue
+++ b/docs/pages/components/carousel/examples/ExWithList.vue
@@ -34,15 +34,15 @@ export default {
             gallery: false,
             al: {
                 hasGrayscale: true,
-                itemsToShow: 6,
+                itemsToShow: 8,
                 breakpoints: {
                     768: {
                         hasGrayscale: false,
-                        itemsToShow: 2
+                        itemsToShow: 4
                     },
                     960: {
                         hasGrayscale: true,
-                        itemsToShow: 4
+                        itemsToShow: 6
                     }
                 }
             },

--- a/docs/pages/components/carousel/examples/ExWithList.vue
+++ b/docs/pages/components/carousel/examples/ExWithList.vue
@@ -12,7 +12,6 @@
         <span v-if="gallery" @click="switchGallery(false)" class="modal-close is-large"/>
         <template slot="list" slot-scope="props">
             <b-carousel-list
-                ref="list"
                 v-model="props.active"
                 :data="items"
                 v-bind="al"

--- a/docs/pages/components/carousel/examples/ExWithList.vue
+++ b/docs/pages/components/carousel/examples/ExWithList.vue
@@ -14,7 +14,7 @@
             <b-carousel-list
                 v-model="props.active"
                 :data="items"
-                :config="al"
+                v-bind="al"
                 :refresh="gallery"
                 @switch="props.switch($event, false)"
                 as-indicator />

--- a/docs/pages/components/carousel/examples/ExWithList.vue
+++ b/docs/pages/components/carousel/examples/ExWithList.vue
@@ -34,15 +34,15 @@ export default {
             gallery: false,
             al: {
                 hasGrayscale: true,
-                itemsToShow: 2,
+                itemsToShow: 6,
                 breakpoints: {
                     768: {
                         hasGrayscale: false,
-                        itemsToShow: 4
+                        itemsToShow: 2
                     },
                     960: {
                         hasGrayscale: true,
-                        itemsToShow: 6
+                        itemsToShow: 4
                     }
                 }
             },

--- a/docs/pages/components/carousel/examples/ExWithList.vue
+++ b/docs/pages/components/carousel/examples/ExWithList.vue
@@ -12,10 +12,10 @@
         <span v-if="gallery" @click="switchGallery(false)" class="modal-close is-large"/>
         <template slot="list" slot-scope="props">
             <b-carousel-list
+                ref="list"
                 v-model="props.active"
                 :data="items"
                 v-bind="al"
-                :refresh="gallery"
                 @switch="props.switch($event, false)"
                 as-indicator />
         </template>
@@ -86,9 +86,9 @@ export default {
         switchGallery(value) {
             this.gallery = value
             if (value) {
-                return document.documentElement.classList.add('is-clipped')
+                document.documentElement.classList.add('is-clipped')
             } else {
-                return document.documentElement.classList.remove('is-clipped')
+                document.documentElement.classList.remove('is-clipped')
             }
         }
     }

--- a/docs/pages/components/carousel/examples/ExWithList.vue
+++ b/docs/pages/components/carousel/examples/ExWithList.vue
@@ -3,9 +3,10 @@
         :autoplay="false"
         with-carousel-list
         :indicator="false"
-        :overlay="gallery">
+        :overlay="gallery"
+        @click="switchGallery(true)">
         <b-carousel-item v-for="(item, i) in items" :key="i">
-            <figure @click="switchGallery(true)" class="image">
+            <figure class="image">
                 <img :src="item.image">
             </figure>
         </b-carousel-item>

--- a/docs/pages/components/carousel/examples/ExWithList.vue
+++ b/docs/pages/components/carousel/examples/ExWithList.vue
@@ -33,7 +33,7 @@ export default {
             gallery: false,
             al: {
                 hasGrayscale: true,
-                itemsToShow: 8,
+                itemsToShow: 2,
                 breakpoints: {
                     768: {
                         hasGrayscale: false,

--- a/docs/pages/components/modal/examples/ExComponent.vue
+++ b/docs/pages/components/modal/examples/ExComponent.vue
@@ -11,19 +11,25 @@
                  :destroy-on-hide="false"
                  aria-role="dialog"
                  aria-modal>
-            <modal-form v-bind="formProps"></modal-form>
+            <template #default="props">
+                <modal-form v-bind="formProps" @close="props.close"></modal-form>
+            </template>
         </b-modal>
     </section>
 </template>
 
 <script>
     const ModalForm = {
-        props: ['email', 'password'],
+        props: ['email', 'password', 'canCancel'],
         template: `
             <form action="">
                 <div class="modal-card" style="width: auto">
                     <header class="modal-card-head">
                         <p class="modal-card-title">Login</p>
+                        <button
+                            type="button"
+                            class="delete"
+                            @click="$emit('close')"/>
                     </header>
                     <section class="modal-card-body">
                         <b-field label="Email">
@@ -48,7 +54,7 @@
                         <b-checkbox>Remember me</b-checkbox>
                     </section>
                     <footer class="modal-card-foot">
-                        <button class="button" type="button" @click="$parent.close()">Close</button>
+                        <button class="button" type="button" @click="$emit('close')">Close</button>
                         <button class="button is-primary">Login</button>
                     </footer>
                 </div>

--- a/docs/pages/components/modal/examples/ExProgrammatic.vue
+++ b/docs/pages/components/modal/examples/ExProgrammatic.vue
@@ -73,7 +73,6 @@
                     parent: this,
                     component: ModalForm,
                     hasModalCard: true,
-                    showX: false,
                     customClass: 'custom-class custom-class-2',
                     trapFocus: true
                 })

--- a/docs/pages/components/modal/examples/ExProgrammatic.vue
+++ b/docs/pages/components/modal/examples/ExProgrammatic.vue
@@ -21,6 +21,10 @@
                 <div class="modal-card" style="width: auto">
                     <header class="modal-card-head">
                         <p class="modal-card-title">Login</p>
+                        <button
+                            type="button"
+                            class="delete"
+                            @click="$emit('close')"/>
                     </header>
                     <section class="modal-card-body">
                         <b-field label="Email">
@@ -45,7 +49,7 @@
                         <b-checkbox>Remember me</b-checkbox>
                     </section>
                     <footer class="modal-card-foot">
-                        <button class="button" type="button" @click="$parent.close()">Close</button>
+                        <button class="button" type="button" @click="$emit('close')">Close</button>
                         <button class="button is-primary">Login</button>
                     </footer>
                 </div>
@@ -69,6 +73,7 @@
                     parent: this,
                     component: ModalForm,
                     hasModalCard: true,
+                    showX: false,
                     customClass: 'custom-class custom-class-2',
                     trapFocus: true
                 })

--- a/docs/pages/components/numberinput/Numberinput.vue
+++ b/docs/pages/components/numberinput/Numberinput.vue
@@ -10,6 +10,8 @@
 
         <Example :component="ExStep" :code="ExStepCode" title="Steps" vertical/>
 
+        <Example :component="ExExpon" :code="ExExponCode" title="Exponential increment" vertical/>
+
         <Example :component="ExSizes" :code="ExSizesCode" title="Sizes" vertical/>
 
         <Example :component="ExCustomize" :code="ExCustomizeCode" title="Customization" vertical />
@@ -34,6 +36,9 @@
     import ExStep from './examples/ExStep'
     import ExStepCode from '!!raw-loader!./examples/ExStep'
 
+    import ExExpon from './examples/ExExpon'
+    import ExExponCode from '!!raw-loader!./examples/ExExpon'
+
     import ExSizes from './examples/ExSizes'
     import ExSizesCode from '!!raw-loader!./examples/ExSizes'
 
@@ -53,6 +58,8 @@
                 ExSimpleCode,
                 ExTypesCode,
                 ExStepCode,
+                ExExpon,
+                ExExponCode,
                 ExCustomizeCode,
                 ExRangeCode,
                 ExSizesCode

--- a/docs/pages/components/numberinput/api/numberinput.js
+++ b/docs/pages/components/numberinput/api/numberinput.js
@@ -75,6 +75,13 @@ export default [
                 default: '—'
             },
             {
+                name: '<code>exponential</code>',
+                description: 'The factor of incrementation on long press',
+                type: 'Boolean, Number',
+                values: 'Between <code>0</code> excluded and <code>10</code>, setting to <code>true</code> is equivalent to passing <code>true</code>',
+                default: 'false'
+            },
+            {
                 name: '<code>controls-rounded</code>',
                 description: 'Show rounded controls',
                 type: 'Boolean',

--- a/docs/pages/components/numberinput/examples/ExExpon.vue
+++ b/docs/pages/components/numberinput/examples/ExExpon.vue
@@ -1,0 +1,13 @@
+<template>
+    <section>
+        <b-field>
+            <b-numberinput step="1" exponential>
+            </b-numberinput>
+        </b-field>
+
+        <b-field>
+            <b-numberinput step="1" :exponential=".5">
+            </b-numberinput>
+        </b-field>
+    </section>
+</template>

--- a/docs/pages/components/steps/api/steps.js
+++ b/docs/pages/components/steps/api/steps.js
@@ -205,6 +205,13 @@ export default [
                 type: 'Boolean',
                 values: '-',
                 default: 'true'
+            },
+            {
+                name: '<code>headerClass</code>',
+                description: 'The classes to add to the step label container',
+                type: 'String, Array, Object',
+                values: '-',
+                default: '-'
             }
         ],
         slots: [

--- a/docs/pages/components/tabs/api/tabs.js
+++ b/docs/pages/components/tabs/api/tabs.js
@@ -118,6 +118,13 @@ export default [
                 type: 'Boolean',
                 values: '-',
                 default: 'true'
+            },
+            {
+                name: '<code>headerClass</code>',
+                description: 'The classes to add to the tab header',
+                type: 'String, Array, Object',
+                values: '-',
+                default: '-'
             }
         ],
         slots: [

--- a/helper-json/attributes.json
+++ b/helper-json/attributes.json
@@ -171,10 +171,6 @@
     "description": "\tDisplay the \"next\" and \"prev\" action",
     "type": "boolean"
   },
-  "b-carousel/arrow-both": {
-    "description": "Display the \"next\" and \"prev\" action when first or last item",
-    "type": "boolean"
-  },
   "b-carousel/arrow-hover": {
     "description": "Display the \"next\" and \"prev\" action when hover, but hidden on mobile",
     "type": "boolean"

--- a/helper-json/tags.json
+++ b/helper-json/tags.json
@@ -54,7 +54,6 @@
       "pause-info-type",
       "pause-text",
       "arrow",
-      "arrow-both",
       "arrow-hover",
       "repeat",
       "icon-pack",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2112,13 +2112,15 @@
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.7.tgz",
       "integrity": "sha512-dBtBbrc+qTHy1WdfHYjBwRln4+LWqASWakLHsWHR2NWHIFkv4W3O070IGoGLEBrJBvct3r0L1BUPuvURi7kYUQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "@types/babylon": {
       "version": "6.16.5",
       "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.5.tgz",
       "integrity": "sha512-xH2e58elpj1X4ynnKp9qSnWlsRTIs6n3tgLGNfwAGHwePw0mulHQllV34n0T25uYSu1k0hRKkWXF890B1yS47w==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@types/babel-types": "*"
       }
@@ -2133,12 +2135,6 @@
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-      "dev": true
-    },
-    "@types/json-schema": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
-      "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
       "dev": true
     },
     "@types/node": {
@@ -5339,25 +5335,6 @@
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true
     },
-    "clone-deep": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
-      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
-      "dev": true,
-      "requires": {
-        "is-plain-object": "^2.0.4",
-        "kind-of": "^6.0.2",
-        "shallow-clone": "^3.0.0"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-          "dev": true
-        }
-      }
-    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -5618,6 +5595,7 @@
       "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.1.2.tgz",
       "integrity": "sha512-yePcBqEFhLOqSBtwYOGGS1exHo/s1xjekXiinh4itpNQGCu4KA1euPh1fg07N2wMITZXQkBz75Ntdt1ctGZouw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@types/babel-types": "^7.0.0",
         "@types/babylon": "^6.16.2",
@@ -8553,7 +8531,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8577,13 +8556,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8600,19 +8581,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8743,7 +8727,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8757,6 +8742,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8773,6 +8759,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8781,13 +8768,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8808,6 +8797,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8896,7 +8886,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8910,6 +8901,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9005,7 +8997,8 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9047,6 +9040,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9068,6 +9062,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9116,13 +9111,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -11334,7 +11331,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
       "integrity": "sha1-Fzb939lyTyijaCrcYjCufk6Weds=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -15517,7 +15515,8 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-1.3.3.tgz",
       "integrity": "sha512-qE3YhESP2mRAWMFJgKdtT5D7ckThRScXRwkfo+Erqga7dyJdY3ZquspprMCj/9sJ2ijm5hXFWQE/A3l4poMWiQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "pug-filters": {
       "version": "3.1.1",
@@ -15651,7 +15650,8 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-2.0.5.tgz",
       "integrity": "sha512-P+rXKn9un4fQY77wtpcuFyvFaBww7/91f3jHa154qU26qFAnOe6SW1CbIDcxiG5lLK9HazYrMCCuDvNgDQNptw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "pug-strip-comments": {
       "version": "1.0.4",
@@ -15667,7 +15667,8 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.8.tgz",
       "integrity": "sha512-GMu3M5nUL3fju4/egXwZO0XLi6fW/K3T3VTgFQ14GxNi8btlxgT5qZL//JwZFm/2Fa64J/PNS8AZeys3wiMkVA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "pump": {
       "version": "2.0.1",
@@ -16263,6 +16264,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
+    },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
       "dev": true
     },
     "resolve": {
@@ -16912,64 +16919,9 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.26.8.tgz",
       "integrity": "sha512-yvtzyrKLGiXQu7H12ekXqsfoGT/aTKeMDyVzCB675k1HYuaj0py63i8Uf4SI9CHXj6apDhpfwbUr3gGOjdpu2Q==",
       "dev": true,
+      "optional": true,
       "requires": {
         "chokidar": ">=2.0.0 <4.0.0"
-      }
-    },
-    "sass-loader": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-8.0.2.tgz",
-      "integrity": "sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==",
-      "dev": true,
-      "requires": {
-        "clone-deep": "^4.0.1",
-        "loader-utils": "^1.2.3",
-        "neo-async": "^2.6.1",
-        "schema-utils": "^2.6.1",
-        "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.12.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
-          "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "ajv-keywords": {
-          "version": "3.4.1",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
-          "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
-          "dev": true
-        },
-        "fast-deep-equal": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-          "dev": true
-        },
-        "schema-utils": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.4",
-            "ajv": "^6.12.2",
-            "ajv-keywords": "^3.4.1"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
       }
     },
     "sax": {
@@ -17218,23 +17170,6 @@
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "shallow-clone": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-      "dev": true,
-      "requires": {
-        "kind-of": "^6.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-          "dev": true
-        }
       }
     },
     "shebang-command": {
@@ -19102,16 +19037,6 @@
       "resolved": "https://registry.npmjs.org/vue-runtime-helpers/-/vue-runtime-helpers-1.0.0.tgz",
       "integrity": "sha512-DgwCNgIXkq1GJsWwtFOjA/K2nxpjyon/QqAut0EiwrMHBatAPbfdqksDdRoK15b5YrSJRa59rx3pc0L6V4udUA==",
       "dev": true
-    },
-    "vue-style-loader": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.2.tgz",
-      "integrity": "sha512-0ip8ge6Gzz/Bk0iHovU9XAUQaFt/G2B61bnWa2tCcqqdgfHs1lF9xXorFbE55Gmy92okFT+8bfmySuUOu13vxQ==",
-      "dev": true,
-      "requires": {
-        "hash-sum": "^1.0.2",
-        "loader-utils": "^1.0.2"
-      }
     },
     "vue-template-compiler": {
       "version": "2.6.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2748,6 +2748,12 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
     },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
     "ansi-escapes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
@@ -3114,6 +3120,16 @@
       "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg==",
       "dev": true
     },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "dev": true,
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -3296,6 +3312,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+      "dev": true
+    },
+    "async-foreach": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+      "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
       "dev": true
     },
     "async-limiter": {
@@ -4480,6 +4502,15 @@
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
     },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "dev": true,
+      "requires": {
+        "inherits": "~2.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.0.tgz",
@@ -5335,6 +5366,29 @@
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true
     },
+    "clone-deep": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.3.0.tgz",
+      "integrity": "sha1-NIxhrpzb4O3+BT2R/0zFIdeQ7eg=",
+      "dev": true,
+      "requires": {
+        "for-own": "^1.0.0",
+        "is-plain-object": "^2.0.1",
+        "kind-of": "^3.2.2",
+        "shallow-clone": "^0.1.2"
+      },
+      "dependencies": {
+        "for-own": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+          "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+          "dev": true,
+          "requires": {
+            "for-in": "^1.0.1"
+          }
+        }
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -5580,6 +5634,12 @@
       "requires": {
         "date-now": "^0.1.4"
       }
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true
     },
     "consolidate": {
       "version": "0.15.1",
@@ -6670,6 +6730,12 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
       "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "dev": true
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
     },
     "depd": {
@@ -9123,6 +9189,18 @@
         }
       }
     },
+    "fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      }
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -9134,6 +9212,31 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
+    },
+    "gaze": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
+      "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
+      "dev": true,
+      "requires": {
+        "globule": "^1.0.0"
+      }
     },
     "generic-names": {
       "version": "1.0.3",
@@ -9288,6 +9391,17 @@
         }
       }
     },
+    "globule": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.2.tgz",
+      "integrity": "sha512-7IDTQTIu2xzXkT+6mlluidnWo+BypnbSoEVVQCGfzqnl5Ik8d3e1d4wycb8Rj9tWW+Z39uPWsdlquqiqPCd/pA==",
+      "dev": true,
+      "requires": {
+        "glob": "~7.1.1",
+        "lodash": "~4.17.10",
+        "minimatch": "~3.0.2"
+      }
+    },
     "good-listener": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
@@ -9379,6 +9493,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
     "has-value": {
@@ -9841,6 +9961,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "in-publish": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz",
+      "integrity": "sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ==",
       "dev": true
     },
     "indent-string": {
@@ -12243,6 +12369,12 @@
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
+    "lodash.tail": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
+      "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
+      "dev": true
+    },
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -12640,6 +12772,24 @@
         }
       }
     },
+    "mixin-object": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
+      "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
+      "dev": true,
+      "requires": {
+        "for-in": "^0.1.3",
+        "is-extendable": "^0.1.1"
+      },
+      "dependencies": {
+        "for-in": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+          "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
+          "dev": true
+        }
+      }
+    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -12700,8 +12850,7 @@
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -12841,6 +12990,37 @@
       "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
       "dev": true
     },
+    "node-gyp": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
+      "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
+      "dev": true,
+      "requires": {
+        "fstream": "^1.0.0",
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": "^2.87.0",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^2.0.0",
+        "which": "1"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        }
+      }
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -12921,6 +13101,43 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
+        }
+      }
+    },
+    "node-sass": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.14.1.tgz",
+      "integrity": "sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==",
+      "dev": true,
+      "requires": {
+        "async-foreach": "^0.1.3",
+        "chalk": "^1.1.1",
+        "cross-spawn": "^3.0.0",
+        "gaze": "^1.0.0",
+        "get-stdin": "^4.0.1",
+        "glob": "^7.0.3",
+        "in-publish": "^2.0.0",
+        "lodash": "^4.17.15",
+        "meow": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "nan": "^2.13.2",
+        "node-gyp": "^3.8.0",
+        "npmlog": "^4.0.0",
+        "request": "^2.88.0",
+        "sass-graph": "2.2.5",
+        "stdout-stream": "^1.4.0",
+        "true-case-path": "^1.0.2"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+          "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
         }
       }
     },
@@ -13036,6 +13253,18 @@
         "commander": "^2.9.0",
         "npm-path": "^2.0.2",
         "which": "^1.2.10"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "dev": true,
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "nth-check": {
@@ -16924,6 +17153,190 @@
         "chokidar": ">=2.0.0 <4.0.0"
       }
     },
+    "sass-graph": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.5.tgz",
+      "integrity": "sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "lodash": "^4.0.0",
+        "scss-tokenizer": "^0.2.3",
+        "yargs": "^13.3.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "yargs": {
+          "version": "13.3.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "sass-loader": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-6.0.6.tgz",
+      "integrity": "sha512-c3/Zc+iW+qqDip6kXPYLEgsAu2lf4xz0EZDplB7EmSUMda12U1sGJPetH55B/j9eu0bTtKzKlNPWWyYC7wFNyQ==",
+      "dev": true,
+      "requires": {
+        "async": "^2.1.5",
+        "clone-deep": "^0.3.0",
+        "loader-utils": "^1.0.1",
+        "lodash.tail": "^4.1.1",
+        "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -16979,6 +17392,27 @@
       "resolved": "https://registry.npmjs.org/scrollreveal/-/scrollreveal-3.3.6.tgz",
       "integrity": "sha512-5HiAtVqwffX18w/kqXkD+S54A0MoE4xLAwQcszEYGuy+EsRUoHsw1BhFpxGCcbTXIy5HMtj/qmLDbpQ+J3llig==",
       "dev": true
+    },
+    "scss-tokenizer": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+      "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
+      "dev": true,
+      "requires": {
+        "js-base64": "^2.1.8",
+        "source-map": "^0.4.2"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
+      }
     },
     "select": {
       "version": "1.1.2",
@@ -17170,6 +17604,41 @@
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "shallow-clone": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
+      "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
+      "dev": true,
+      "requires": {
+        "is-extendable": "^0.1.1",
+        "kind-of": "^2.0.1",
+        "lazy-cache": "^0.2.3",
+        "mixin-object": "^2.0.1"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.0.2"
+          }
+        },
+        "lazy-cache": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+          "dev": true
+        }
       }
     },
     "shebang-command": {
@@ -17708,6 +18177,15 @@
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
       "dev": true
     },
+    "stdout-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
+      "integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.1"
+      }
+    },
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
@@ -18093,6 +18571,17 @@
       "integrity": "sha512-2wsvQ+4GwBvLPLWsNfLCDYGsW6xb7aeC6utq2Qh0PFwgEy7K7dsma9Jsmb2zSQj7GvYAyUGSntLtsv++GmgL1A==",
       "dev": true
     },
+    "tar": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+      "dev": true,
+      "requires": {
+        "block-stream": "*",
+        "fstream": "^1.0.12",
+        "inherits": "2"
+      }
+    },
     "teeny-request": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-6.0.1.tgz",
@@ -18350,6 +18839,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+    },
+    "true-case-path": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
+      "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.2"
+      }
     },
     "tsconfig": {
       "version": "7.0.0",
@@ -19037,6 +19535,16 @@
       "resolved": "https://registry.npmjs.org/vue-runtime-helpers/-/vue-runtime-helpers-1.0.0.tgz",
       "integrity": "sha512-DgwCNgIXkq1GJsWwtFOjA/K2nxpjyon/QqAut0EiwrMHBatAPbfdqksDdRoK15b5YrSJRa59rx3pc0L6V4udUA==",
       "dev": true
+    },
+    "vue-style-loader": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-3.0.1.tgz",
+      "integrity": "sha1-yLY5uy8kuvnXgnTcF+TyZMHe2gg=",
+      "dev": true,
+      "requires": {
+        "hash-sum": "^1.0.2",
+        "loader-utils": "^1.0.2"
+      }
     },
     "vue-template-compiler": {
       "version": "2.6.11",
@@ -20823,6 +21331,15 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
     },
     "window-size": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "pre-commit": "1.2.2",
     "prerender-spa-plugin": "3.4.0",
     "raw-loader": "0.5.1",
+    "resize-observer-polyfill": "^1.5.1",
     "rimraf": "2.6.0",
     "rollup": "1.17.0",
     "rollup-copy-plugin": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "jest": "23.5.0",
     "jest-serializer-vue": "0.3.0",
     "lint-staged": "6.1.1",
-    "node-sass": "4.11.0",
+    "node-sass": "4.14.1",
     "opn": "4.0.2",
     "optimize-css-assets-webpack-plugin": "3.2.0",
     "optimize-js-plugin": "0.0.4",

--- a/src/components/carousel/Carousel.spec.js
+++ b/src/components/carousel/Carousel.spec.js
@@ -1,12 +1,12 @@
 import { shallowMount } from '@vue/test-utils'
 import BCarousel from '@components/carousel/Carousel'
 import BIcon from '@components/icon/Icon'
-import InjectedChildMixin from '../../utils/InjectedChildMixin'
+import {default as InjectedChildMixin, Sorted} from '../../utils/InjectedChildMixin'
 
 let wrapper
 
 const mockCarouselItems = {
-    mixins: [InjectedChildMixin('carousel')],
+    mixins: [InjectedChildMixin('carousel', Sorted)],
     name: 'BCarouselItem',
     template: '<div></div>',
     computed: {

--- a/src/components/carousel/Carousel.spec.js
+++ b/src/components/carousel/Carousel.spec.js
@@ -21,6 +21,10 @@ describe('BCarousel', () => {
         wrapper = shallowMount(BCarousel, {
             sync: false,
             Component: BIcon,
+            propsData: {
+                autoplay: false,
+                repeat: false
+            },
             stubs: {'b-carousel-item': mockCarouselItems},
             slots: {
                 default: [
@@ -57,20 +61,20 @@ describe('BCarousel', () => {
         wrapper.vm.pauseTimer = jest.fn(wrapper.vm.pauseTimer)
         wrapper.vm.next = jest.fn(wrapper.vm.next)
 
-        let autoplay = false
+        let autoplay = true
         wrapper.setProps({ autoplay })
-        await wrapper.vm.$nextTick()
-
-        expect(wrapper.vm.autoplay).toBe(autoplay)
-        expect(wrapper.vm.pauseTimer).toHaveBeenCalled()
-
-        autoplay = true
-        wrapper.setProps({ autoplay })
-
         await wrapper.vm.$nextTick()
 
         expect(wrapper.vm.autoplay).toBe(autoplay)
         expect(wrapper.vm.startTimer).toHaveBeenCalled()
+
+        autoplay = false
+        wrapper.setProps({ autoplay })
+
+        await wrapper.vm.$nextTick()
+
+        expect(wrapper.vm.autoplay).toBe(autoplay)
+        expect(wrapper.vm.pauseTimer).toHaveBeenCalled()
     })
 
     it('returns item classes accordingly', () => {
@@ -122,10 +126,57 @@ describe('BCarousel', () => {
         expect(wrapper.vm.activeChild).toBe(last) // Wont go above last when not using repeat
     })
 
-    it('pauses on hover', async () => {
+    it('autoplays', async () => {
         jest.useFakeTimers()
-        wrapper.setProps({ autoplay: true, 'pause-hover': false, interval: 1 })
+        wrapper.setProps({ autoplay: true, 'pause-hover': false, repeat: false })
+
+        expect(wrapper.vm.activeChild).toBe(0)
+
+        await wrapper.vm.$nextTick()
+        jest.runOnlyPendingTimers()
+        await wrapper.vm.$nextTick()
+        expect(wrapper.vm.activeChild).toBe(1)
 
         jest.runOnlyPendingTimers()
+        await wrapper.vm.$nextTick()
+        expect(wrapper.vm.activeChild).toBe(1)
+
+        wrapper.setProps({ repeat: true })
+
+        await wrapper.vm.$nextTick()
+        jest.runOnlyPendingTimers()
+        await wrapper.vm.$nextTick()
+        expect(wrapper.vm.activeChild).toBe(0)
+    })
+
+    it('pauses on hover', async () => {
+        jest.useFakeTimers()
+        wrapper.setProps({ autoplay: true, 'pause-hover': true, repeat: true })
+
+        await wrapper.vm.$nextTick()
+        jest.runOnlyPendingTimers()
+        await wrapper.vm.$nextTick()
+
+        expect(wrapper.vm.activeChild).toBe(1)
+
+        jest.runOnlyPendingTimers()
+        await wrapper.vm.$nextTick()
+
+        expect(wrapper.vm.activeChild).toBe(0)
+
+        wrapper.find('.carousel').trigger('mouseenter')
+
+        jest.runOnlyPendingTimers()
+        await wrapper.vm.$nextTick()
+
+        expect(wrapper.vm.activeChild).toBe(0)
+
+        wrapper.find('.carousel').trigger('mouseleave')
+        expect(wrapper.vm.activeChild).toBe(0)
+
+        jest.runOnlyPendingTimers()
+        await wrapper.vm.$nextTick()
+
+        expect(wrapper.vm.activeChild).toBe(1)
     })
 })

--- a/src/components/carousel/Carousel.spec.js
+++ b/src/components/carousel/Carousel.spec.js
@@ -179,4 +179,12 @@ describe('BCarousel', () => {
 
         expect(wrapper.vm.activeChild).toBe(1)
     })
+
+    it('destroys correctly', async () => {
+        wrapper.setProps({autoplay: true})
+        await wrapper.vm.$nextTick()
+        expect(wrapper.vm.timer).toBeTruthy()
+        wrapper.destroy()
+        expect(wrapper.vm.timer).toBeFalsy()
+    })
 })

--- a/src/components/carousel/Carousel.vue
+++ b/src/components/carousel/Carousel.vue
@@ -306,7 +306,7 @@ export default {
         // handle drag event
         dragStart(event) {
             if (!this.hasDrag ||
-                (!event.target.draggable && !event.target.tagName.match(/^(section|div|h[1-6]|p)$/i))) return
+                (!event.target.draggable && event.target.textContent.trim() === '')) return
             this.dragX = event.touches ? event.changedTouches[0].pageX : event.pageX
             if (event.touches) {
                 this.pauseTimer()

--- a/src/components/carousel/Carousel.vue
+++ b/src/components/carousel/Carousel.vue
@@ -228,10 +228,16 @@ export default {
             }
         },
         /**
-         *  When autoplay is change, set by status
+         *  When autoplay is changed, start or pause timer accordingly
          */
         autoplay(status) {
             status ? this.startTimer() : this.pauseTimer()
+        },
+        /**
+         *  Since the timer can get paused at the end, if repeat is changed we need to restart it
+         */
+        repeat(status) {
+            if (status) { this.startTimer() }
         }
     },
     methods: {

--- a/src/components/carousel/Carousel.vue
+++ b/src/components/carousel/Carousel.vue
@@ -131,10 +131,6 @@ export default {
             type: Boolean,
             default: true
         },
-        arrowBoth: {
-            type: Boolean,
-            default: true
-        },
         arrowHover: {
             type: Boolean,
             default: true
@@ -300,7 +296,7 @@ export default {
         },
         // checking arrow between both
         checkArrow(value) {
-            if (this.arrowBoth) return true
+            if (this.repeat) return true
             if (this.activeChild !== value) return true
         },
         // handle drag event

--- a/src/components/carousel/Carousel.vue
+++ b/src/components/carousel/Carousel.vue
@@ -305,7 +305,8 @@ export default {
         },
         // handle drag event
         dragStart(event) {
-            if (!this.hasDrag || !event.target.draggable) return
+            if (!this.hasDrag ||
+                (!event.target.draggable && !event.target.tagName.match(/^(section|div|h[1-6]|p)$/i))) return
             this.dragX = event.touches ? event.changedTouches[0].pageX : event.pageX
             if (event.touches) {
                 this.pauseTimer()

--- a/src/components/carousel/Carousel.vue
+++ b/src/components/carousel/Carousel.vue
@@ -324,11 +324,10 @@ export default {
                 } else {
                     this.prev()
                 }
-            } else if (event.target.tagName !== 'A' && !event.target.closest('.carousel-arrow')) {
-                this.sortedItems[this.activeChild].$emit('click')
-                this.$emit('click')
             } else {
                 event.target.click()
+                this.sortedItems[this.activeChild].$emit('click')
+                this.$emit('click')
             }
             if (event.touches) {
                 this.startTimer()

--- a/src/components/carousel/Carousel.vue
+++ b/src/components/carousel/Carousel.vue
@@ -214,7 +214,7 @@ export default {
             return this.repeat || this.activeChild !== 0
         },
         hasNext() {
-            return this.repeat || this.activeChild < this.childItems.length
+            return this.repeat || this.activeChild < this.childItems.length - 1
         }
     },
     watch: {

--- a/src/components/carousel/Carousel.vue
+++ b/src/components/carousel/Carousel.vue
@@ -24,7 +24,7 @@
                 class="carousel-arrow"
                 :class="{'is-hovered': arrowHover}">
                 <b-icon
-                    v-if="checkArrow(0)"
+                    v-show="hasPrev"
                     class="has-icons-left"
                     @click.native="prev"
                     :pack="iconPack"
@@ -32,7 +32,7 @@
                     :size="iconSize"
                     both />
                 <b-icon
-                    v-if="checkArrow(childItems.length - 1)"
+                    v-show="hasNext"
                     class="has-icons-right"
                     @click.native="next"
                     :pack="iconPack"
@@ -84,7 +84,7 @@
 import config from '../../utils/config'
 
 import Icon from '../icon/Icon'
-import ProviderParentMixin from '../../utils/ProviderParentMixin'
+import {default as ProviderParentMixin, Sorted} from '../../utils/ProviderParentMixin'
 import {mod, bound} from '../../utils/helpers'
 
 export default {
@@ -92,7 +92,7 @@ export default {
     components: {
         [Icon.name]: Icon
     },
-    mixins: [ProviderParentMixin('carousel')],
+    mixins: [ProviderParentMixin('carousel', Sorted)],
     props: {
         value: {
             type: Number,
@@ -207,6 +207,14 @@ export default {
                 this.indicatorCustom && this.indicatorCustomSize,
                 this.indicatorInside && this.indicatorPosition
             ]
+        },
+
+        // checking arrows
+        hasPrev() {
+            return this.repeat || this.activeChild !== 0
+        },
+        hasNext() {
+            return this.repeat || this.activeChild < this.childItems.length
         }
     },
     watch: {
@@ -293,11 +301,6 @@ export default {
         },
         next() {
             this.changeActive(this.activeChild + 1, 1)
-        },
-        // checking arrow between both
-        checkArrow(value) {
-            if (this.repeat) return true
-            if (this.activeChild !== value) return true
         },
         // handle drag event
         dragStart(event) {

--- a/src/components/carousel/Carousel.vue
+++ b/src/components/carousel/Carousel.vue
@@ -22,7 +22,6 @@
             <div
                 v-if="arrow"
                 class="carousel-arrow"
-                @mousedown.stop
                 :class="{'is-hovered': arrowHover}">
                 <b-icon
                     v-if="checkArrow(0)"
@@ -318,7 +317,7 @@ export default {
             if (this.dragX === false) return
             const detected = event.touches ? event.changedTouches[0].pageX : event.pageX
             const diffX = detected - this.dragX
-            if (Math.abs(diffX) > 50) {
+            if (Math.abs(diffX) > 30) {
                 if (diffX < 0) {
                     this.next()
                 } else {

--- a/src/components/carousel/CarouselItem.spec.js
+++ b/src/components/carousel/CarouselItem.spec.js
@@ -1,11 +1,11 @@
 import { shallowMount } from '@vue/test-utils'
 import BCarouselItem from '@components/carousel/CarouselItem'
-import ProviderParentMixin from '../../utils/ProviderParentMixin'
+import { default as ProviderParentMixin, Sorted } from '../../utils/ProviderParentMixin'
 
 let wrapper
 const BCarousel = {
     template: '<b-carousel-stub></b-carousel-stub>',
-    mixins: [ProviderParentMixin('carousel')]
+    mixins: [ProviderParentMixin('carousel', Sorted)]
 }
 
 describe('BCarouselItem', () => {

--- a/src/components/carousel/CarouselItem.spec.js
+++ b/src/components/carousel/CarouselItem.spec.js
@@ -1,18 +1,11 @@
 import { shallowMount } from '@vue/test-utils'
 import BCarouselItem from '@components/carousel/CarouselItem'
+import ProviderParentMixin from '../../utils/ProviderParentMixin'
 
 let wrapper
 const BCarousel = {
     template: '<b-carousel-stub></b-carousel-stub>',
-    data() {
-        return {
-            childItems: [],
-            _isCarousel: true
-        }
-    },
-    methods: {
-        refreshSlots: jest.fn()
-    }
+    mixins: [ProviderParentMixin('carousel')]
 }
 
 describe('BCarouselItem', () => {
@@ -29,10 +22,5 @@ describe('BCarouselItem', () => {
 
     it('render correctly', () => {
         expect(wrapper.html()).toMatchSnapshot()
-    })
-
-    it('set action when status is called', () => {
-        wrapper.vm.status()
-        expect(wrapper.vm.isActive).toBeFalsy()
     })
 })

--- a/src/components/carousel/CarouselItem.vue
+++ b/src/components/carousel/CarouselItem.vue
@@ -7,11 +7,11 @@
 </template>
 
 <script>
-import InjectedChildMixin from '../../utils/InjectedChildMixin'
+import {default as InjectedChildMixin, Sorted} from '../../utils/InjectedChildMixin'
 
 export default {
     name: 'BCarouselItem',
-    mixins: [InjectedChildMixin('carousel')],
+    mixins: [InjectedChildMixin('carousel', Sorted)],
     data() {
         return {
             transitionName: null

--- a/src/components/carousel/CarouselItem.vue
+++ b/src/components/carousel/CarouselItem.vue
@@ -7,44 +7,27 @@
 </template>
 
 <script>
+import InjectedChildMixin from '../../utils/InjectedChildMixin'
+
 export default {
     name: 'BCarouselItem',
+    mixins: [InjectedChildMixin('carousel')],
     data() {
         return {
-            _isCarouselItem: true,
-            isActive: false,
             transitionName: null
         }
     },
     computed: {
         transition() {
-            if (this.$parent.animated === 'fade') {
+            if (this.parent.animated === 'fade') {
                 return 'fade'
-            } else {
-                return this.transitionName
+            } else if (this.parent.transition) {
+                return 'slide-' + this.parent.transition
             }
+        },
+        isActive() {
+            return this.parent.activeChild === this.index
         }
-    },
-    methods: {
-        /**
-        * Status of item, alter animation name based on action.
-        */
-        status(value, action) {
-            this.transitionName = action
-                ? 'slide-next'
-                : 'slide-prev'
-            this.isActive = value
-        }
-    },
-    created() {
-        if (!this.$parent.$data._isCarousel) {
-            this.$destroy()
-            throw new Error('You should wrap bCarouselItem on a bCarousel')
-        }
-        this.$parent.refreshSlots()
-    },
-    beforeDestroy() {
-        this.$parent.refreshSlots()
     }
 }
 </script>

--- a/src/components/carousel/CarouselList.spec.js
+++ b/src/components/carousel/CarouselList.spec.js
@@ -103,7 +103,7 @@ describe('BCarouselList', () => {
             value: 8
         })
 
-        expect(wrapper.vm.activeItem).toBe(4)
+        expect(wrapper.vm.scrollIndex).toBe(4)
         expect(wrapper.vm.hasNext).toBe(false)
     })
 
@@ -115,19 +115,19 @@ describe('BCarouselList', () => {
             value: 0
         })
 
-        expect(wrapper.vm.activeItem).toBe(0)
+        expect(wrapper.vm.scrollIndex).toBe(0)
         wrapper.vm.next()
         wrapper.vm.next()
         wrapper.vm.next()
         wrapper.vm.next()
         await wrapper.vm.$nextTick()
-        expect(wrapper.vm.activeItem).toBe(4)
+        expect(wrapper.vm.scrollIndex).toBe(4)
 
         wrapper.vm.next()
-        expect(wrapper.vm.activeItem).toBe(0)
+        expect(wrapper.vm.scrollIndex).toBe(0)
 
         wrapper.vm.prev()
-        expect(wrapper.vm.activeItem).toBe(4)
+        expect(wrapper.vm.scrollIndex).toBe(4)
     })
 
     it('removes events listener when removed', () => {

--- a/src/components/carousel/CarouselList.spec.js
+++ b/src/components/carousel/CarouselList.spec.js
@@ -59,17 +59,17 @@ describe('BCarouselList', () => {
 
     it('uses breakpoints', async () => {
         wrapper.setProps({
-            itemsToShow: 8,
-            itemsToList: 2,
+            itemsToShow: 4,
+            itemsToList: 1,
             breakpoints: {
                 768: {
                     hasGrayscale: false,
-                    itemsToShow: 4,
-                    itemsToList: 1
+                    itemsToShow: 6,
+                    itemsToList: 2
                 },
                 960: {
                     hasGrayscale: true,
-                    itemsToShow: 6
+                    itemsToShow: 8
                 }
             }
         })

--- a/src/components/carousel/CarouselList.spec.js
+++ b/src/components/carousel/CarouselList.spec.js
@@ -3,11 +3,48 @@ import BCarouselList from '@components/carousel/CarouselList'
 import BIcon from '@components/icon/Icon'
 
 let wrapper
+const data = [
+    {
+        title: 'Slide 1',
+        image: 'https://picsum.photos/id/0/1230/500'
+    },
+    {
+        title: 'Slide 2',
+        image: 'https://picsum.photos/id/1/1230/500'
+    },
+    {
+        title: 'Slide 3',
+        image: 'https://picsum.photos/id/2/1230/500'
+    },
+    {
+        title: 'Slide 4',
+        image: 'https://picsum.photos/id/3/1230/500'
+    },
+    {
+        title: 'Slide 5',
+        image: 'https://picsum.photos/id/4/1230/500'
+    },
+    {
+        title: 'Slide 6',
+        image: 'https://picsum.photos/id/5/1230/500'
+    },
+    {
+        title: 'Slide 7',
+        image: 'https://picsum.photos/id/6/1230/500'
+    },
+    {
+        title: 'Slide 8',
+        image: 'https://picsum.photos/id/7/1230/500'
+    }
+]
 
 describe('BCarouselList', () => {
     beforeEach(() => {
         wrapper = shallowMount(BCarouselList, {
-            Component: BIcon
+            Component: BIcon,
+            propsData: {
+                data
+            }
         })
     })
 
@@ -18,5 +55,119 @@ describe('BCarouselList', () => {
 
     it('render correctly', () => {
         expect(wrapper.html()).toMatchSnapshot()
+    })
+
+    it('uses breakpoints', async () => {
+        wrapper.setProps({
+            itemsToShow: 8,
+            itemsToList: 2,
+            breakpoints: {
+                768: {
+                    hasGrayscale: false,
+                    itemsToShow: 4,
+                    itemsToList: 1
+                },
+                960: {
+                    hasGrayscale: true,
+                    itemsToShow: 6
+                }
+            }
+        })
+
+        await wrapper.vm.$nextTick()
+
+        expect(wrapper.vm.settings.itemsToShow).toBe(8)
+
+        global.innerWidth = 960
+        global.dispatchEvent(new Event('resize'))
+        await wrapper.vm.$nextTick()
+
+        expect(wrapper.vm.settings.itemsToShow).toBe(8)
+
+        global.innerWidth = 959
+        global.dispatchEvent(new Event('resize'))
+        await wrapper.vm.$nextTick()
+
+        expect(wrapper.vm.settings.itemsToShow).toBe(6)
+
+        global.innerWidth = 767
+        global.dispatchEvent(new Event('resize'))
+        await wrapper.vm.$nextTick()
+        expect(wrapper.vm.settings.itemsToShow).toBe(4)
+        expect(wrapper.vm.settings.itemsToList).toBe(1)
+    })
+
+    it('doesn\'t show empty slots', async () => {
+        wrapper.setProps({
+            itemsToShow: 4,
+            value: 8
+        })
+
+        expect(wrapper.vm.activeItem).toBe(4)
+        expect(wrapper.vm.hasNext).toBe(false)
+    })
+
+    it('repeats', async () => {
+        wrapper.setProps({
+            itemsToShow: 4,
+            itemsToList: 1,
+            repeat: true,
+            value: 0
+        })
+
+        expect(wrapper.vm.activeItem).toBe(0)
+        wrapper.vm.next()
+        wrapper.vm.next()
+        wrapper.vm.next()
+        wrapper.vm.next()
+        await wrapper.vm.$nextTick()
+        expect(wrapper.vm.activeItem).toBe(4)
+
+        wrapper.vm.next()
+        expect(wrapper.vm.activeItem).toBe(0)
+
+        wrapper.vm.prev()
+        expect(wrapper.vm.activeItem).toBe(4)
+    })
+
+    it('removes events listener when removed', () => {
+        const map = {}
+        window.removeEventListener = jest.fn((event, cb) => {
+            map[event] = cb
+        })
+        wrapper.find('.carousel-list').trigger('mousedown')
+        wrapper.destroy()
+
+        expect(map.resize).toBe(wrapper.vm.resized)
+        expect(map.mousemove).toBe(wrapper.vm.dragMove)
+        expect(map.mouseup).toBe(wrapper.vm.dragEnd)
+    })
+
+    it('drags correctly', async () => {
+        wrapper.setProps({
+            itemsToShow: 4
+        })
+        wrapper.setData({delta: 0})
+        wrapper.vm._computedWatchers['itemWidth'].value = 100
+
+        await wrapper.vm.$nextTick()
+        expect(wrapper.vm.translation).toBe(-0)
+
+        wrapper.setData({delta: -600})
+        await wrapper.vm.$nextTick()
+        expect(wrapper.vm.translation).toBe(-0)
+
+        wrapper.setData({delta: 2000})
+        await wrapper.vm.$nextTick()
+        expect(wrapper.vm.translation).toBe(-400)
+
+        wrapper.setProps({
+            value: 4
+        })
+        expect(wrapper.vm.translation).toBe(-400)
+        await wrapper.vm.$nextTick()
+        wrapper.setData({delta: -300})
+        await wrapper.vm.$nextTick()
+        expect(wrapper.vm.translation).toBe(-100)
     })
 })

--- a/src/components/carousel/CarouselList.vue
+++ b/src/components/carousel/CarouselList.vue
@@ -111,7 +111,6 @@ export default {
                 return config.defaultIconNext
             }
         },
-        refresh: Boolean,
         breakpoints: {
             type: Object,
             default: () => ({})
@@ -124,7 +123,9 @@ export default {
             dragging: false,
             hold: 0,
             windowWidth: 0,
-            touch: false
+            touch: false,
+            observer: null,
+            refresh_: 0
         }
     },
     computed: {
@@ -172,7 +173,7 @@ export default {
         itemWidth() {
             if (this.windowWidth) { // Ensure component is mounted
                 /* eslint-disable-next-line */
-                this.asIndicator && this.refresh; // We force the computed property to refresh if this prop is changed
+                this.refresh_; // We force the computed property to refresh if this prop is changed
 
                 const rect = this.$el.getBoundingClientRect()
                 return rect.width / this.settings.itemsToShow
@@ -248,9 +249,16 @@ export default {
             this.delta = 0
             window.removeEventListener(this.touch ? 'touchmove' : 'mousemove', this.dragMove)
             window.removeEventListener(this.touch ? 'touchend' : 'mouseup', this.dragEnd)
+        },
+        refresh() {
+            this.$nextTick(() => {
+                this.refresh_++
+            })
         }
     },
     mounted() {
+        this.observer = new ResizeObserver(this.refresh)
+        this.observer.observe(this.$el)
         window.addEventListener('resize', this.resized)
         this.resized()
         if (this.$attrs.config) {
@@ -258,7 +266,8 @@ export default {
         }
     },
     beforeDestroy() {
-        window.removeEventListener('resize', this.resized)
+        this.observer.disconnect()
+        this.window.removeEventListener('resize', this.resized)
         this.dragEnd()
     }
 }

--- a/src/components/carousel/CarouselList.vue
+++ b/src/components/carousel/CarouselList.vue
@@ -32,22 +32,22 @@
         <div
             v-if="arrow"
             class="carousel-arrow"
-            :class="{'is-hovered': arrowHover}">
+            :class="{'is-hovered': settings.arrowHover}">
             <b-icon
                 v-show="hasPrev"
                 class="has-icons-left"
                 @click.native.prevent="prev"
-                :pack="iconPack"
-                :icon="iconPrev"
-                :size="iconSize"
+                :pack="settings.iconPack"
+                :icon="settings.iconPrev"
+                :size="settings.iconSize"
                 both />
             <b-icon
                 v-show="hasNext"
                 class="has-icons-right"
                 @click.native.prevent="next"
-                :pack="iconPack"
-                :icon="iconNext"
-                :size="iconSize"
+                :pack="settings.iconPack"
+                :icon="settings.iconNext"
+                :size="settings.iconSize"
                 both />
         </div>
     </div>
@@ -131,8 +131,8 @@ export default {
         listClass() {
             return [
                 {
-                    'has-grayscale': this.settings.hasGrayscale || this.hasGrayscale,
-                    'has-opacity': this.settings.hasOpacity || this.hasOpacity,
+                    'has-grayscale': this.settings.hasGrayscale,
+                    'has-opacity': this.settings.hasOpacity,
                     'is-dragging': this.dragging
                 }
             ]
@@ -150,17 +150,17 @@ export default {
             return this.data.length - this.settings.itemsToShow
         },
         hasPrev() {
-            return (this.repeat || this.activeItem > 0)
+            return (this.settings.repeat || this.activeItem > 0)
         },
         hasNext() {
-            return (this.repeat || this.activeItem < this.total)
+            return (this.settings.repeat || this.activeItem < this.total)
         },
         breakpointKeys() {
-            return Object.keys(this.breakpoints).sort((a, b) => a - b)
+            return Object.keys(this.breakpoints).sort((a, b) => b - a)
         },
         settings() {
             let breakpoint = this.breakpointKeys.find((breakpoint) => {
-                if (this.windowWidth < breakpoint) {
+                if (this.windowWidth >= breakpoint) {
                     return true
                 }
             })
@@ -198,7 +198,7 @@ export default {
         switchTo(newIndex) {
             if (newIndex === this.activeItem) { return }
 
-            if (this.repeat) {
+            if (this.settings.repeat) {
                 newIndex = this.mod(newIndex, this.total + 1)
             }
             newIndex = Math.min(this.total, Math.max(0, newIndex))
@@ -223,7 +223,7 @@ export default {
         },
         // handle drag event
         dragStart(event) {
-            if (this.dragging || !this.hasDrag || (event.button !== 0 && event.type !== 'touchstart')) return
+            if (this.dragging || !this.settings.hasDrag || (event.button !== 0 && event.type !== 'touchstart')) return
             this.hold = new Date().getTime()
             this.dragging = true
             this.touch = !!event.touches

--- a/src/components/carousel/CarouselList.vue
+++ b/src/components/carousel/CarouselList.vue
@@ -282,18 +282,22 @@ export default {
         }
     },
     mounted() {
-        this.observer = new ResizeObserver(this.refresh)
-        this.observer.observe(this.$el)
-        window.addEventListener('resize', this.resized)
-        this.resized()
+        if (typeof window !== 'undefined') {
+            this.observer = new ResizeObserver(this.refresh)
+            this.observer.observe(this.$el)
+            window.addEventListener('resize', this.resized)
+            this.resized()
+        }
         if (this.$attrs.config) {
             throw new Error('The config prop was removed, you need to use v-bind instead')
         }
     },
     beforeDestroy() {
-        this.observer.disconnect()
-        window.removeEventListener('resize', this.resized)
-        this.dragEnd()
+        if (typeof window !== 'undefined') {
+            this.observer.disconnect()
+            window.removeEventListener('resize', this.resized)
+            this.dragEnd()
+        }
     }
 }
 </script>

--- a/src/components/carousel/CarouselList.vue
+++ b/src/components/carousel/CarouselList.vue
@@ -2,7 +2,7 @@
     <div
         class="carousel-list"
         :class="{'has-shadow': scrollIndex > 0}"
-        @mousedown.stop.prevent="dragStart"
+        @mousedown.prevent="dragStart"
         @touchstart="dragStart">
         <div
             class="carousel-slides"
@@ -271,6 +271,7 @@ export default {
                 this.switchTo(this.scrollIndex + signCheck * results)
             }
             this.delta = 0
+            this.dragX = false
             window.removeEventListener(this.touch ? 'touchmove' : 'mousemove', this.dragMove)
             window.removeEventListener(this.touch ? 'touchend' : 'mouseup', this.dragEnd)
         },

--- a/src/components/carousel/CarouselList.vue
+++ b/src/components/carousel/CarouselList.vue
@@ -59,6 +59,7 @@
 <script>
 import {sign, mod, bound} from '../../utils/helpers'
 import config from '../../utils/config'
+import ResizeObserver from 'resize-observer-polyfill'
 
 import Icon from '../icon/Icon'
 

--- a/src/components/carousel/CarouselList.vue
+++ b/src/components/carousel/CarouselList.vue
@@ -129,7 +129,7 @@ export default {
             activeItem: this.value,
             scrollIndex: this.asIndicator ? this.scrollValue : this.value,
             delta: 0,
-            dragging: false,
+            dragX: false,
             hold: 0,
             windowWidth: 0,
             touch: false,
@@ -138,6 +138,9 @@ export default {
         }
     },
     computed: {
+        dragging() {
+            return this.dragX !== false
+        },
         listClass() {
             return [
                 {
@@ -200,7 +203,6 @@ export default {
                 this.activeItem = bound(value, 0, this.data.length - 1)
             }
         },
-
         scrollValue(value) {
             this.switchTo(value)
         }
@@ -233,9 +235,9 @@ export default {
             if (!this.asIndicator) return
 
             const dragEndX = event.touches ? event.touches[0].clientX : event.clientX
-            if (this.hold - Date.now() > 2000 || Math.abs(this.dragStartX - dragEndX) > 10) return
+            if (this.hold - Date.now() > 2000 || Math.abs(this.dragX - dragEndX) > 10) return
 
-            this.dragging = false
+            this.dragX = false
             this.hold = 0
             event.preventDefault()
 
@@ -248,16 +250,15 @@ export default {
         dragStart(event) {
             if (this.dragging || !this.settings.hasDrag || (event.button !== 0 && event.type !== 'touchstart')) return
             this.hold = Date.now()
-            this.dragging = true
             this.touch = !!event.touches
-            this.dragStartX = this.touch ? event.touches[0].clientX : event.clientX
+            this.dragX = this.touch ? event.touches[0].clientX : event.clientX
             window.addEventListener(this.touch ? 'touchmove' : 'mousemove', this.dragMove)
             window.addEventListener(this.touch ? 'touchend' : 'mouseup', this.dragEnd)
         },
         dragMove(event) {
             if (!this.dragging) return
             const dragEndX = event.touches ? event.touches[0].clientX : event.clientX
-            this.delta = this.dragStartX - dragEndX
+            this.delta = this.dragX - dragEndX
             if (!event.touches) {
                 event.preventDefault()
             }
@@ -269,7 +270,6 @@ export default {
                 const results = Math.round(Math.abs(this.delta / this.itemWidth) + 0.15)// Hack
                 this.switchTo(this.scrollIndex + signCheck * results)
             }
-            this.dragging = false
             this.delta = 0
             window.removeEventListener(this.touch ? 'touchmove' : 'mousemove', this.dragMove)
             window.removeEventListener(this.touch ? 'touchend' : 'mouseup', this.dragEnd)

--- a/src/components/carousel/__snapshots__/Carousel.spec.js.snap
+++ b/src/components/carousel/__snapshots__/Carousel.spec.js.snap
@@ -7,8 +7,8 @@ exports[`BCarousel render correctly 1`] = `
         <div></div>
         <div></div>
         <div class="carousel-arrow is-hovered">
-            <b-icon-stub icon="chevron-left" both="true" class="has-icons-left"></b-icon-stub>
-            <b-icon-stub icon="chevron-right" both="true" class="has-icons-right"></b-icon-stub>
+            <b-icon-stub icon="chevron-left" both="true" class="has-icons-left" style="display: none;"></b-icon-stub>
+            <b-icon-stub icon="chevron-right" both="true" class="has-icons-right" style=""></b-icon-stub>
         </div>
     </div>
     <!---->

--- a/src/components/carousel/__snapshots__/CarouselList.spec.js.snap
+++ b/src/components/carousel/__snapshots__/CarouselList.spec.js.snap
@@ -2,7 +2,32 @@
 
 exports[`BCarouselList render correctly 1`] = `
 <div class="carousel-list">
-    <div class="carousel-slides" style="transform: translateX(0px);"></div>
+    <div class="carousel-slides" style="transform: translateX(0px);">
+        <div class="carousel-slide is-active" style="width: 0px;">
+            <figure class="image"><img src="https://picsum.photos/id/0/1230/500" title="Slide 1"></figure>
+        </div>
+        <div class="carousel-slide" style="width: 0px;">
+            <figure class="image"><img src="https://picsum.photos/id/1/1230/500" title="Slide 2"></figure>
+        </div>
+        <div class="carousel-slide" style="width: 0px;">
+            <figure class="image"><img src="https://picsum.photos/id/2/1230/500" title="Slide 3"></figure>
+        </div>
+        <div class="carousel-slide" style="width: 0px;">
+            <figure class="image"><img src="https://picsum.photos/id/3/1230/500" title="Slide 4"></figure>
+        </div>
+        <div class="carousel-slide" style="width: 0px;">
+            <figure class="image"><img src="https://picsum.photos/id/4/1230/500" title="Slide 5"></figure>
+        </div>
+        <div class="carousel-slide" style="width: 0px;">
+            <figure class="image"><img src="https://picsum.photos/id/5/1230/500" title="Slide 6"></figure>
+        </div>
+        <div class="carousel-slide" style="width: 0px;">
+            <figure class="image"><img src="https://picsum.photos/id/6/1230/500" title="Slide 7"></figure>
+        </div>
+        <div class="carousel-slide" style="width: 0px;">
+            <figure class="image"><img src="https://picsum.photos/id/7/1230/500" title="Slide 8"></figure>
+        </div>
+    </div>
     <div class="carousel-arrow is-hovered">
         <b-icon-stub icon="chevron-left" both="true" class="has-icons-left" style="display: none;"></b-icon-stub>
         <b-icon-stub icon="chevron-right" both="true" class="has-icons-right"></b-icon-stub>

--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -46,7 +46,7 @@
 import trapFocus from '../../directives/trapFocus'
 import config from '../../utils/config'
 import { removeElement, createAbsoluteElement } from '../../utils/helpers'
-import { default as ProviderParentMixin, Sorted } from '../../utils/ProviderParentMixin'
+import ProviderParentMixin from '../../utils/ProviderParentMixin'
 
 const DEFAULT_CLOSE_OPTIONS = ['escape', 'outside']
 
@@ -55,7 +55,7 @@ export default {
     directives: {
         trapFocus
     },
-    mixins: [ProviderParentMixin('dropdown', Sorted)],
+    mixins: [ProviderParentMixin('dropdown')],
     props: {
         value: {
             type: [String, Number, Boolean, Object, Array, Function],

--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -46,7 +46,7 @@
 import trapFocus from '../../directives/trapFocus'
 import config from '../../utils/config'
 import { removeElement, createAbsoluteElement } from '../../utils/helpers'
-import ProviderParentMixin from '../../utils/ProviderParentMixin'
+import { default as ProviderParentMixin, Sorted } from '../../utils/ProviderParentMixin'
 
 const DEFAULT_CLOSE_OPTIONS = ['escape', 'outside']
 
@@ -55,7 +55,7 @@ export default {
     directives: {
         trapFocus
     },
-    mixins: [ProviderParentMixin('dropdown', false, false)],
+    mixins: [ProviderParentMixin('dropdown', Sorted)],
     props: {
         value: {
             type: [String, Number, Boolean, Object, Array, Function],

--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -46,6 +46,7 @@
 import trapFocus from '../../directives/trapFocus'
 import config from '../../utils/config'
 import { removeElement, createAbsoluteElement } from '../../utils/helpers'
+import ProviderParentMixin from '../../utils/ProviderParentMixin'
 
 const DEFAULT_CLOSE_OPTIONS = ['escape', 'outside']
 
@@ -54,6 +55,7 @@ export default {
     directives: {
         trapFocus
     },
+    mixins: [ProviderParentMixin('dropdown', false, false)],
     props: {
         value: {
             type: [String, Number, Boolean, Object, Array, Function],
@@ -124,7 +126,6 @@ export default {
             style: {},
             isActive: false,
             isHoverable: this.hoverable,
-            _isDropdown: true, // Used internally by DropdownItem
             _bodyEl: undefined // Used to append to body
         }
     },

--- a/src/components/dropdown/DropdownItem.spec.js
+++ b/src/components/dropdown/DropdownItem.spec.js
@@ -1,13 +1,14 @@
 import { shallowMount } from '@vue/test-utils'
 import BDropdownItem from '@components/dropdown/DropdownItem'
+import ProviderParentMixin from '../../utils/ProviderParentMixin'
 
 let wrapper
 const dropdownSelected = 'val'
 const BDropdown = {
+    mixins: [ProviderParentMixin('dropdown', false, false)],
     template: '<b-dropdown-stub></b-dropdown-stub>',
     data() {
         return {
-            _isDropdown: true,
             selected: dropdownSelected
         }
     }

--- a/src/components/dropdown/DropdownItem.spec.js
+++ b/src/components/dropdown/DropdownItem.spec.js
@@ -1,11 +1,11 @@
 import { shallowMount } from '@vue/test-utils'
 import BDropdownItem from '@components/dropdown/DropdownItem'
-import ProviderParentMixin from '../../utils/ProviderParentMixin'
+import { default as ProviderParentMixin, Sorted } from '../../utils/ProviderParentMixin'
 
 let wrapper
 const dropdownSelected = 'val'
 const BDropdown = {
-    mixins: [ProviderParentMixin('dropdown', false, false)],
+    mixins: [ProviderParentMixin('dropdown', Sorted)],
     template: '<b-dropdown-stub></b-dropdown-stub>',
     data() {
         return {

--- a/src/components/dropdown/DropdownItem.spec.js
+++ b/src/components/dropdown/DropdownItem.spec.js
@@ -1,11 +1,11 @@
 import { shallowMount } from '@vue/test-utils'
 import BDropdownItem from '@components/dropdown/DropdownItem'
-import { default as ProviderParentMixin, Sorted } from '../../utils/ProviderParentMixin'
+import ProviderParentMixin from '../../utils/ProviderParentMixin'
 
 let wrapper
 const dropdownSelected = 'val'
 const BDropdown = {
-    mixins: [ProviderParentMixin('dropdown', Sorted)],
+    mixins: [ProviderParentMixin('dropdown')],
     template: '<b-dropdown-stub></b-dropdown-stub>',
     data() {
         return {

--- a/src/components/dropdown/DropdownItem.vue
+++ b/src/components/dropdown/DropdownItem.vue
@@ -24,7 +24,7 @@ import InjectedChildMixin from '../../utils/InjectedChildMixin'
 
 export default {
     name: 'BDropdownItem',
-    mixins: [InjectedChildMixin('dropdown', false)],
+    mixins: [InjectedChildMixin('dropdown')],
     props: {
         value: {
             type: [String, Number, Boolean, Object, Array, Function],

--- a/src/components/dropdown/DropdownItem.vue
+++ b/src/components/dropdown/DropdownItem.vue
@@ -20,8 +20,11 @@
 </template>
 
 <script>
+import InjectedChildMixin from '../../utils/InjectedChildMixin'
+
 export default {
     name: 'BDropdownItem',
+    mixins: [InjectedChildMixin('dropdown', false)],
     props: {
         value: {
             type: [String, Number, Boolean, Object, Array, Function],
@@ -44,7 +47,7 @@ export default {
     computed: {
         anchorClasses() {
             return {
-                'is-disabled': this.$parent.disabled || this.disabled,
+                'is-disabled': this.parent.disabled || this.disabled,
                 'is-paddingless': this.paddingless,
                 'is-active': this.isActive
             }
@@ -62,12 +65,12 @@ export default {
             return this.ariaRole === 'menuitem' || this.ariaRole === 'listitem' ? this.ariaRole : null
         },
         isClickable() {
-            return !this.$parent.disabled && !this.separator && !this.disabled && !this.custom
+            return !this.parent.disabled && !this.separator && !this.disabled && !this.custom
         },
         isActive() {
-            if (this.$parent.selected === null) return false
-            if (this.$parent.multiple) return this.$parent.selected.indexOf(this.value) >= 0
-            return this.value === this.$parent.selected
+            if (this.parent.selected === null) return false
+            if (this.parent.multiple) return this.parent.selected.indexOf(this.value) >= 0
+            return this.value === this.parent.selected
         },
         isFocusable() {
             return this.hasLink ? false : this.focusable
@@ -80,14 +83,8 @@ export default {
         selectItem() {
             if (!this.isClickable) return
 
-            this.$parent.selectItem(this.value)
+            this.parent.selectItem(this.value)
             this.$emit('click')
-        }
-    },
-    created() {
-        if (!this.$parent.$data._isDropdown) {
-            this.$destroy()
-            throw new Error('You should wrap bDropdownItem on a bDropdown')
         }
     }
 }

--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -24,9 +24,14 @@
                     v-bind="props"
                     v-on="events"
                     :is="component"
-                    @close="close"/>
+                    :can-cancel="canCancel"
+                    @close="close"
+                />
                 <div v-else-if="content"> {{ content }} </div>
-                <slot v-else/>
+                <slot
+                    v-else
+                    :can-cancel="canCancel"
+                    :close="close"/>
                 <button
                     type="button"
                     v-if="showX"
@@ -131,7 +136,7 @@ export default {
                 : this.canCancel
         },
         showX() {
-            return this.cancelOptions.indexOf('x') >= 0
+            return this.cancelOptions.indexOf('x') >= 0 && !this.hasModalCard
         },
         customStyle() {
             if (!this.fullScreen) {

--- a/src/components/numberinput/Numberinput.spec.js
+++ b/src/components/numberinput/Numberinput.spec.js
@@ -61,7 +61,7 @@ describe('BNumberinput', () => {
             wrapper.find('.control.plus').trigger('mouseup')
 
             expect(wrapper.vm.computedValue).toBeGreaterThan(200)
-            expect(wrapper.vm.computedValue).toBeLessThan(300)
+            expect(wrapper.vm.computedValue).toBeLessThan(600)
         })
 
         it('increments/decrements on long pressing', async () => {

--- a/src/components/numberinput/Numberinput.spec.js
+++ b/src/components/numberinput/Numberinput.spec.js
@@ -3,6 +3,10 @@ import BNumberinput from '@components/numberinput/Numberinput'
 
 let wrapper
 
+const wait = (time) => {
+    return new Promise((resolve) => setTimeout(resolve, time))
+}
+
 describe('BNumberinput', () => {
     describe('Rendered', () => {
         beforeEach(() => {
@@ -33,6 +37,64 @@ describe('BNumberinput', () => {
         it('default value is 0', () => {
             const input = wrapper.find('input')
             expect(input.element.value).toBe('0')
+        })
+
+        it('increments/decrements on long pressing exponentially', async () => {
+            wrapper.setProps({exponential: true, value: 1, step: 1})
+
+            wrapper.find('.control.plus button').trigger('mousedown')
+
+            await wait(1500)
+
+            wrapper.find('.control.plus').trigger('mouseup')
+            await wrapper.vm.$nextTick()
+
+            expect(wrapper.vm.computedValue).toBeGreaterThan(90)
+            expect(wrapper.vm.computedValue).toBeLessThan(150)
+
+            wrapper.setProps({exponential: 3, value: 0, step: 1})
+
+            wrapper.find('.control.plus button').trigger('mousedown')
+
+            await wait(1000)
+
+            wrapper.find('.control.plus').trigger('mouseup')
+
+            expect(wrapper.vm.computedValue).toBeGreaterThan(200)
+            expect(wrapper.vm.computedValue).toBeLessThan(300)
+        })
+
+        it('increments/decrements on long pressing', async () => {
+            jest.useFakeTimers()
+
+            let val = 0
+
+            // Increment
+            wrapper.find('.control.plus button').trigger('mousedown')
+            val++
+
+            // await wait(2000)
+            jest.runOnlyPendingTimers()
+            jest.runOnlyPendingTimers()
+            jest.runOnlyPendingTimers()
+            val += 3
+
+            wrapper.find('.control.plus').trigger('mouseup')
+            expect(wrapper.vm.computedValue).toBe(val)
+
+            // Decrement
+            wrapper.find('.control.minus button').trigger('mousedown')
+            val--
+
+            jest.runOnlyPendingTimers()
+            jest.runOnlyPendingTimers()
+            val -= 2
+
+            wrapper.find('.control.minus button').trigger('mouseup')
+            // Trigger it another time to check for unexpected browser behavior
+            wrapper.find('.control.minus button').trigger('mouseup')
+
+            expect(wrapper.vm.computedValue).toBe(val)
         })
     })
 
@@ -101,6 +163,22 @@ describe('BNumberinput', () => {
             wrapper.setProps({ min })
             wrapper.vm.computedValue = ''
             expect(wrapper.vm.computedValue).toBe(min)
+        })
+
+        it('increments/decrements on click', async () => {
+            wrapper.setProps({value: 5, step: 1})
+
+            wrapper.find('.control.plus button').trigger('click')
+
+            await wrapper.vm.$nextTick()
+
+            expect(wrapper.vm.computedValue).toBe(6)
+
+            wrapper.find('.control.minus button').trigger('click')
+
+            await wrapper.vm.$nextTick()
+
+            expect(wrapper.vm.computedValue).toBe(5)
         })
     })
 })

--- a/src/components/numberinput/Numberinput.vue
+++ b/src/components/numberinput/Numberinput.vue
@@ -2,11 +2,11 @@
     <div class="b-numberinput field" :class="fieldClasses">
         <p
             v-if="controls"
-            class="control"
-            @mouseup="onStopLongPress(false)"
-            @mouseleave="onStopLongPress(false)"
-            @touchend="onStopLongPress(false)"
-            @touchcancel="onStopLongPress(false)">
+            class="control minus"
+            @mouseup="onStopLongPress"
+            @mouseleave="onStopLongPress"
+            @touchend="onStopLongPress"
+            @touchcancel="onStopLongPress">
             <button
                 type="button"
                 class="button"
@@ -44,11 +44,11 @@
             @blur="$emit('blur', $event)" />
         <p
             v-if="controls"
-            class="control"
-            @mouseup="onStopLongPress(true)"
-            @mouseleave="onStopLongPress(true)"
-            @touchend="onStopLongPress(true)"
-            @touchcancel="onStopLongPress(true)">
+            class="control plus"
+            @mouseup="onStopLongPress"
+            @mouseleave="onStopLongPress"
+            @touchend="onStopLongPress"
+            @touchcancel="onStopLongPress">
             <button
                 type="button"
                 class="button"
@@ -85,6 +85,7 @@ export default {
         min: [Number, String],
         max: [Number, String],
         step: [Number, String],
+        exponential: [Boolean, Number],
         disabled: Boolean,
         type: {
             type: String,
@@ -108,6 +109,7 @@ export default {
         return {
             newValue: !isNaN(this.value) ? this.value : parseFloat(this.min) || 0,
             newStep: this.step || 1,
+            timesPressed: 1,
             _elementRef: 'input'
         }
     },
@@ -193,27 +195,27 @@ export default {
         },
         onControlClick(event, inc) {
             // IE 11 -> filter click event
-            if (event.detail !== 0 || event.type === 'click') return
+            if (event.detail !== 0 || event.type !== 'click') return
             if (inc) this.increment()
             else this.decrement()
         },
+        longPressTick(inc) {
+            if (inc) this.increment()
+            else this.decrement()
+
+            this._$intervalRef = setTimeout(() => {
+                this.longPressTick(inc)
+            }, this.exponential ? (250 / (this.exponential * this.timesPressed++)) : 250)
+        },
         onStartLongPress(event, inc) {
             if (event.button !== 0 && event.type !== 'touchstart') return
-            this._$intervalTime = new Date()
-            clearInterval(this._$intervalRef)
-            this._$intervalRef = setInterval(() => {
-                if (inc) this.increment()
-                else this.decrement()
-            }, 250)
+            clearTimeout(this._$intervalRef)
+            this.longPressTick(inc)
         },
-        onStopLongPress(inc) {
+        onStopLongPress() {
             if (!this._$intervalRef) return
-            const d = new Date()
-            if (d - this._$intervalTime < 250) {
-                if (inc) this.increment()
-                else this.decrement()
-            }
-            clearInterval(this._$intervalRef)
+            this.timesPressed = 1
+            clearTimeout(this._$intervalRef)
             this._$intervalRef = null
         }
     }

--- a/src/components/slider/Slider.vue
+++ b/src/components/slider/Slider.vue
@@ -54,6 +54,7 @@
 <script>
 import SliderThumb from './SliderThumb'
 import SliderTick from './SliderTick'
+import {bound} from '../../utils/helpers'
 
 export default {
     name: 'BSlider',
@@ -199,17 +200,17 @@ export default {
                 this.isRange = true
                 const smallValue = typeof newValue[0] !== 'number' || isNaN(newValue[0])
                     ? this.min
-                    : Math.min(Math.max(this.min, newValue[0]), this.max)
+                    : bound(newValue[0], this.min, this.max)
                 const largeValue = typeof newValue[1] !== 'number' || isNaN(newValue[1])
                     ? this.max
-                    : Math.max(Math.min(this.max, newValue[1]), this.min)
+                    : bound(newValue[1], this.min, this.max)
                 this.value1 = this.isThumbReversed ? largeValue : smallValue
                 this.value2 = this.isThumbReversed ? smallValue : largeValue
             } else {
                 this.isRange = false
                 this.value1 = isNaN(newValue)
                     ? this.min
-                    : Math.min(this.max, Math.max(this.min, newValue))
+                    : bound(newValue, this.min, this.max)
                 this.value2 = null
             }
         },

--- a/src/components/steps/StepItem.vue
+++ b/src/components/steps/StepItem.vue
@@ -3,7 +3,7 @@ import TabbedChildMixin from '../../utils/TabbedChildMixin.js'
 
 export default {
     name: 'BStepItem',
-    mixins: [TabbedChildMixin],
+    mixins: [TabbedChildMixin('step')],
     props: {
         step: [String, Number],
         type: [String, Object],
@@ -15,12 +15,6 @@ export default {
     data() {
         return {
             elementClass: 'step-item'
-        }
-    },
-    created() {
-        if (!this.parent) {
-            this.$destroy()
-            throw new Error('You should wrap bStepItem in a bSteps')
         }
     }
 }

--- a/src/components/steps/Steps.vue
+++ b/src/components/steps/Steps.vue
@@ -7,7 +7,7 @@
                     :key="childItem.value"
                     v-show="childItem.visible"
                     class="step-item"
-                    :class="[childItem.type || type, {
+                    :class="[childItem.type || type, childItem.headerClass, {
                         'is-active': childItem.isActive,
                         'is-previous': activeItem.index > childItem.index
                 }]">
@@ -73,7 +73,7 @@ import config from '../../utils/config'
 
 export default {
     name: 'BSteps',
-    mixins: [TabbedMixin],
+    mixins: [TabbedMixin('step')],
     props: {
         iconPack: String,
         iconPrev: {
@@ -123,7 +123,7 @@ export default {
     computed: {
         // Override mixin implementation to always have a value
         activeItem() {
-            return this.childItems.find((i) => i.value === this.activeId) || this.childItems[0]
+            return this.childItems.find((i) => i.value === this.activeId) || this.items[0]
         },
         wrapperClasses() {
             return [

--- a/src/components/tabs/TabItem.spec.js
+++ b/src/components/tabs/TabItem.spec.js
@@ -3,11 +3,17 @@ import BTabs from '@components/tabs/Tabs'
 import BTabItem from '@components/tabs/TabItem'
 
 let wrapper
+let wrapperParent
 
 const WrapperComp = {
+    data() {
+        return {
+            show1: true
+        }
+    },
     template: `
         <BTabs>
-            <BTabItem value="tab1"/>
+            <BTabItem v-if="show1" value="tab1"/>
             <BTabItem ref="testItem" value="tab2"/>
             <BTabItem value="tab3" :visible="false"/>
         </BTabs>`,
@@ -18,7 +24,8 @@ const WrapperComp = {
 
 describe('BTabItem', () => {
     beforeEach(() => {
-        wrapper = mount(WrapperComp).find({ ref: 'testItem' })
+        wrapperParent = mount(WrapperComp)
+        wrapper = wrapperParent.find({ ref: 'testItem' })
     })
 
     it('is called', () => {
@@ -33,6 +40,15 @@ describe('BTabItem', () => {
 
     it('computes its position correctly', () => {
         expect(wrapper.vm.index).toBe(1)
+    })
+
+    it('will recompute indexes when a sibling gets removed', async () => {
+        expect(wrapper.vm.index).toBe(1)
+        wrapperParent.vm.show1 = false
+
+        await wrapper.vm.$nextTick()
+
+        expect(wrapper.vm.index).toBe(0)
     })
 
     it('transition correctly when activate is called', () => {

--- a/src/components/tabs/TabItem.vue
+++ b/src/components/tabs/TabItem.vue
@@ -3,19 +3,13 @@ import TabbedChildMixin from '../../utils/TabbedChildMixin.js'
 
 export default {
     name: 'BTabItem',
-    mixins: [TabbedChildMixin],
+    mixins: [TabbedChildMixin('tab')],
     props: {
         disabled: Boolean
     },
     data() {
         return {
             elementClass: 'tab-item'
-        }
-    },
-    created() {
-        if (!this.parent) {
-            this.$destroy()
-            throw new Error('You should wrap bTabItem in a bTabs')
         }
     }
 }

--- a/src/components/tabs/Tabs.spec.js
+++ b/src/components/tabs/Tabs.spec.js
@@ -108,4 +108,14 @@ describe('BTabs', () => {
         expect(wrapper.vm.activeId).toBeNull()
         expect(wrapper.vm.activeTab).toBe(undefined)
     })
+
+    it('still renders if there is no item', () => {
+        wrapper = mount({
+            template: `<BTabs value="tab1"></BTabs>`,
+            components: {
+                BTabs
+            }
+        }).find(BTabs)
+        expect(wrapper.html()).toMatchSnapshot()
+    })
 })

--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -6,9 +6,8 @@
                     v-for="childItem in items"
                     :key="childItem.value"
                     v-show="childItem.visible"
-                    :class="{ 'is-active': childItem.isActive,
-                              'is-disabled': childItem.disabled }">
-
+                    :class="[ childItem.headerClass, { 'is-active': childItem.isActive,
+                                                       'is-disabled': childItem.disabled }]">
                     <b-slot-component
                         v-if="childItem.$slots.header"
                         :component="childItem"
@@ -39,7 +38,7 @@ import TabbedMixin from '../../utils/TabbedMixin.js'
 
 export default {
     name: 'BTabs',
-    mixins: [TabbedMixin],
+    mixins: [TabbedMixin('tab')],
     props: {
         expanded: Boolean,
         animated: {

--- a/src/components/tabs/__snapshots__/Tabs.spec.js.snap
+++ b/src/components/tabs/__snapshots__/Tabs.spec.js.snap
@@ -16,3 +16,12 @@ exports[`BTabs render correctly 1`] = `
     </section>
 </div>
 `;
+
+exports[`BTabs still renders if there is no item 1`] = `
+<div class="b-tabs">
+    <nav class="tabs">
+        <ul></ul>
+    </nav>
+    <section class="tab-content"></section>
+</div>
+`;

--- a/src/components/tooltip/Tooltip.vue
+++ b/src/components/tooltip/Tooltip.vue
@@ -208,7 +208,7 @@ export default {
         }
     },
     mounted() {
-        if (this.appendToBody) {
+        if (this.appendToBody && typeof window !== 'undefined') {
             this.$data._bodyEl = createAbsoluteElement(this.$refs.content)
             this.updateAppendToBody()
         }

--- a/src/utils/InjectedChildMixin.js
+++ b/src/utils/InjectedChildMixin.js
@@ -1,0 +1,26 @@
+export default (parentItemName, needsSorted = true) => {
+    const mixin = {
+        inject: {parent: {from: 'b' + parentItemName, default: false}},
+        created() {
+            if (!this.parent) {
+                this.$destroy()
+                throw new Error('You should wrap ' + this.$options.name + ' in a b' + parentItemName + 's')
+            } else if (this.parent._registerItem) {
+                this.parent._registerItem(this)
+            }
+        },
+        beforeDestroy() {
+            if (this.parent && this.parent._unregisterItem) {
+                this.parent._unregisterItem(this)
+            }
+        }
+    }
+    if (needsSorted) {
+        mixin.data = () => {
+            return {
+                index: null
+            }
+        }
+    }
+    return mixin
+}

--- a/src/utils/InjectedChildMixin.js
+++ b/src/utils/InjectedChildMixin.js
@@ -1,10 +1,20 @@
-export default (parentItemName, needsSorted = true) => {
+import {hasFlag} from './helpers'
+
+const sorted = 1
+const optional = 2
+
+export const Sorted = sorted
+export const Optional = optional
+
+export default (parentItemName, flags = 0) => {
     const mixin = {
         inject: {parent: {from: 'b' + parentItemName, default: false}},
         created() {
             if (!this.parent) {
-                this.$destroy()
-                throw new Error('You should wrap ' + this.$options.name + ' in a b' + parentItemName + 's')
+                if (!hasFlag(flags, optional)) {
+                    this.$destroy()
+                    throw new Error('You should wrap ' + this.$options.name + ' in a ' + parentItemName)
+                }
             } else if (this.parent._registerItem) {
                 this.parent._registerItem(this)
             }
@@ -15,7 +25,7 @@ export default (parentItemName, needsSorted = true) => {
             }
         }
     }
-    if (needsSorted) {
+    if (hasFlag(flags, sorted)) {
         mixin.data = () => {
             return {
                 index: null

--- a/src/utils/ProviderParentMixin.js
+++ b/src/utils/ProviderParentMixin.js
@@ -1,4 +1,12 @@
-export default (itemName, needsItems = true, needsSorted = true) => {
+import {hasFlag} from './helpers'
+
+const items = 1
+const sorted = 3
+
+export const Items = items
+export const Sorted = sorted
+
+export default (itemName, flags = 0) => {
     const mixin = {
         provide() {
             return {
@@ -7,7 +15,7 @@ export default (itemName, needsItems = true, needsSorted = true) => {
         }
     }
 
-    if (needsItems) {
+    if (hasFlag(flags, items)) {
         mixin.data = function () {
             return {
                 childItems: []
@@ -22,7 +30,7 @@ export default (itemName, needsItems = true, needsSorted = true) => {
             }
         }
 
-        if (needsSorted) {
+        if (hasFlag(flags, sorted)) {
             mixin.watch = {
                 /**
                  * When items are added/removed deep search in the elements default's slot

--- a/src/utils/ProviderParentMixin.js
+++ b/src/utils/ProviderParentMixin.js
@@ -29,7 +29,7 @@ export default (itemName, needsItems = true, needsSorted = true) => {
                  * And mark the items with their index
                  */
                 childItems(items) {
-                    if (items.length > 0) {
+                    if (items.length > 0 && this.$scopedSlots.default) {
                         let tag = items[0].$vnode.tag
                         let index = 0
 

--- a/src/utils/ProviderParentMixin.js
+++ b/src/utils/ProviderParentMixin.js
@@ -1,0 +1,75 @@
+export default (itemName, needsItems = true, needsSorted = true) => {
+    const mixin = {
+        provide() {
+            return {
+                ['b' + itemName]: this
+            }
+        }
+    }
+
+    if (needsItems) {
+        mixin.data = function () {
+            return {
+                childItems: []
+            }
+        }
+        mixin.methods = {
+            _registerItem(item) {
+                this.childItems.push(item)
+            },
+            _unregisterItem(item) {
+                this.childItems = this.childItems.filter((i) => i !== item)
+            }
+        }
+
+        if (needsSorted) {
+            mixin.watch = {
+                /**
+                 * When items are added/removed deep search in the elements default's slot
+                 * And mark the items with their index
+                 */
+                childItems(items) {
+                    if (items.length > 0) {
+                        let tag = items[0].$vnode.tag
+                        let index = 0
+
+                        const deepSearch = (children) => {
+                            for (let child of children) {
+                                if (child.tag === tag) {
+                                    // An item with the same tag will for sure be found
+                                    const it = items.find((i) => i.$vnode === child)
+                                    if (it) {
+                                        it.index = index++
+                                    }
+                                } else if (child.tag) {
+                                    const sub = child.componentInstance
+                                        ? (child.componentInstance.$scopedSlots.default
+                                            ? child.componentInstance.$scopedSlots.default()
+                                            : child.componentInstance.$children)
+                                        : child.children
+                                    if (Array.isArray(sub) && sub.length > 0) {
+                                        deepSearch(sub.map((e) => e.$vnode))
+                                    }
+                                }
+                            }
+                            return false
+                        }
+
+                        deepSearch(this.$scopedSlots.default())
+                    }
+                }
+            }
+            mixin.computed = {
+                /**
+                 * When items are added/removed sort them according to their position
+                 */
+                sortedItems() {
+                    return this.childItems.slice().sort((i1, i2) => {
+                        return i1.index - i2.index
+                    })
+                }
+            }
+        }
+    }
+    return mixin
+}

--- a/src/utils/TabbedChildMixin.js
+++ b/src/utils/TabbedChildMixin.js
@@ -1,4 +1,7 @@
-export default {
+import InjectedChildMixin from './InjectedChildMixin'
+
+export default (parentCmp) => ({
+    mixins: [InjectedChildMixin(parentCmp)],
     props: {
         label: String,
         icon: String,
@@ -10,9 +13,12 @@ export default {
         value: {
             type: String,
             default() { return this._uid.toString() }
+        },
+        headerClass: {
+            type: [String, Array, Object],
+            default: null
         }
     },
-    inject: {$tabbed: {name: '$tabbed', default: false}},
     data() {
         return {
             transitionName: null,
@@ -20,37 +26,6 @@ export default {
         }
     },
     computed: {
-        parent() {
-            return this.$tabbed
-        },
-        index() {
-            let index = 0
-
-            const deepSearch = (children) => {
-                for (let child of children) {
-                    if (child.tag === this.$vnode.tag) {
-                        if (this.$vnode === child) {
-                            return true
-                        }
-                        index += 1
-                    } else if (child.tag) {
-                        const sub = child.componentInstance
-                            ? (child.componentInstance.$scopedSlots.default
-                                ? child.componentInstance.$scopedSlots.default()
-                                : child.componentInstance.$children)
-                            : child.children
-                        if (Array.isArray(sub) && sub.length > 0) {
-                            if (deepSearch(sub.map((e) => e.$vnode))) { return true }
-                        }
-                    }
-                }
-                return false
-            }
-
-            deepSearch(this.parent.$scopedSlots.default())
-
-            return index
-        },
         isActive() {
             return this.parent.activeItem === this
         }
@@ -73,12 +48,6 @@ export default {
                 ? this.parent.vertical ? 'slide-down' : 'slide-next'
                 : this.parent.vertical ? 'slide-up' : 'slide-prev'
         }
-    },
-    created() {
-        if (this.parent) { this.parent._registerItem(this) }
-    },
-    beforeDestroy() {
-        if (this.parent) { this.parent._unregisterItem(this) }
     },
     render(createElement) {
         // if destroy apply v-if
@@ -108,4 +77,4 @@ export default {
         }
         return vnode
     }
-}
+})

--- a/src/utils/TabbedChildMixin.js
+++ b/src/utils/TabbedChildMixin.js
@@ -1,7 +1,7 @@
-import InjectedChildMixin from './InjectedChildMixin'
+import {default as InjectedChildMixin, Sorted} from './InjectedChildMixin'
 
 export default (parentCmp) => ({
-    mixins: [InjectedChildMixin(parentCmp)],
+    mixins: [InjectedChildMixin(parentCmp, Sorted)],
     props: {
         label: String,
         icon: String,

--- a/src/utils/TabbedMixin.js
+++ b/src/utils/TabbedMixin.js
@@ -1,7 +1,9 @@
 import Icon from '../components/icon/Icon'
 import SlotComponent from '../utils/SlotComponent'
+import ProviderParentMixin from './ProviderParentMixin'
 
-export default {
+export default (cmp) => ({
+    mixins: [ProviderParentMixin(cmp)],
     components: {
         [Icon.name]: Icon,
         [SlotComponent.name]: SlotComponent
@@ -27,25 +29,19 @@ export default {
             default: false
         }
     },
-    provide() {
-        return {
-            $tabbed: this
-        }
-    },
     data() {
         return {
             activeId: this.value, // Internal state
-            childItems: [],
             defaultSlots: [],
             contentHeight: 0,
             isTransitioning: false
         }
     },
     mounted() {
-        if (this.childItems.length < 1) {
-            this.$destroy()
-            throw new Error('A ' + this.$vnode.tag + ' must have at least 1 item inside')
-        }
+        // if (this.childItems.length < 1) {
+        //     this.$destroy()
+        //     throw new Error(this.$options.name + ' must have at least 1 item inside')
+        // }
 
         if (typeof this.value === 'number') {
             // Backward compatibility: converts the index value to an id
@@ -57,17 +53,12 @@ export default {
     },
     computed: {
         activeItem() {
-            return this.activeId === undefined ? this.childItems[0]
+            return this.activeId === undefined ? this.items[0]
                 : (this.activeId === null ? null
                     : this.childItems.find((i) => i.value === this.activeId))
         },
-        /**
-         * When items are added/removed sort them according to their position
-         */
         items() {
-            return this.childItems.slice().sort((i1, i2) => {
-                return i1.index - i2.index
-            })
+            return this.sortedItems
         }
     },
     watch: {
@@ -105,13 +96,6 @@ export default {
         }
     },
     methods: {
-        _registerItem(item) {
-            this.childItems.push(item)
-        },
-        _unregisterItem(item) {
-            this.childItems = this.childItems.filter((i) => i !== item)
-        },
-
         /**
         * Child click listener, emit input event and change active child.
         */
@@ -119,4 +103,4 @@ export default {
             this.activeId = child.value
         }
     }
-}
+})

--- a/src/utils/TabbedMixin.js
+++ b/src/utils/TabbedMixin.js
@@ -38,11 +38,6 @@ export default (cmp) => ({
         }
     },
     mounted() {
-        // if (this.childItems.length < 1) {
-        //     this.$destroy()
-        //     throw new Error(this.$options.name + ' must have at least 1 item inside')
-        // }
-
         if (typeof this.value === 'number') {
             // Backward compatibility: converts the index value to an id
             const value = Math.max(0, Math.min(this.value, this.items.length - 1))

--- a/src/utils/TabbedMixin.js
+++ b/src/utils/TabbedMixin.js
@@ -1,10 +1,10 @@
 import Icon from '../components/icon/Icon'
 import SlotComponent from '../utils/SlotComponent'
-import ProviderParentMixin from './ProviderParentMixin'
+import { default as ProviderParentMixin, Sorted } from './ProviderParentMixin'
 import {bound} from './helpers'
 
 export default (cmp) => ({
-    mixins: [ProviderParentMixin(cmp)],
+    mixins: [ProviderParentMixin(cmp, Sorted)],
     components: {
         [Icon.name]: Icon,
         [SlotComponent.name]: SlotComponent

--- a/src/utils/TabbedMixin.js
+++ b/src/utils/TabbedMixin.js
@@ -1,6 +1,7 @@
 import Icon from '../components/icon/Icon'
 import SlotComponent from '../utils/SlotComponent'
 import ProviderParentMixin from './ProviderParentMixin'
+import {bound} from './helpers'
 
 export default (cmp) => ({
     mixins: [ProviderParentMixin(cmp)],
@@ -40,7 +41,7 @@ export default (cmp) => ({
     mounted() {
         if (typeof this.value === 'number') {
             // Backward compatibility: converts the index value to an id
-            const value = Math.max(0, Math.min(this.value, this.items.length - 1))
+            const value = bound(this.value, 0, this.items.length - 1)
             this.activeId = this.items[value].value
         } else {
             this.activeId = this.value
@@ -63,7 +64,7 @@ export default (cmp) => ({
         value(value) {
             if (typeof value === 'number') {
                 // Backward compatibility: converts the index value to an id
-                value = Math.max(0, Math.min(value, this.items.length - 1))
+                value = bound(value, 0, this.items.length - 1)
                 this.activeId = this.items[value].value
             } else {
                 this.activeId = value

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -8,6 +8,16 @@ function signPoly(value) {
 export const sign = Math.sign || signPoly
 
 /**
+ * Checks if the flag is set
+ * @param val
+ * @param flag
+ * @returns {boolean}
+ */
+function hasFlag(val, flag) {
+    return (val & flag) === flag
+}
+
+/**
  * Native modulo bug with negative numbers
  * @param n
  * @param mod
@@ -28,7 +38,7 @@ function bound(val, min, max) {
     return Math.max(min, Math.min(max, val))
 }
 
-export {mod, bound}
+export {mod, bound, hasFlag}
 
 /**
  * Get value of an object property/path even if it's nested

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -8,11 +8,33 @@ function signPoly(value) {
 export const sign = Math.sign || signPoly
 
 /**
+ * Native modulo bug with negative numbers
+ * @param n
+ * @param mod
+ * @returns {number}
+ */
+function mod(n, mod) {
+    return ((n % mod) + mod) % mod
+}
+
+/**
+ * Asserts a value is beetween min and max
+ * @param val
+ * @param min
+ * @param max
+ * @returns {number}
+ */
+function bound(val, min, max) {
+    return Math.max(min, Math.min(max, val))
+}
+
+export {mod, bound}
+
+/**
  * Get value of an object property/path even if it's nested
  */
 export function getValueByPath(obj, path) {
-    const value = path.split('.').reduce((o, i) => o ? o[i] : null, obj)
-    return value
+    return path.split('.').reduce((o, i) => o ? o[i] : null, obj)
 }
 
 /**


### PR DESCRIPTION
This PR moves the provide inject features to factory mixins and adds this feature to the dropdown and carousel as well

Fixed: #2591 #2196

Refactored the carousel list to respect vue guidelines (use computed properties rather than events and methods) and fixed some bugs + added some test units, I removed the config prop because it's redundant and the v-bind directive already does what this was trying to do very badly

Improved the doc on card modal to vue best practice using `$emit` rather than `$parent` and added the close icon to the card modal rather than in the overlay (like shown on the bulma doc)

Added a prop headerClass to Tabs and Steps the same way as it exists on Table

Added a prop exponential to NumberInput + documentation + examples + test units + improved coverage (There was actually a bug in the onclick handler that got uncovered)
![Peek 2020-06-23 16-53](https://user-images.githubusercontent.com/6115458/85419297-31863680-b572-11ea-9cec-1c291bf6c857.gif)

