### PR TITLE
[fix] Registered iconSize prop for input to pass onto icon

### DIFF
--- a/docs/pages/components/input/api/input.js
+++ b/docs/pages/components/input/api/input.js
@@ -79,6 +79,13 @@ export default [
                 default: '<code>false</code>'
             },
             {
+                name: '<code>icon-size</code>',
+                description: 'Size of the icon, optional',
+                type: 'String',
+                values: '<code>is-small</code>, <code>is-medium</code>, <code>is-large</code>',
+                default: '—'
+            },
+            {
                 name: '<code>maxlength</code>',
                 description: 'Same as native <code>maxlength</code>, plus character counter',
                 type: 'String, Number',

--- a/helper-json/attributes.json
+++ b/helper-json/attributes.json
@@ -1023,6 +1023,10 @@
     "description": "Make the icon right clickable",
     "type": "boolean"
   },
+  "b-input/icon-size": {
+    "description": "Size of the icon, optional",
+    "type": "string"
+  },
   "b-input/maxlength": {
     "description": "Same as native maxlength, plus character counter",
     "type": "string|number"

--- a/helper-json/tags.json
+++ b/helper-json/tags.json
@@ -348,6 +348,7 @@
       "icon-right",
       "icon-clickable",
       "icon-right-clickable",
+      "icon-size",
       "maxlength",
       "has-counter",
       "custom-class",

--- a/src/components/input/Input.vue
+++ b/src/components/input/Input.vue
@@ -87,7 +87,8 @@ export default {
             default: ''
         },
         iconRight: String,
-        iconRightClickable: Boolean
+        iconRightClickable: Boolean,
+        iconSize: String
     },
     data() {
         return {


### PR DESCRIPTION
##  Proposed Changes

Currently there is a method called `iconSize` that is being passed to the `b-icon` component but its not being initialized anywhere or being accepted as a prop.

This commit allows the `input` component to receive iconSize as a prop