### PR TITLE
Adds Snackbar .close() method to API docs

### DIFF
--- a/docs/pages/components/snackbar/api/snackbar.js
+++ b/docs/pages/components/snackbar/api/snackbar.js
@@ -67,6 +67,20 @@ export default [
                 values: '—',
                 default: '—'
             }
+        ],
+        methods: [
+            {
+                name: '<code>open</code>',
+                description: 'Opens the snackbar',
+                parameters: 'String, Object',
+                return: 'Reference to the opened Snackbar'
+            },
+            {
+                name: '<code>close</code>',
+                description: 'Close the snackbar',
+                parameters: '—',
+                return: '—'
+            }
         ]
     }
 ]

--- a/docs/pages/components/snackbar/examples/ExSimple.vue
+++ b/docs/pages/components/snackbar/examples/ExSimple.vue
@@ -6,7 +6,7 @@
             </button>
 
             <button class="button is-medium is-warning" @click="warning">
-                {{ snackbarRef ? 'Close' : 'Launch' }} Warning snackbar (custom)
+                Launch snackbar (custom)
             </button>
 
             <button class="button is-medium is-danger" @click="danger">
@@ -18,35 +18,24 @@
 
 <script>
     export default {
-        data() {
-            return {
-                snackbarRef: null,
-            }
-        },
         methods: {
             snackbar() {
                 this.$buefy.snackbar.open(`Default, positioned bottom-right with a green 'OK' button`)
             },
             warning() {
-                if (this.snackbarRef) {
-                    this.snackbarRef.close()
-                    this.snackbarRef = null
-                } else {
-                    this.snackbarRef = this.$buefy.snackbar.open({
-                        message: 'Yellow button and positioned on top, click to close',
-                        type: 'is-warning',
-                        position: 'is-top',
-                        actionText: 'Retry',
-                        indefinite: true,
-                        onAction: () => {
-                            this.snackbarRef = null
-                            this.$buefy.toast.open({
-                                message: 'Action pressed',
-                                queue: false
-                            })
-                        }
-                    })
-                }
+                this.$buefy.snackbar.open({
+                    message: 'Yellow button and positioned on top, click to close',
+                    type: 'is-warning',
+                    position: 'is-top',
+                    actionText: 'Retry',
+                    indefinite: true,
+                    onAction: () => {
+                        this.$buefy.toast.open({
+                            message: 'Action pressed',
+                            queue: false
+                        })
+                    }
+                })
             },
             danger() {
                 this.$buefy.snackbar.open({

--- a/docs/pages/components/snackbar/examples/ExSimple.vue
+++ b/docs/pages/components/snackbar/examples/ExSimple.vue
@@ -6,7 +6,7 @@
             </button>
 
             <button class="button is-medium is-warning" @click="warning">
-                Launch snackbar (custom)
+                {{ snackbarRef ? 'Close' : 'Launch' }} Warning snackbar (custom)
             </button>
 
             <button class="button is-medium is-danger" @click="danger">
@@ -18,24 +18,35 @@
 
 <script>
     export default {
+        data() {
+            return {
+                snackbarRef: null,
+            }
+        },
         methods: {
             snackbar() {
                 this.$buefy.snackbar.open(`Default, positioned bottom-right with a green 'OK' button`)
             },
             warning() {
-                this.$buefy.snackbar.open({
-                    message: 'Yellow button and positioned on top, click to close',
-                    type: 'is-warning',
-                    position: 'is-top',
-                    actionText: 'Retry',
-                    indefinite: true,
-                    onAction: () => {
-                        this.$buefy.toast.open({
-                            message: 'Action pressed',
-                            queue: false
-                        })
-                    }
-                })
+                if (this.snackbarRef) {
+                    this.snackbarRef.close()
+                    this.snackbarRef = null
+                } else {
+                    this.snackbarRef = this.$buefy.snackbar.open({
+                        message: 'Yellow button and positioned on top, click to close',
+                        type: 'is-warning',
+                        position: 'is-top',
+                        actionText: 'Retry',
+                        indefinite: true,
+                        onAction: () => {
+                            this.snackbarRef = null
+                            this.$buefy.toast.open({
+                                message: 'Action pressed',
+                                queue: false
+                            })
+                        }
+                    })
+                }
             },
             danger() {
                 this.$buefy.snackbar.open({


### PR DESCRIPTION
The documentation did not make clear that snackbar.open() returned
a reference to the Snackbar, which can then be closed manually at
a later time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/buefy/buefy/2703)
<!-- Reviewable:end -->
