### PR TITLE
Fix a console error since we cannot destructure preventDefault

### DIFF
--- a/src/components/taginput/Taginput.vue
+++ b/src/components/taginput/Taginput.vue
@@ -321,7 +321,8 @@ export default {
             }
         },
 
-        keydown({ key, preventDefault }) {
+        keydown(event) {
+            const { key } = event // cannot destructure preventDefault (https://stackoverflow.com/a/49616808/2774496)
             if (this.removeOnKeys.indexOf(key) !== -1 && !this.newTag.length) {
                 this.removeLastTag()
             }
@@ -329,7 +330,7 @@ export default {
             if (this.autocomplete && !this.allowNew) return
 
             if (this.confirmKeys.indexOf(key) >= 0) {
-                preventDefault()
+                event.preventDefault()
                 this.addTag()
             }
         },


### PR DESCRIPTION


## Proposed Changes

- remove `preventDefault` destructuring

It was causing an error in the console that prevented adding a tag in the taginput component.
> [Vue warn]: Error in v-on handler: "TypeError: Illegal invocation

The cause is explain here:
https://stackoverflow.com/a/49616808/2774496
