### PR TITLE
Allow string as component type in modals

### DIFF
--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -52,7 +52,7 @@ export default {
     },
     props: {
         active: Boolean,
-        component: [Object, Function],
+        component: [Object, Function, String],
         content: String,
         programmatic: Boolean,
         props: Object,


### PR DESCRIPTION
This PR allows to add global components as modals.

## Proposed Changes

- Add type "String" to modal component prop.
