### PR TITLE
Update carousel API and fix pages icon ExCustom

### DIFF
--- a/docs/pages/components/carousel/api/carousel.js
+++ b/docs/pages/components/carousel/api/carousel.js
@@ -240,7 +240,7 @@ export default [
         ]
     },
     {
-      title: 'CarouselItem',
+      title: 'Item',
         events: [
             {
                 name: '<code>click</code>',

--- a/docs/pages/components/icon/examples/ExCustom.vue
+++ b/docs/pages/components/icon/examples/ExCustom.vue
@@ -216,7 +216,7 @@
         customIconPacks: {
             'fas': {
                 sizes: {
-                    'default': null,
+                    'default': '',
                     'is-small': 'fa-xs',
                     'is-medium': 'fa-lg',
                     'is-large': 'fa-2x'


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->


<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- update carousel API from `CarouselItem` to `Item`
- fix pages icon ExCustom from error `null`
