### PR TITLE
Add events after-enter and after-leave to Modal

### DIFF
--- a/docs/pages/components/modal/api/modal.js
+++ b/docs/pages/components/modal/api/modal.js
@@ -137,13 +137,13 @@ export default [
                 parameters: '—'
             },
             {
-                name: '<code>after-opened</code>',
-                description: 'Triggers after animation open complete.',
+                name: '<code>after-enter</code>',
+                description: 'Triggers when the modal transition <code>after-enter</code> hook is called.',
                 parameters: '—'
             },
             {
-                name: '<code>after-closed</code>',
-                description: 'Triggers after animation close complete.',
+                name: '<code>after-leave</code>',
+                description: 'Triggers when the modal transition <code>after-leave</code> hook is called.',
                 parameters: '—'
             }
         ]

--- a/docs/pages/components/modal/api/modal.js
+++ b/docs/pages/components/modal/api/modal.js
@@ -135,6 +135,16 @@ export default [
                 name: '<code>close</code>',
                 description: 'Triggers when user closed/canceled or called programmatically from the injected component',
                 parameters: '—'
+            },
+            {
+                name: '<code>after-opened</code>',
+                description: 'Triggers after animation open complete.',
+                parameters: '—'
+            },
+            {
+                name: '<code>after-closed</code>',
+                description: 'Triggers after animation close complete.',
+                parameters: '—'
             }
         ]
     }

--- a/src/components/modal/Modal.spec.js
+++ b/src/components/modal/Modal.spec.js
@@ -91,4 +91,14 @@ describe('BModal', () => {
         jest.advanceTimersByTime(150)
         expect(wrapper.vm.$destroy).toHaveBeenCalled()
     })
+
+    it('emit event on animation open and end', () => {
+        wrapper.vm.afterEnter()
+        expect(wrapper.emitted()['after-opened']).toBeTruthy()
+    })
+
+    it('emit event on animation close and end', () => {
+        wrapper.vm.afterLeave()
+        expect(wrapper.emitted()['after-closed']).toBeTruthy()
+    })
 })

--- a/src/components/modal/Modal.spec.js
+++ b/src/components/modal/Modal.spec.js
@@ -92,13 +92,13 @@ describe('BModal', () => {
         expect(wrapper.vm.$destroy).toHaveBeenCalled()
     })
 
-    it('emit event on animation open and end', () => {
+    it('emit event on transition after-enter hook.', () => {
         wrapper.vm.afterEnter()
-        expect(wrapper.emitted()['after-opened']).toBeTruthy()
+        expect(wrapper.emitted()['after-enter']).toBeTruthy()
     })
 
-    it('emit event on animation close and end', () => {
+    it('emit event on transition after-leave hook.', () => {
         wrapper.vm.afterLeave()
-        expect(wrapper.emitted()['after-closed']).toBeTruthy()
+        expect(wrapper.emitted()['after-leave']).toBeTruthy()
     })
 })

--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -239,6 +239,7 @@ export default {
         */
         afterEnter() {
             this.animating = false
+            this.$emit('after-opened')
         },
 
         /**
@@ -255,6 +256,7 @@ export default {
             if (this.destroyOnHide) {
                 this.destroyed = true
             }
+            this.$emit('after-closed')
         }
     },
     created() {

--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -239,7 +239,7 @@ export default {
         */
         afterEnter() {
             this.animating = false
-            this.$emit('after-opened')
+            this.$emit('after-enter')
         },
 
         /**
@@ -256,7 +256,7 @@ export default {
             if (this.destroyOnHide) {
                 this.destroyed = true
             }
-            this.$emit('after-closed')
+            this.$emit('after-leave')
         }
     },
     created() {


### PR DESCRIPTION

## Proposed Changes

- Add events to be triggered after model component opens or closes animation.
- For example, this can be utilized in processing activities such as initialization or disposal of contents included in the modal after completion of the animation.
-  I required these events in my application therefore, would like to request these options to be added.
