### PR TITLE
Allow number input values smaller than step size

### DIFF
--- a/docs/pages/components/numberinput/api/numberinput.js
+++ b/docs/pages/components/numberinput/api/numberinput.js
@@ -72,7 +72,14 @@ export default [
                 description: 'Incremental number step',
                 type: 'Number, String',
                 values: '—',
-                default: '—'
+                default: '1'
+            },
+            {
+                name: '<code>min-step</code>',
+                description: 'Minimum step-size allowed. Input value is validated to be integer multiple of <code>min-step</code>',
+                type: 'Number, String',
+                values: '—',
+                default: 'Defaults to value of <code>step</code>'
             },
             {
                 name: '<code>exponential</code>',

--- a/docs/pages/components/numberinput/examples/ExStep.vue
+++ b/docs/pages/components/numberinput/examples/ExStep.vue
@@ -9,5 +9,10 @@
             <b-numberinput step="0.01">
             </b-numberinput>
         </b-field>
+
+        <b-field label="Minimum step">
+            <b-numberinput step="5" min-step="0.25">
+            </b-numberinput>
+        </b-field>
     </section>
 </template>

--- a/docs/pages/components/numberinput/examples/ExStep.vue
+++ b/docs/pages/components/numberinput/examples/ExStep.vue
@@ -11,7 +11,7 @@
         </b-field>
 
         <b-field label="Minimum step">
-            <b-numberinput step="5" min-step="0.25">
+            <b-numberinput step="0.2" min-step="0.01">
             </b-numberinput>
         </b-field>
     </section>

--- a/src/components/numberinput/Numberinput.spec.js
+++ b/src/components/numberinput/Numberinput.spec.js
@@ -212,16 +212,25 @@ describe('BNumberinput', () => {
         })
 
         it('can increment / decrement with minStep', () => {
-            const start = 5.5
-            const step = 2
+            const start = 5.51
+            const step = 0.2
+            const minStep = 0.01
             const min = -5
-            const minStep = 0.5
             wrapper.vm.computedValue = start
             wrapper.setProps({ step, min, minStep })
             wrapper.vm.decrement()
-            expect(wrapper.vm.computedValue).toBe(start - step)
+            expect(wrapper.vm.computedValue).toBe(5.31)
             wrapper.vm.decrement()
-            expect(wrapper.vm.computedValue).toBe(start - (step * 2))
+            expect(wrapper.vm.computedValue).toBe(5.11)
+            wrapper.vm.increment()
+            expect(wrapper.vm.computedValue).toBe(5.31)
+            wrapper.vm.increment()
+            expect(wrapper.vm.computedValue).toBe(5.51)
+
+            const newMinStep = 0.1
+            wrapper.setProps({ minStep: newMinStep })
+            wrapper.vm.decrement()
+            expect(wrapper.vm.computedValue).toBe(5.3)
         })
 
         it('manages empty value', () => {

--- a/src/components/numberinput/Numberinput.spec.js
+++ b/src/components/numberinput/Numberinput.spec.js
@@ -103,6 +103,7 @@ describe('BNumberinput', () => {
             const max = 15
             const step = 5
             const stepDec = 1.5
+            const minStep = 0.05
 
             wrapper.setProps({ min })
             expect(wrapper.vm.minNumber).toBe(min)
@@ -116,13 +117,23 @@ describe('BNumberinput', () => {
 
             wrapper.vm.newStep = step
             expect(wrapper.vm.stepNumber).toBe(step)
+            expect(wrapper.vm.minStepNumber).toBe(step)
             wrapper.vm.newStep = `${step}`
             expect(wrapper.vm.stepNumber).toBe(step)
+            expect(wrapper.vm.minStepNumber).toBe(step)
 
             wrapper.vm.newStep = step
             expect(wrapper.vm.stepDecimals).toBe(0)
             wrapper.vm.newStep = stepDec
             expect(wrapper.vm.stepDecimals).toBe(1)
+
+            wrapper.vm.newStep = step
+            wrapper.vm.newMinStep = minStep
+            expect(wrapper.vm.stepDecimals).toBe(2)
+            expect(wrapper.vm.minStepNumber).toBe(minStep)
+            wrapper.vm.newStep = stepDec
+            expect(wrapper.vm.stepDecimals).toBe(2)
+            expect(wrapper.vm.minStepNumber).toBe(minStep)
         })
 
         it('manage prop value', () => {
@@ -194,6 +205,19 @@ describe('BNumberinput', () => {
             const min = -5
             wrapper.vm.computedValue = start
             wrapper.setProps({ step, min })
+            wrapper.vm.decrement()
+            expect(wrapper.vm.computedValue).toBe(start - step)
+            wrapper.vm.decrement()
+            expect(wrapper.vm.computedValue).toBe(start - (step * 2))
+        })
+
+        it('can increment / decrement with minStep', () => {
+            const start = 5.5
+            const step = 2
+            const min = -5
+            const minStep = 0.5
+            wrapper.vm.computedValue = start
+            wrapper.setProps({ step, min, minStep })
             wrapper.vm.decrement()
             expect(wrapper.vm.computedValue).toBe(start - step)
             wrapper.vm.decrement()

--- a/src/components/numberinput/Numberinput.vue
+++ b/src/components/numberinput/Numberinput.vue
@@ -29,7 +29,7 @@
             ref="input"
             v-model.number="computedValue"
             v-bind="$attrs"
-            :step="newStep"
+            :step="minStepNumber"
             :max="max"
             :min="min"
             :size="size"
@@ -93,6 +93,7 @@ export default {
         },
         max: [Number, String],
         step: [Number, String],
+        minStep: [Number, String],
         exponential: [Boolean, Number],
         disabled: Boolean,
         type: {
@@ -118,6 +119,7 @@ export default {
         return {
             newValue: this.value,
             newStep: this.step || 1,
+            newMinStep: this.minStep,
             timesPressed: 1,
             _elementRef: 'input'
         }
@@ -156,6 +158,10 @@ export default {
         stepNumber() {
             return typeof this.newStep === 'string' ? parseFloat(this.newStep) : this.newStep
         },
+        minStepNumber() {
+            const step = typeof this.newMinStep !== 'undefined' ? this.newMinStep : this.newStep
+            return typeof step === 'string' ? parseFloat(step) : step
+        },
         disabledMin() {
             return this.computedValue - this.stepNumber < this.minNumber
         },
@@ -163,7 +169,7 @@ export default {
             return this.computedValue + this.stepNumber > this.maxNumber
         },
         stepDecimals() {
-            const step = this.stepNumber.toString()
+            const step = this.minStepNumber.toString()
             const index = step.indexOf('.')
             if (index >= 0) {
                 return step.substring(index + 1).length
@@ -184,6 +190,9 @@ export default {
         },
         step(value) {
             this.newStep = value
+        },
+        minStep(value) {
+            this.newMinStep = value
         }
     },
     methods: {


### PR DESCRIPTION
## Proposed Changes 

Add a new prop to BNumberInput which allows for input values with fractional values smaller than `step`, without triggering a validation error. 

The previous workaround was to set `step` to the desired precision, which may be undesirable in terms of incrementing/decrementing the input value using the up/down buttons.

PR for #2832