### PR TITLE
Add new internal icon 'close-circle' to docs

### DIFF
--- a/docs/pages/components/icon/examples/ExCustom.vue
+++ b/docs/pages/components/icon/examples/ExCustom.vue
@@ -247,7 +247,8 @@
                     'eye': 'eye',
                     'eye-off': 'eye-off',
                     'menu-down': 'arrow-dropdown',
-                    'menu-up': 'arrow-dropup'
+                    'menu-up': 'arrow-dropup',
+                    'close-circle': 'close-circle-outline'
                 }
             },
             'uil': {
@@ -271,7 +272,8 @@
                     'eye': 'eye',
                     'eye-off': 'eye-slash',
                     'menu-down': 'angle-down',
-                    'menu-up': 'angle-up'
+                    'menu-up': 'angle-up',
+                    'close-circle': 'times-circle'
                 }
             }
         }


### PR DESCRIPTION
To make custom icons work when using clearable autocomplete.

Thank you for the work you do on this excellent framework!

<!-- Thank you for helping Buefy! -->