### PR TITLE
Fix missing type for dialog container option

### DIFF
--- a/types/components.d.ts
+++ b/types/components.d.ts
@@ -117,6 +117,13 @@ export declare type BDialogConfig = {
     closeOnConfirm?: boolean;
 
     /**
+    * DOM element the dialog will be created on.
+    * Note that this also changes the position of the dialog from fixed
+    * to absolute. Meaning that the container should be fixed.
+    */
+    container?: string;
+
+    /**
      * Callback function when the confirm button is clicked
      */
     onConfirm?: (value: string, dialog: BComponent) => any;


### PR DESCRIPTION
Fixes #
TypeScript types for Dialog component is missing the `container` field.

## Proposed Changes

- This adds the missing type info.