### PR TITLE
Fix contextmenu event always being prevented on tooltips

### DIFF
--- a/docs/pages/components/tooltip/api/tooltip.js
+++ b/docs/pages/components/tooltip/api/tooltip.js
@@ -29,7 +29,7 @@ export default [
                 name: '<code>triggers</code>',
                 description: 'Tooltip will be triggered by any events',
                 type: 'Array',
-                values: '<code>click</code>.<code>hover</code>,<code>focus</code>',
+                values: '<code>click</code>,<code>hover</code>,<code>focus</code>,<code>contextmenu</code>',
                 default: '<code>[\'hover\']</code>'
             },
             {

--- a/src/components/tooltip/Tooltip.vue
+++ b/src/components/tooltip/Tooltip.vue
@@ -16,7 +16,7 @@
             ref="trigger"
             class="tooltip-trigger"
             @click="onClick"
-            @contextmenu.prevent="onContextMenu"
+            @contextmenu="onContextMenu"
             @mouseenter="onHover"
             @focus.capture="onFocus"
             @mouseleave="close">
@@ -158,8 +158,8 @@ export default {
             if (this.triggers.indexOf('hover') < 0) return
             this.open()
         },
-        onContextMenu() {
-            if (this.triggers.indexOf('contextmenu') < 0) return
+        onContextMenu(e) {
+            if (this.triggers.indexOf('contextmenu') < 0) return e.preventDefault()
             this.open()
         },
         onFocus() {

--- a/src/components/tooltip/Tooltip.vue
+++ b/src/components/tooltip/Tooltip.vue
@@ -159,7 +159,8 @@ export default {
             this.open()
         },
         onContextMenu(e) {
-            if (this.triggers.indexOf('contextmenu') < 0) return e.preventDefault()
+            if (this.triggers.indexOf('contextmenu') < 0) return
+            e.preventDefault()
             this.open()
         },
         onFocus() {


### PR DESCRIPTION
Commit https://github.com/buefy/buefy/commit/5c76d23ddd8a69c604ed770bc4b1dfec5c4cd61d broke the context menu on elements with a tooltip as it's always prevented ([repro](https://codesandbox.io/s/buefy-template-forked-rjpuq?file=/src/App.vue), try right clicking the link to open the context menu)

## Proposed Changes
- only prevent the context menu when the `contextmenu` is not set in the `triggers` prop
- fixed a typo in the documentation + added missing `contextmenu` trigger
- this PR will again allow to right-click links with a tooltip to open them in a new tab