### PR TITLE
fix upstream issue #2795

### DIFF
--- a/src/scss/components/_table.scss
+++ b/src/scss/components/_table.scss
@@ -144,6 +144,7 @@ $table-sticky-header-height: 300px !default;
             .sort-icon, .multi-sort-cancel-icon {
                 position: absolute;
                 bottom: 50%;
+                left: 100%;
                 transform: translateY(50%);
             }
             .multi-sort-cancel-icon {


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #2795
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Add a `left: 100%;` to fix the absolute positioned sort icon to remove ambiguity in Safari and Chrome/FF  
-
-
