### PR TITLE
Adds Snackbar.close() example to docs.

### DIFF
--- a/docs/pages/components/snackbar/examples/ExSimple.vue
+++ b/docs/pages/components/snackbar/examples/ExSimple.vue
@@ -6,7 +6,7 @@
             </button>
 
             <button class="button is-medium is-warning" @click="warning">
-                Launch snackbar (custom)
+                {{ snackbarRef ? 'Close' : 'Launch' }} Warning snackbar (custom)
             </button>
 
             <button class="button is-medium is-danger" @click="danger">
@@ -18,24 +18,35 @@
 
 <script>
     export default {
+        data() {
+            return {
+                snackbarRef: null,
+            }
+        },
         methods: {
             snackbar() {
                 this.$buefy.snackbar.open(`Default, positioned bottom-right with a green 'OK' button`)
             },
             warning() {
-                this.$buefy.snackbar.open({
-                    message: 'Yellow button and positioned on top, click to close',
-                    type: 'is-warning',
-                    position: 'is-top',
-                    actionText: 'Retry',
-                    indefinite: true,
-                    onAction: () => {
-                        this.$buefy.toast.open({
-                            message: 'Action pressed',
-                            queue: false
-                        })
-                    }
-                })
+                if (this.snackbarRef) {
+                    this.snackbarRef.close()
+                    this.snackbarRef = null
+                } else {
+                    this.snackbarRef = this.$buefy.snackbar.open({
+                        message: 'Yellow button and positioned on top, click to close',
+                        type: 'is-warning',
+                        position: 'is-top',
+                        actionText: 'Retry',
+                        indefinite: true,
+                        onAction: () => {
+                            this.snackbarRef = null
+                            this.$buefy.toast.open({
+                                message: 'Action pressed',
+                                queue: false
+                            })
+                        }
+                    })
+                }
             },
             danger() {
                 this.$buefy.snackbar.open({


### PR DESCRIPTION
The documentation did not make clear that snackbar.open() returned
a reference to the Snackbar, which can then be closed manually at
a later time.

## Proposed Changes

- Adds to the Snackbar docs an example of calling `.close()` on a previously opened Snackbar.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/buefy/buefy/2701)
<!-- Reviewable:end -->
