### PR TITLE
Fix disabled b-select and b-input having different opacity

### DIFF
--- a/src/scss/components/_select.scss
+++ b/src/scss/components/_select.scss
@@ -20,6 +20,12 @@
             font-style: normal;
             padding: 0.25em 0;
         }
+
+        &[disabled] {
+            // Chrome add `opacity: 0.7` on disabled select, but not on disabled input fields.
+            // every disabled fields now have the same look.
+            opacity: 1;
+        }
     }
     &.is-empty select {
         color: rgba($grey, 0.7);


### PR DESCRIPTION
Fix #2599

## Proposed Changes

- Force `opacity: 1` for select since Browsers (at least Chrome) are setting `opacity: 0.7`
- This way, disabled select and disabled input have the same look
