### PR TITLE
- Clean input on meridian change (Bool flag)

### DIFF
--- a/docs/pages/components/timepicker/api/timepicker.js
+++ b/docs/pages/components/timepicker/api/timepicker.js
@@ -163,6 +163,13 @@ export default [
                 default: '<code>false</code>'
             },
             {
+                name: '<code>reset-on-meridian-change</code>',
+                description: 'Reset timepicker values on meridian change',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
                 name: 'Any native attribute',
                 description: '—',
                 type: '—',

--- a/docs/pages/components/timepicker/examples/ExSimple.vue
+++ b/docs/pages/components/timepicker/examples/ExSimple.vue
@@ -7,6 +7,9 @@
             <div class="control">
                 <b-switch v-model="enableSeconds">Enable seconds</b-switch>
             </div>
+            <div class="control">
+                <b-switch v-model="isReset">Reset on change</b-switch>
+            </div>
         </b-field>
         <b-field label="Select time">
             <b-timepicker
@@ -14,7 +17,8 @@
                 placeholder="Click to select..."
                 icon="clock"
                 :enable-seconds="enableSeconds"
-                :hour-format="format">
+                :hour-format="format"
+                :reset-on-meridian-change="isReset">
             </b-timepicker>
         </b-field>
     </section>
@@ -25,7 +29,8 @@ export default {
     data() {
         return {
             formatAmPm: false,
-            enableSeconds: false
+            enableSeconds: false,
+            isReset: false
         }
     },
     computed: {

--- a/src/components/timepicker/Timepicker.vue
+++ b/src/components/timepicker/Timepicker.vue
@@ -116,6 +116,7 @@
             :min="formatHHMMSS(minTime)"
             :disabled="disabled"
             :readonly="false"
+            :reset-on-meridian-change="isReset"
             v-bind="$attrs"
             :use-html5-validation="useHtml5Validation"
             @change.native="onChange($event.target.value)"

--- a/src/utils/TimepickerMixin.js
+++ b/src/utils/TimepickerMixin.js
@@ -143,7 +143,11 @@ export default {
             type: Number,
             default: 0
         },
-        appendToBody: Boolean
+        appendToBody: Boolean,
+        resetOnMeridianChange: {
+            type: Boolean,
+            default: false
+        }
     },
     data() {
         return {
@@ -254,7 +258,12 @@ export default {
     },
     methods: {
         onMeridienChange(value) {
-            if (this.hoursSelected !== null) {
+            if (this.hoursSelected !== null && this.resetOnMeridianChange) {
+                this.hoursSelected = null
+                this.minutesSelected = null
+                this.secondsSelected = null
+                this.computedValue = null
+            } else if (this.hoursSelected !== null) {
                 if (value === PM) {
                     this.hoursSelected += 12
                 } else if (value === AM) {


### PR DESCRIPTION
Fixes:

Prevent users to ''trick'' the timepicker component by selecting a min-max time outside of the specified range by changing the meridian.


## Proposed Changes

- Added a new flag (boolean) to clean the input values from the timepicker component when the meridian changes.
