### PR TITLE
2754-range-props-with-type-month

### DIFF
--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -162,7 +162,10 @@
                             :events="events"
                             :indicators="indicators"
                             :date-creator="dateCreator"
+                            :range="range"
                             :multiple="multiple"
+                            @range-start="date => $emit('range-start', date)"
+                            @range-end="date => $emit('range-end', date)"
                             @close="togglePicker(false)"
                             @change-focus="changeFocus"
                             @update:focused="focusedDateData = $event" />

--- a/src/components/datepicker/DatepickerMonth.spec.js
+++ b/src/components/datepicker/DatepickerMonth.spec.js
@@ -106,6 +106,15 @@ describe('BDatepickerMonth', () => {
         expect(wrapper.emitted()['input']).toBeTruthy()
     })
 
+    it('emit input when updateSelectedDate is called with range props false', () => {
+        wrapper.setProps({
+            range: false
+        })
+        wrapper.vm.selectableDate = jest.fn(() => true)
+        wrapper.vm.updateSelectedDate(5)
+        expect(wrapper.emitted()['input']).toBeTruthy()
+    })
+
     it('manage selectable dates as expected', () => {
         const day = newDate(2019, 7, 7)
 
@@ -214,6 +223,60 @@ describe('BDatepickerMonth', () => {
 
             wrapper.vm.emitChosenDate(date1)
             expect(wrapper.vm.multipleSelectedDates).toEqual([date2, date3])
+        })
+    })
+
+    describe('ClassObject with range props', () => {
+        beforeEach(() => {
+            wrapper.setProps({
+                range: true,
+                focused: {
+                    month: newDate(2020, 1, 1).getMonth(),
+                    year: newDate(2020, 1, 1).getFullYear()
+                },
+                value: [newDate(2020, 1, 1), newDate(2020, 5, 1)]
+            })
+        })
+
+        it('should have is-selected class for all range of dates selected', () => {
+            expect(wrapper.findAll('section > div > div > .is-selected').length).toBe(5)
+        })
+
+        it('should have is-first-selected class for the first date selected within the range', () => {
+            expect(wrapper.findAll('section > div > div > .is-selected').at(0).classes()).toContain('is-first-selected')
+        })
+
+        it('should have is-within-selected class for the dates selected within the range', () => {
+            expect(wrapper.findAll('section > div > div > .is-selected.is-within-selected').length).toBe(3)
+        })
+
+        it('should have is-last-selected class for the last date selected within the range', () => {
+            expect(wrapper.findAll('section > div > div > .is-selected').at(4).classes()).toContain('is-last-selected')
+        })
+
+        describe('hoverd class with range props', () => {
+            beforeEach(() => {
+                wrapper.setData({
+                    selectedBeginDate: newDate(2020, 3, 1),
+                    hoveredEndDate: newDate(2020, 6, 1)
+                })
+            })
+
+            it('should have is-within-hovered-range class for all range of dates hovered', () => {
+                expect(wrapper.findAll('section > div > div > .is-within-hovered-range').length).toBe(4)
+            })
+
+            it('should have is-first-hovered class for the first date hovered within the range', () => {
+                expect(wrapper.findAll('section > div > div > .is-first-hovered').at(0).classes()).toContain('is-first-hovered')
+            })
+
+            it('should have is-within-hovered class for the dates hovered within the range', () => {
+                expect(wrapper.findAll('section > div > div > .is-within-hovered-range.is-within-hovered').length).toBe(2)
+            })
+
+            it('should have is-last-hovered class for the last date hovered within the range', () => {
+                expect(wrapper.findAll('section > div > div > .is-within-hovered-range').at(3).classes()).toContain('is-last-hovered')
+            })
         })
     })
 })

--- a/src/components/datepicker/DatepickerMonth.vue
+++ b/src/components/datepicker/DatepickerMonth.vue
@@ -16,7 +16,8 @@
                         role="button"
                         href="#"
                         :disabled="disabled"
-                        @click.prevent="emitChosenDate(date)"
+                        @click.prevent="updateSelectedDate(date)"
+                        @mouseenter="setRangeHoverEndDate(date)"
                         @keydown.prevent="manageKeydown($event, date)"
                         :tabindex="focused.month === date.getMonth() ? null : -1">
                         {{ monthNames[date.getMonth()] }}
@@ -42,6 +43,8 @@
 </template>
 
 <script>
+import { isDefined } from '../../utils/helpers'
+
 export default {
     name: 'BDatepickerMonth',
     props: {
@@ -59,10 +62,14 @@ export default {
         unselectableDates: Array,
         unselectableDaysOfWeek: Array,
         selectableDates: Array,
+        range: Boolean,
         multiple: Boolean
     },
     data() {
         return {
+            selectedBeginDate: undefined,
+            selectedEndDate: undefined,
+            hoveredEndDate: undefined,
             multipleSelectedDates: this.multiple && this.value ? this.value : []
         }
     },
@@ -110,6 +117,19 @@ export default {
 
         focusedMonth() {
             return this.focused.month
+        },
+
+        hoveredDateRange() {
+            if (!this.range) {
+                return []
+            }
+            if (!isNaN(this.selectedEndDate)) {
+                return []
+            }
+            if (this.hoveredEndDate < this.selectedBeginDate) {
+                return [this.hoveredEndDate, this.selectedBeginDate].filter(isDefined)
+            }
+            return [this.selectedBeginDate, this.hoveredEndDate].filter(isDefined)
         }
     },
     watch: {
@@ -213,9 +233,19 @@ export default {
                 if (!dateOne || !dateTwo || multiple) {
                     return false
                 }
-
+                if (Array.isArray(dateTwo)) {
+                    return dateTwo.some((date) => (
+                        dateOne.getFullYear() === date.getFullYear() &&
+                        dateOne.getMonth() === date.getMonth()
+                    ))
+                }
                 return (dateOne.getFullYear() === dateTwo.getFullYear() &&
                     dateOne.getMonth() === dateTwo.getMonth())
+            }
+            function dateWithin(dateOne, dates, multiple) {
+                if (!Array.isArray(dates) || multiple) { return false }
+
+                return dateOne > dates[0] && dateOne < dates[1]
             }
             function dateMultipleSelected(dateOne, dates, multiple) {
                 if (!Array.isArray(dates) || !multiple) { return false }
@@ -227,7 +257,37 @@ export default {
             }
 
             return {
-                'is-selected': dateMatch(day, this.value, this.multiple) || dateMultipleSelected(day, this.multipleSelectedDates, this.multiple),
+                'is-selected': dateMatch(day, this.value, this.multiple) ||
+                               dateWithin(day, this.value, this.multiple) ||
+                               dateMultipleSelected(day, this.multipleSelectedDates, this.multiple),
+                'is-first-selected':
+                    dateMatch(
+                        day,
+                        Array.isArray(this.value) && this.value[0],
+                        this.multiple
+                    ),
+                'is-within-selected':
+                    dateWithin(day, this.value, this.multiple),
+                'is-last-selected':
+                    dateMatch(
+                        day,
+                        Array.isArray(this.value) && this.value[1],
+                        this.multiple
+                    ),
+                'is-within-hovered-range':
+                    this.hoveredDateRange && this.hoveredDateRange.length === 2 &&
+                    (dateMatch(day, this.hoveredDateRange) ||
+                        dateWithin(day, this.hoveredDateRange)),
+                'is-first-hovered': dateMatch(
+                    day,
+                    Array.isArray(this.hoveredDateRange) && this.hoveredDateRange[0]
+                ),
+                'is-within-hovered':
+                    dateWithin(day, this.hoveredDateRange),
+                'is-last-hovered': dateMatch(
+                    day,
+                    Array.isArray(this.hoveredDateRange) && this.hoveredDateRange[1]
+                ),
                 'is-today': dateMatch(day, this.dateCreator()),
                 'is-selectable': this.selectableDate(day) && !this.disabled,
                 'is-unselectable': !this.selectableDate(day) || this.disabled
@@ -241,7 +301,7 @@ export default {
                 case 'Space':
                 case 'Spacebar':
                 case 'Enter': {
-                    this.emitChosenDate(date)
+                    this.updateSelectedDate(date)
                     break
                 }
 
@@ -269,6 +329,19 @@ export default {
         },
 
         /*
+        * Emit input event with selected date as payload for v-model in parent
+        */
+        updateSelectedDate(date) {
+            if (!this.range && !this.multiple) {
+                this.emitChosenDate(date)
+            } else if (this.range) {
+                this.handleSelectRangeDate(date)
+            } else if (this.multiple) {
+                this.selectMultipleDates(date)
+            }
+        },
+
+        /*
          * Emit select event with chosen date as payload
          */
         emitChosenDate(day) {
@@ -280,6 +353,38 @@ export default {
                 }
             } else {
                 this.selectMultipleDates(day)
+            }
+        },
+
+        /*
+        * If both begin and end dates are set, reset the end date and set the begin date.
+        * If only begin date is selected, emit an array of the begin date and the new date.
+        * If not set, only set the begin date.
+        */
+        handleSelectRangeDate(date) {
+            if (this.disabled) return
+            if (this.selectedBeginDate && this.selectedEndDate) {
+                this.selectedBeginDate = date
+                this.selectedEndDate = undefined
+                this.$emit('range-start', date)
+            } else if (this.selectedBeginDate && !this.selectedEndDate) {
+                if (this.selectedBeginDate > date) {
+                    this.selectedEndDate = this.selectedBeginDate
+                    this.selectedBeginDate = date
+                } else {
+                    this.selectedEndDate = date
+                }
+                this.$emit('range-end', date)
+                this.$emit('input', [this.selectedBeginDate, this.selectedEndDate])
+            } else {
+                this.selectedBeginDate = date
+                this.$emit('range-start', date)
+            }
+        },
+
+        setRangeHoverEndDate(day) {
+            if (this.range) {
+                this.hoveredEndDate = day
             }
         },
 

--- a/src/components/datepicker/DatepickerTable.vue
+++ b/src/components/datepicker/DatepickerTable.vue
@@ -42,8 +42,7 @@
 
 <script>
 import DatepickerTableRow from './DatepickerTableRow'
-
-const isDefined = (d) => d !== undefined
+import { isDefined } from '../../utils/helpers'
 
 export default {
     name: 'BDatepickerTable',

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -289,3 +289,5 @@ export function isWebpSupported() {
 export function isCustomElement(vm) {
     return 'shadowRoot' in vm.$root.$options
 }
+
+export const isDefined = (d) => d !== undefined


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #2754 
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Enable to use `range` props with `type='month'`.

## Images
![image](https://user-images.githubusercontent.com/62658104/91867287-70411700-ecae-11ea-89ba-3af059ddeb3b.png)

![image](https://user-images.githubusercontent.com/62658104/91867127-3c65f180-ecae-11ea-8888-64fc0f4e244d.png)

## Others
This is a draft because the I've not written unit tests yet.
