### PR TITLE
Fixing empty slot in autocomplete

### DIFF
--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -73,7 +73,7 @@
                         </a>
                     </template>
                     <div
-                        v-if="computedData.length === 0 && hasEmptySlot"
+                        v-if="(computedData.length > 0 && computedData[0].length === 0) && hasEmptySlot"
                         class="dropdown-item is-disabled">
                         <slot name="empty" />
                     </div>

--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -73,7 +73,7 @@
                         </a>
                     </template>
                     <div
-                        v-if="(computedData.length > 0 && computedData[0].length === 0) && hasEmptySlot"
+                        v-if="(computedData.length > 0 && computedData[0].items.length === 0) && hasEmptySlot"
                         class="dropdown-item is-disabled">
                         <slot name="empty" />
                     </div>


### PR DESCRIPTION
The groups change in autocomplete broke the empty slot; since computeData now always returns an array with at least one element.