### PR TITLE
Small documentation update

### DIFF
--- a/docs/pages/components/modal/api/modal.js
+++ b/docs/pages/components/modal/api/modal.js
@@ -113,7 +113,7 @@ export default [
                 description: 'Destroy modal on hide',
                 type: 'Boolean',
                 values: '—',
-                default: '<code>false</code>'
+                default: '<code>true</code>'
             },
             {
                 name: '<code>aria-role</code>',


### PR DESCRIPTION
My first contribution to Buefy!

The default value of destroy-on-hide is [true](https://github.com/buefy/buefy/blob/dev/src/components/modal/Modal.vue) (line 116), while the documentation said it was false.