### PR TITLE
make local switch state entirely dependent on bound value

### DIFF
--- a/src/components/switch/Switch.spec.js
+++ b/src/components/switch/Switch.spec.js
@@ -29,10 +29,11 @@ describe('BSwitch', () => {
     })
 
     it('emit input event when computedValue is set', () => {
+        const originalValue = wrapper.vm.computedValue
         const newValue = 'switch value'
         wrapper.vm.computedValue = newValue
         const valueEmitted = wrapper.emitted()['input'][0]
-        expect(wrapper.vm.newValue).toBe(newValue)
+        expect(wrapper.vm.computedValue).toBe(originalValue)
         expect(valueEmitted).toContainEqual(newValue)
     })
 

--- a/src/components/switch/Switch.vue
+++ b/src/components/switch/Switch.vue
@@ -4,7 +4,7 @@
         :class="newClass"
         ref="label"
         :disabled="disabled"
-        @click="focus"
+        @click.prevent="focusAndToggle"
         @keydown.prevent.enter="$refs.label.click()"
         @mousedown="isMouseDown = true"
         @mouseup="isMouseDown = false"
@@ -72,7 +72,6 @@ export default {
                 return this.newValue
             },
             set(value) {
-                this.newValue = value
                 this.$emit('input', value)
             }
         },
@@ -99,6 +98,10 @@ export default {
         focus() {
             // MacOS FireFox and Safari do not focus when clicked
             this.$refs.input.focus()
+        },
+        focusAndToggle() {
+            this.focus()
+            this.computedValue = !this.computedValue
         }
     }
 }


### PR DESCRIPTION
This fixes the switch behavior in cases where the state emitted by the switch is not applied by the parent component. Until now the switch would toggle even if the bound value never changed after an input event from it.

Feel free to change any of this (including the commit description… I’m kind of struggling with the words to adequately describe the problem and solution today...).

Fixes buefy#2686