### PR TITLE
Fix TagInput focus

### DIFF
--- a/src/components/taginput/Taginput.vue
+++ b/src/components/taginput/Taginput.vue
@@ -179,7 +179,7 @@ export default {
         return {
             tags: Array.isArray(this.value) ? this.value.slice(0) : (this.value || []),
             newTag: '',
-            _elementRef: 'input',
+            _elementRef: 'autocomplete',
             _isTaginput: true
         }
     },


### PR DESCRIPTION
## Proposed Changes
Focus method for the TagInput element is not working
- Point TagInput _elementRef to the `autocomplete` element instead of `input`, which is an invalid reference.
