### PR TITLE
Fix arrow keys for older browsers

### DIFF
--- a/src/components/datepicker/DatepickerMonth.vue
+++ b/src/components/datepicker/DatepickerMonth.vue
@@ -17,12 +17,7 @@
                         href="#"
                         :disabled="disabled"
                         @click.prevent="emitChosenDate(date)"
-                        @keydown.enter.prevent="emitChosenDate(date)"
-                        @keydown.space.prevent="emitChosenDate(date)"
-                        @keydown.arrow-left.prevent="changeFocus(date, -1)"
-                        @keydown.arrow-right.prevent="changeFocus(date, 1)"
-                        @keydown.arrow-up.prevent="changeFocus(date, -3)"
-                        @keydown.arrow-down.prevent="changeFocus(date, 3)"
+                        @keydown.prevent="manageKeydown($event, date)"
                         :tabindex="focused.month === date.getMonth() ? null : -1">
                         {{ monthNames[date.getMonth()] }}
                         <div class="events" v-if="eventsDateMatch(date)">
@@ -240,6 +235,40 @@ export default {
                 'is-today': dateMatch(day, this.dateCreator()),
                 'is-selectable': this.selectableDate(day) && !this.disabled,
                 'is-unselectable': !this.selectableDate(day) || this.disabled
+            }
+        },
+
+        manageKeydown({ key }, date) {
+            // https://developer.mozilla.org/fr/docs/Web/API/KeyboardEvent/key/Key_Values#Navigation_keys
+            switch (key) {
+                case ' ':
+                case 'Space':
+                case 'Spacebar':
+                case 'Enter': {
+                    this.emitChosenDate(date)
+                    break
+                }
+
+                case 'ArrowLeft':
+                case 'Left': {
+                    this.changeFocus(date, -1)
+                    break
+                }
+                case 'ArrowRight':
+                case 'Right': {
+                    this.changeFocus(date, 1)
+                    break
+                }
+                case 'ArrowUp':
+                case 'Up': {
+                    this.changeFocus(date, -3)
+                    break
+                }
+                case 'ArrowDown':
+                case 'Down': {
+                    this.changeFocus(date, 3)
+                    break
+                }
             }
         },
 

--- a/src/components/datepicker/DatepickerTableRow.vue
+++ b/src/components/datepicker/DatepickerTableRow.vue
@@ -14,13 +14,8 @@
                 href="#"
                 :disabled="disabled"
                 @click.prevent="emitChosenDate(weekDay)"
-                @keydown.enter.prevent="emitChosenDate(weekDay)"
-                @keydown.space.prevent="emitChosenDate(weekDay)"
                 @mouseenter="setRangeHoverEndDate(weekDay)"
-                @keydown.arrow-left.prevent="changeFocus(weekDay, -1)"
-                @keydown.arrow-right.prevent="changeFocus(weekDay, 1)"
-                @keydown.arrow-up.prevent="changeFocus(weekDay, -7)"
-                @keydown.arrow-down.prevent="changeFocus(weekDay, 7)"
+                @keydown.prevent="manageKeydown($event, weekDay)"
                 :tabindex="day === weekDay.getDate() ? null : -1">
                 <span>{{ weekDay.getDate() }}</span>
                 <div class="events" v-if="eventsDateMatch(weekDay)">
@@ -294,6 +289,40 @@ export default {
         setRangeHoverEndDate(day) {
             if (this.range) {
                 this.$emit('rangeHoverEndDate', day)
+            }
+        },
+
+        manageKeydown({ key }, weekDay) {
+            // https://developer.mozilla.org/fr/docs/Web/API/KeyboardEvent/key/Key_Values#Navigation_keys
+            switch (key) {
+                case ' ':
+                case 'Space':
+                case 'Spacebar':
+                case 'Enter': {
+                    this.emitChosenDate(weekDay)
+                    break
+                }
+
+                case 'ArrowLeft':
+                case 'Left': {
+                    this.changeFocus(weekDay, -1)
+                    break
+                }
+                case 'ArrowRight':
+                case 'Right': {
+                    this.changeFocus(weekDay, 1)
+                    break
+                }
+                case 'ArrowUp':
+                case 'Up': {
+                    this.changeFocus(weekDay, -7)
+                    break
+                }
+                case 'ArrowDown':
+                case 'Down': {
+                    this.changeFocus(weekDay, 7)
+                    break
+                }
             }
         },
 


### PR DESCRIPTION
> Internet Explorer, Edge (16 and earlier), and Firefox (36 and earlier) use "Left", "Right", "Up", and "Down" instead of "ArrowLeft", "ArrowRight", "ArrowUp", and "ArrowDown".
https://developer.mozilla.org/fr/docs/Web/API/KeyboardEvent/key/Key_Values#Navigation_keys
