### PR TITLE
Datepicker: Be sure $refs.input exists onChange

### DIFF
--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -606,7 +606,9 @@ export default {
             } else {
                 // Force refresh input value when not valid date
                 this.computedValue = null
-                this.$refs.input.newValue = this.computedValue
+                if (this.$refs.input) {
+                    this.$refs.input.newValue = this.computedValue
+                }
             }
         },
 


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes Unit tests and prevent errors if user are using custom trigger for Datepicker