### PR TITLE
Extend placeholder selector instead of the class selector

### DIFF
--- a/src/scss/components/_taginput.scss
+++ b/src/scss/components/_taginput.scss
@@ -4,7 +4,7 @@ $taginput-height: 1.7em !default;
     .taginput-container {
         display: flex;
         &.is-focusable {
-            @extend .input;
+            @extend %input-textarea;
             padding-bottom: 0;
             padding-top: calc(0.275em - 1px);
             padding-left: 0;


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #2667
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Instead of extending .input directly, we extend a placeholder selector from bulma. 

## Reason for extending `%input-textarea` instead of `%input`
- Because `%input-textarea` extends `%input` and then `.input` extends `%input-textarea` in bulma. This means that if we only extend `%input` we're gonna lose the styles added by `%input-textarea` on `.input`
https://github.com/jgthms/bulma/blob/0.7.5/sass/form/input-textarea.sass#L2
https://github.com/jgthms/bulma/blob/0.7.5/sass/form/input-textarea.sass#L34

- When we do `@extend .input`, SASS will look for every selector that matches `.input` and update their style rules so that they contain the extending selector as well.
- Because extends are resolved after the stylesheet is compiled, this means above example `.input, .textarea` will become `.input, .taginput .taginput-container.is-focusable, .textarea`.
