### PR TITLE
Fix error in console in documentation for steps

### DIFF
--- a/docs/pages/components/steps/examples/ExVertical.vue
+++ b/docs/pages/components/steps/examples/ExVertical.vue
@@ -2,7 +2,7 @@
     <section>
         <b-field grouped group-multiline>
             <div class="control">
-                <b-switch v-model="position" true-value="is-right"> Right position </b-switch>
+                <b-switch v-model="position" true-value="is-right" false-value="is-left"> Right position </b-switch>
             </div>
             <b-field label="Size" label-position="on-border">
                 <b-select v-model="size" placeholder="Size">


### PR DESCRIPTION


## Proposed Changes

- Placing vertical steps at right then bringing them back to the left was causing an issue
- Using `false-value` to the switch component have expected results
