### PR TITLE
docs: change taginput confirm-key-codes default value

### DIFF
--- a/docs/pages/components/taginput/api/taginput.js
+++ b/docs/pages/components/taginput/api/taginput.js
@@ -124,7 +124,7 @@ export default [
                 description: 'Array of key codes which will add a tag when typing (default comma, enter and tab)',
                 type: 'Array',
                 values: '—',
-                default: '<code>[13, 188, 9]</code>'
+                default: '<code>[13, 188]</code>'
             },
             {
                 name: '<code>on-paste-separators</code>',


### PR DESCRIPTION
`TAB` key (code 9) is actually not in the default `confirm-key-codes` in Taginput component:
https://github.com/buefy/buefy/blob/dev/src/components/taginput/Taginput.vue#L143