### PR TITLE
Feature: icon-size property for menu component

### DIFF
--- a/src/components/menu/MenuItem.vue
+++ b/src/components/menu/MenuItem.vue
@@ -13,7 +13,7 @@
                 v-if="icon"
                 :icon="icon"
                 :pack="iconPack"
-                size="is-small"
+                :size="size"
             />
             <span v-if="label">{{ label }}</span>
             <slot
@@ -65,6 +65,10 @@ export default {
         ariaRole: {
             type: String,
             default: ''
+        },
+        size: {
+            type: String,
+            default: 'is-small'
         }
     },
     data() {

--- a/src/components/menu/MenuList.vue
+++ b/src/components/menu/MenuList.vue
@@ -9,6 +9,10 @@ export default {
         ariaRole: {
             type: String,
             default: ''
+        },
+        size: {
+            type: String,
+            default: 'is-small'
         }
     },
     render(createElement, context) {
@@ -23,7 +27,7 @@ export default {
                                 props: {
                                     'icon': context.props.icon,
                                     'pack': context.props.iconPack,
-                                    'size': 'is-small'
+                                    'size': context.props.size
                                 }
                             }),
                             createElement('span', {}, context.props.label)


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

## Fixes 
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
As referenced in issue #2709, I have added the icon-size modifier to the Buefy Menu, for the ```<b-menu-list>``` and the ```<b-menu-item>``` tags. 
I'm a beginner to open source, so please review changes and let me know if I had done something wrong 😅 
## Proposed Changes
- Add icon-size modifier to  ```<b-menu-list>```
- Add icon-size modifier to ```<b-menu-item>```
