### PR TITLE
Add !default to $skeleton-background

### DIFF
--- a/src/scss/components/_skeleton.scss
+++ b/src/scss/components/_skeleton.scss
@@ -1,6 +1,6 @@
 
 $skeleton-color: $grey-lighter !default;
-$skeleton-background: linear-gradient(90deg, $skeleton-color 25%, rgba($skeleton-color, 0.5) 50%, $skeleton-color 75%);
+$skeleton-background: linear-gradient(90deg, $skeleton-color 25%, rgba($skeleton-color, 0.5) 50%, $skeleton-color 75%) !default;
 $skeleton-border-radius: $radius !default;
 $skeleton-duration: 1.5s !default;
 $skeleton-margin-top: .5rem !default;


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
According with the [documentation](https://buefy.org/documentation/skeleton/), `$skeleton-background` is meant to be customizable.
This PR adds missing the `!default` to `$skeleton-background` allowing it to be easily customizable.
