### PR TITLE
BulmaCssVars doc fixed path

### DIFF
--- a/docs/pages/extensions/bulmacssvars/BulmaCssVars.vue
+++ b/docs/pages/extensions/bulmacssvars/BulmaCssVars.vue
@@ -34,7 +34,7 @@
             return {
                 npmInstallSnippet: `npm install -S bulma-css-vars
 npm install -D sass
-node ./node_modules/bin/bulma-css-vars --init`,
+node ./node_modules/.bin/bulma-css-vars --init`,
                 vueCompSnippet: `import './main.scss'`,
                 scriptSnippet: `"scripts": {
   "bulma-css-vars": "bulma-css-vars"


### PR DESCRIPTION
This is my first contrib for a very small mistake in documentation, let me know if i forgot something in the PR.

## Proposed Changes

bulma-css-vars is in ".bin" folder and not "bin" in the command:
`node ./node_modules/bin/bulma-css-vars --init`