### PR TITLE
Add events fired by vue's transition component #2830

### DIFF
--- a/src/components/carousel/CarouselList.vue
+++ b/src/components/carousel/CarouselList.vue
@@ -288,6 +288,8 @@ export default {
             }
             window.addEventListener('resize', this.resized)
             document.addEventListener('animationend', this.refresh)
+            document.addEventListener('transitionend', this.refresh)
+            document.addEventListener('transitionstart', this.refresh)
             this.resized()
         }
         if (this.$attrs.config) {
@@ -301,6 +303,8 @@ export default {
             }
             window.removeEventListener('resize', this.resized)
             document.removeEventListener('animationend', this.refresh)
+            document.removeEventListener('transitionend', this.refresh)
+            document.removeEventListener('transitionstart', this.refresh)
             this.dragEnd()
         }
     }


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #2830

## Proposed Changes
Vue's transition element fires transitionstart after the element added transition finishes and transitionend after the removed transition finishes

It's a bit weird because the spec should be transitionend firing on both cases, but adding those events ensure the width will be correctly calculated
