### PR TITLE
Add input to navbar's clickableWhiteList

### DIFF
--- a/src/components/navbar/NavbarItem.vue
+++ b/src/components/navbar/NavbarItem.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script>
-const clickableWhiteList = ['div', 'span']
+const clickableWhiteList = ['div', 'span', 'input']
 
 export default {
     name: 'BNavbarItem',


### PR DESCRIPTION
Having the following configuration, with an `<input>` inside the navbar (which is handy for a search bar for instance), makes the navbar close on mobile.
```vue
<b-navbar>
  <template slot="start">
     <b-navbar-item href="#">
       Home
     </b-navbar-item>
  </template>

  <template slot="end">
    <b-navbar-item tag="div">
	  <label for="navSearchField">
        <b-input
          custom-class="searchField"
          id="navSearchField"
          icon="magnify"
          type="search"
          rounded
          :placeholder="defaultPlaceHolder"
          v-model="searchText"
          @keyup.native.enter="enter"
      />
    </label>
    </b-navbar-item>
  </template>
</b-navbar>
```

## Proposed Changes

- Add `input` to the `clickableWhiteList` so that focusing an `<input>` element doesn't close the navbar
