### PR TITLE
Fixed b-table has-mobile-cards margin part background-color

### DIFF
--- a/src/scss/components/_table.scss
+++ b/src/scss/components/_table.scss
@@ -235,6 +235,13 @@ $table-sticky-header-height: 300px !default;
             }
         }
         &.has-mobile-cards {
+            tr {
+                background: $table-background-color!important;
+            }
+
+            .table {
+                background-color: transparent;
+            }
             @include mobile {
                 @include table-cards
             }


### PR DESCRIPTION
If `has-mobile-cards` on `b-table` the table class must have transparent background color an tr background is `$table-background-color` to avoid white space between them.

Fixes #2824

## Proposed Changes

- Fixed with scss in `_table.scss` file 
