### PR TITLE
Fix addons height for field with `labelPosition="inside"`

### DIFF
--- a/src/scss/components/_form.scss
+++ b/src/scss/components/_form.scss
@@ -196,7 +196,7 @@ $floating-in-height: 3.25em !default;
             }
         }
 
-        &.has-addons, &.is-grouped {
+        .has-addons, .is-grouped {
             .control {
                 .button,
                 .input,


### PR DESCRIPTION

## Proposed Changes

- Changes Form SCSS File

### Before
![image](https://user-images.githubusercontent.com/12817388/89582692-0ba5b000-d807-11ea-8db5-a6132c085be7.png)

### After
![image](https://user-images.githubusercontent.com/12817388/89582738-24ae6100-d807-11ea-97e6-1f2adda61b90.png)

