### PR TITLE
Set $input-arrow only if it is not defined

### DIFF
--- a/src/scss/utils/_variables.scss
+++ b/src/scss/utils/_variables.scss
@@ -15,5 +15,4 @@ $link-focus-border: $primary !default;
 
 $label-weight: $weight-semibold !default;
 
-$input-arrow: $primary;
-
+$input-arrow: $primary !default;


### PR DESCRIPTION
Fixes the default value of `$select-arrow-color` to use the same arrow color for select as Bulma.

## Proposed Changes
- Set `$input-arrow` only if it is not defined