### PR TITLE
Remove immediate from datepicker watcher

### DIFF
--- a/src/components/datepicker/DatepickerMonth.vue
+++ b/src/components/datepicker/DatepickerMonth.vue
@@ -113,19 +113,15 @@ export default {
         }
     },
     watch: {
-        focusedMonth: {
-            handler(month) {
-                const refName = `month-${month}`
-                if (this.$refs[refName] && this.$refs[refName].length > 0) {
-                    this.$nextTick(() => {
-                        if (this.$refs[refName][0]) {
-                            this.$refs[refName][0].focus()
-                        }
-                    }) // $nextTick needed when year is changed
-                }
-            },
-            deep: true,
-            immediate: true
+        focusedMonth(month) {
+            const refName = `month-${month}`
+            if (this.$refs[refName] && this.$refs[refName].length > 0) {
+                this.$nextTick(() => {
+                    if (this.$refs[refName][0]) {
+                        this.$refs[refName][0].focus()
+                    }
+                }) // $nextTick needed when year is changed
+            }
         }
     },
     methods: {

--- a/src/components/datepicker/DatepickerTableRow.vue
+++ b/src/components/datepicker/DatepickerTableRow.vue
@@ -80,18 +80,15 @@ export default {
         firstDayOfWeek: Number
     },
     watch: {
-        day: {
-            handler(day) {
-                const refName = `day-${day}`
-                this.$nextTick(() => {
-                    if (this.$refs[refName] && this.$refs[refName].length > 0) {
-                        if (this.$refs[refName][0]) {
-                            this.$refs[refName][0].focus()
-                        }
+        day(day) {
+            const refName = `day-${day}`
+            this.$nextTick(() => {
+                if (this.$refs[refName] && this.$refs[refName].length > 0) {
+                    if (this.$refs[refName][0]) {
+                        this.$refs[refName][0].focus()
                     }
-                }) // $nextTick needed when month is changed
-            },
-            immediate: true
+                }
+            }) // $nextTick needed when month is changed
         }
     },
     methods: {


### PR DESCRIPTION


<!-- Thank you for helping Buefy! -->

Fixes Focus given too early. It makes the datepicker documentation pages to scroll down.

## Proposed Changes

- Useful when navigating using keyboard
- Does not need to bi fired immediately
