### PR TITLE
New progress bar text color proposal

### DIFF
--- a/docs/pages/components/progress/examples/ExTypes.vue
+++ b/docs/pages/components/progress/examples/ExTypes.vue
@@ -1,13 +1,13 @@
 <template>
     <section>
-        <b-progress :value="20"></b-progress>
+        <b-progress :value="20" show-value></b-progress>
 
-        <b-progress type="is-danger" :value="40"></b-progress>
+        <b-progress type="is-danger" :value="40" show-value></b-progress>
 
-        <b-progress type="is-success" :value="60"></b-progress>
+        <b-progress type="is-success" :value="60" show-value></b-progress>
 
-        <b-progress type="is-info" :value="80"></b-progress>
+        <b-progress type="is-info" :value="80" show-value></b-progress>
 
-        <b-progress type="is-warning" :value="100"></b-progress>
+        <b-progress type="is-warning" :value="100" show-value></b-progress>
     </section>
 </template>

--- a/docs/pages/components/progress/variables/progress.js
+++ b/docs/pages/components/progress/variables/progress.js
@@ -1,9 +1,5 @@
 export default [
     {
-        name: '<code>$progress-text-color</code>',
-        default: '<code>$scheme-main</code>'
-    },
-    {
         name: 'Bulma variables',
         default: '<a target="_blank" href="https://bulma.io/documentation/elements/progress/#variables">Link</a>'
     }

--- a/src/components/progress/Progress.vue
+++ b/src/components/progress/Progress.vue
@@ -67,7 +67,10 @@ export default {
         newType() {
             return [
                 this.size,
-                this.type
+                this.type,
+                {
+                    'is-more-than-half': this.value && this.value > this.max / 2
+                }
             ]
         },
         newValue() {

--- a/src/scss/components/_progress.scss
+++ b/src/scss/components/_progress.scss
@@ -1,5 +1,3 @@
-$progress-text-color: $scheme-main !default;
-
 .progress-wrapper {
     position: relative;
     overflow: hidden;
@@ -16,7 +14,7 @@ $progress-text-color: $scheme-main !default;
         font-size: calc(#{$size-normal} / 1.5);
         line-height: $size-normal;
         font-weight: $weight-bold;
-        color: $progress-text-color;
+        color: findColorInvert($progress-bar-background-color);
         white-space: nowrap;
     }
 
@@ -54,6 +52,22 @@ $progress-text-color: $scheme-main !default;
 
         &::-webkit-progress-value {
             transition: width 0.5s ease;
+        }
+
+        &.is-more-than-half {
+            +.progress-value {
+                color: findColorInvert($progress-value-background-color);
+            }
+
+            @each $name, $pair in $colors {
+                $color: nth($pair, 1);
+                $color-invert: nth($pair, 2);
+                &.is-#{$name} {
+                    + .progress-value {
+                        color: $color-invert;
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION


## Proposed Changes

- Use color-invert for displayed text instead of a fixed value
- It if it less than 50%, the text color will be the invert of $progress-bar-background-color
- It if it more than 50%, the text color will be the invert of $progress-value-background-color
- It if it more than 50% and using a type, the text color will be the invert of the type

### Little breaking change

- No more $progress-text-color variable

#### Before
![image](https://user-images.githubusercontent.com/12817388/91455448-14aaff80-e850-11ea-9f6e-fea4e310986e.png)

#### After
![image](https://user-images.githubusercontent.com/12817388/91455482-1ffe2b00-e850-11ea-821c-694dc6f90788.png)

