### PR TITLE
Fixed table row comparison

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -201,7 +201,7 @@
                         <tr
                             :key="customRowKey ? row[customRowKey] : index"
                             :class="[rowClass(row, index), {
-                                'is-selected': row === selected,
+                                'is-selected': isRowSelected(row, selected),
                                 'is-checked': isRowChecked(row),
                             }]"
                             @click="selectRow(row)"
@@ -932,6 +932,13 @@ export default {
                 column.customSort,
                 this.isAsc
             )
+        },
+
+        isRowSelected(row, selected) {
+            if (this.customRowKey) {
+                return row[this.customRowKey] === selected[this.customRowKey]
+            }
+            return row === selected
         },
 
         /**


### PR DESCRIPTION
## Proposed Changes

Since the comparison is done with `row === selected`, even if the key is the same, the selected state will be lost as different data.

Changed to perform key comparison instead of object comparison if customRowKey is set.

### Example
https://codepen.io/hikaruworld/pen/BaKyeaM