### PR TITLE
[Table] Fix regex match 

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -1091,8 +1091,7 @@ export default {
                     if (value !== Number(this.filters[key])) return false
                 } else {
                     const re = new RegExp(this.filters[key], 'i')
-                    if (typeof value === 'boolean') value = `${value}`
-                    if (!value.match(re)) return false
+                    if (!re.test(value)) return false
                 }
             }
             return true


### PR DESCRIPTION
Fixes #2704 

`value.match` assumed value was a string
`re.test(value)` will work with any type even with recursive arrays, booleans, floats etc

`/test/.test([1, ['test']]) => true`
`/bla/.test([1, ['test']]) => false`

It only does not work for objects and additional case to json stringify may be needed but is not great performance wise
`/test/.test({1: ['test']}) => false`
`/test/.test(JSON.stringify({1: ['test']})) => true`