### PR TITLE
Fixes #2815: Support multiple bars in progress

### DIFF
--- a/docs/pages/components/progress/Progress.vue
+++ b/docs/pages/components/progress/Progress.vue
@@ -9,7 +9,12 @@
         <Example :component="ExValues" :code="ExValuesCode" title="Values" vertical/>
 
         <Example :component="ExSlot" :code="ExSlotCode" title="Slot" vertical>
-            <p>There is also a default slot if you want to display anything you want inside the progress bar</p>
+            <p>There is also a default slot if you want to display anything you want inside the progress bar.</p>
+        </Example>
+
+        <Example :component="ExBars" :code="ExBarsCode" title="Multiple bars" vertical>
+            <p>You can also include multiple progress bars in a progress component if you need.</p>
+            <p><i>* This will not use the native <code>progress</code> element.</i></p>
         </Example>
 
         <ApiView :data="api"/>
@@ -36,6 +41,9 @@
     import ExSlot from './examples/ExSlot'
     import ExSlotCode from '!!raw-loader!./examples/ExSlot'
 
+    import ExBars from './examples/ExBars'
+    import ExBarsCode from '!!raw-loader!./examples/ExBars'
+
     export default {
         data() {
             return {
@@ -50,7 +58,9 @@
                 ExTypesCode,
                 ExSizesCode,
                 ExValuesCode,
-                ExSlotCode
+                ExSlotCode,
+                ExBars,
+                ExBarsCode
             }
         }
     }

--- a/docs/pages/components/progress/api/progress.js
+++ b/docs/pages/components/progress/api/progress.js
@@ -1,5 +1,6 @@
 export default [
     {
+        title: 'Progress',
         props: [
             {
                 name: '<code>type</code>',
@@ -70,6 +71,47 @@ export default [
                 values: '—',
                 default: '<code>undefined</code>: default to browser locale.'
             }
+        ],
+        slots: [
+            {
+                name: '<code>default</code>',
+                description: 'This will be displayed inside the progress bar instead of the calculated value',
+                props: '—'
+            },
+            {
+                name: '<code>bar</code>',
+                description: 'You can insert <code>b-progress-bar</code> components if you want to have multiple bars.',
+                props: '—'
+            }
+        ]
+    },
+    {
+        'title': 'Bar',
+        'props': [
+            {
+                name: '<code>type</code>',
+                description: 'Type (color) of the progress bar, optional',
+                type: 'String',
+                values: `<code>is-white</code>, <code>is-black</code>, <code>is-light</code>,
+                    <code>is-dark</code>, <code>is-primary</code>, <code>is-info</code>, <code>is-success</code>,
+                    <code>is-warning</code>, <code>is-danger</code>,
+                    and any other colors you've set in the <code>$colors</code> list on Sass`,
+                default: 'inherited from parent'
+            },
+            {
+                name: '<code>value</code>',
+                description: 'The progress value.',
+                type: 'Number',
+                values: '—',
+                default: '—'
+            },
+            {
+                name: '<code>show-value</code>',
+                description: 'If the value should be displayed inside the progress bar.',
+                type: 'Boolean',
+                values: '—',
+                default: 'inherited from parent'
+            },
         ],
         slots: [
             {

--- a/docs/pages/components/progress/examples/ExBars.vue
+++ b/docs/pages/components/progress/examples/ExBars.vue
@@ -1,0 +1,19 @@
+<template>
+    <section>
+        <b-progress format="percent" :max="80">
+            <b-progress-bar slot="bar" :value="10" show-value></b-progress-bar>
+            <b-progress-bar slot="bar" :value="20" type="is-primary" show-value></b-progress-bar>
+            <b-progress-bar slot="bar" :value="30" type="is-warning" show-value></b-progress-bar>
+        </b-progress>
+        <b-progress size="is-medium" type="is-success" show-value>
+            <b-progress-bar slot="bar" :value="10"></b-progress-bar>
+            <b-progress-bar slot="bar" :value="20" type="is-primary"></b-progress-bar>
+            <b-progress-bar slot="bar" :value="30" type="is-warning">Wow!</b-progress-bar>
+        </b-progress>
+        <b-progress size="is-large">
+            <b-progress-bar slot="bar" :value="10" show-value></b-progress-bar>
+            <b-progress-bar slot="bar" :value="20" type="is-primary" show-value></b-progress-bar>
+            <b-progress-bar slot="bar" :value="30" type="is-warning"></b-progress-bar>
+        </b-progress>
+    </section>
+</template>

--- a/src/components/progress/Progress.vue
+++ b/src/components/progress/Progress.vue
@@ -1,22 +1,26 @@
 <template>
-    <div class="progress-wrapper">
+    <div class="progress-wrapper" :class="wrapperClasses">
         <progress
+            v-if="isNative"
             ref="progress"
             class="progress"
             :class="newType"
             :max="max"
             :value="value">{{ newValue }}</progress>
+        <slot v-else name="bar" />
         <p
-            v-if="showValue"
+            v-if="isNative && showValue"
             class="progress-value"><slot>{{ newValue }}</slot></p>
     </div>
 </template>
 
 <script>
 import config from '../../utils/config'
+import ProviderParentMixin from '../../utils/ProviderParentMixin'
 
 export default {
     name: 'BProgress',
+    mixins: [ProviderParentMixin('progress')],
     props: {
         type: {
             type: [String, Object],
@@ -74,30 +78,16 @@ export default {
             ]
         },
         newValue() {
-            if (this.value === undefined || this.value === null || isNaN(this.value)) {
-                return undefined
+            return this.calculateValue(this.value)
+        },
+        isNative() {
+            return this.$slots.bar === undefined
+        },
+        wrapperClasses() {
+            return {
+                'is-not-native': !this.isNative,
+                [this.size]: !this.isNative
             }
-
-            const minimumFractionDigits = this.keepTrailingZeroes ? this.precision : 0
-            const maximumFractionDigits = this.precision
-            if (this.format === 'percent') {
-                return new Intl.NumberFormat(
-                    this.locale,
-                    {
-                        style: 'percent',
-                        minimumFractionDigits: minimumFractionDigits,
-                        maximumFractionDigits: maximumFractionDigits
-                    }
-                ).format(this.value / this.max)
-            }
-
-            return new Intl.NumberFormat(
-                this.locale,
-                {
-                    minimumFractionDigits: minimumFractionDigits,
-                    maximumFractionDigits: maximumFractionDigits
-                }
-            ).format(this.value)
         }
     },
     watch: {
@@ -115,6 +105,34 @@ export default {
                     }
                 }
             })
+        }
+    },
+    methods: {
+        calculateValue(value) {
+            if (value === undefined || value === null || isNaN(value)) {
+                return undefined
+            }
+
+            const minimumFractionDigits = this.keepTrailingZeroes ? this.precision : 0
+            const maximumFractionDigits = this.precision
+            if (this.format === 'percent') {
+                return new Intl.NumberFormat(
+                    this.locale,
+                    {
+                        style: 'percent',
+                        minimumFractionDigits: minimumFractionDigits,
+                        maximumFractionDigits: maximumFractionDigits
+                    }
+                ).format(value / this.max)
+            }
+
+            return new Intl.NumberFormat(
+                this.locale,
+                {
+                    minimumFractionDigits: minimumFractionDigits,
+                    maximumFractionDigits: maximumFractionDigits
+                }
+            ).format(value)
         }
     }
 }

--- a/src/components/progress/ProgressBar.spec.js
+++ b/src/components/progress/ProgressBar.spec.js
@@ -1,0 +1,26 @@
+import { shallowMount } from '@vue/test-utils'
+import BProgressBar from '@components/progress/ProgressBar'
+import ProviderParentMixin from '../../utils/ProviderParentMixin'
+
+let wrapper
+const BProgress = {
+    mixins: [ProviderParentMixin('progress')],
+    template: '<b-progress-stub></b-progress-stub>'
+}
+
+describe('BProgressBar', () => {
+    beforeEach(() => {
+        wrapper = shallowMount(BProgressBar, {
+            parentComponent: BProgress
+        })
+    })
+
+    it('is called', () => {
+        expect(wrapper.name()).toBe('BProgressBar')
+        expect(wrapper.isVueInstance()).toBeTruthy()
+    })
+
+    it('render correctly', () => {
+        expect(wrapper.html()).toMatchSnapshot()
+    })
+})

--- a/src/components/progress/ProgressBar.vue
+++ b/src/components/progress/ProgressBar.vue
@@ -1,0 +1,57 @@
+<template>
+    <div
+        class="progress-bar"
+        :class="newType"
+        role="progressbar"
+        :aria-valuenow="value"
+        :aria-valuemax="parent.max"
+        aria-valuemin="0"
+        :style="{width: barWidth}"
+    >
+        <p
+            v-if="newShowValue"
+            class="progress-value">
+            <slot>{{ newValue }}</slot>
+        </p>
+    </div>
+</template>
+
+<script>
+import InjectedChildMixin from '../../utils/InjectedChildMixin'
+
+export default {
+    name: 'BProgressBar',
+    mixins: [InjectedChildMixin('progress')],
+    props: {
+        type: {
+            type: [String, Object],
+            default: undefined
+        },
+        value: {
+            type: Number,
+            default: undefined
+        },
+        showValue: {
+            type: Boolean,
+            default: false
+        }
+    },
+    computed: {
+        newType() {
+            return [
+                this.parent.size,
+                this.type || this.parent.type
+            ]
+        },
+        newShowValue() {
+            return this.showValue || this.parent.showValue
+        },
+        newValue() {
+            return this.parent.calculateValue(this.value)
+        },
+        barWidth() {
+            return `${this.value * 100 / this.parent.max}%`
+        }
+    }
+}
+</script>

--- a/src/components/progress/__snapshots__/ProgressBar.spec.js.snap
+++ b/src/components/progress/__snapshots__/ProgressBar.spec.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BProgressBar render correctly 1`] = `
+<div role="progressbar" aria-valuemin="0" class="progress-bar">
+    <!---->
+</div>
+`;

--- a/src/components/progress/index.js
+++ b/src/components/progress/index.js
@@ -1,10 +1,12 @@
 import Progress from './Progress'
+import ProgressBar from './ProgressBar'
 
 import { use, registerComponent } from '../../utils/plugins'
 
 const Plugin = {
     install(Vue) {
         registerComponent(Vue, Progress)
+        registerComponent(Vue, ProgressBar)
     }
 }
 
@@ -13,5 +15,6 @@ use(Plugin)
 export default Plugin
 
 export {
-    Progress as BProgress
+    Progress as BProgress,
+    ProgressBar as BProgressBar
 }

--- a/src/scss/components/_progress.scss
+++ b/src/scss/components/_progress.scss
@@ -1,3 +1,24 @@
+@mixin progress-size() {
+    &.is-small {
+        + .progress-value, .progress-value {
+            font-size: calc(#{$size-small} / 1.5);
+            line-height: $size-small;
+        }
+    }
+    &.is-medium {
+        + .progress-value, .progress-value {
+            font-size: calc(#{$size-medium} / 1.5);
+            line-height: $size-medium;
+        }
+    }
+    &.is-large {
+        + .progress-value, .progress-value {
+            font-size: calc(#{$size-large} / 1.5);
+            line-height: $size-large;
+        }
+    }
+}
+
 .progress-wrapper {
     position: relative;
     overflow: hidden;
@@ -18,27 +39,10 @@
         white-space: nowrap;
     }
 
-    .progress {
+    .progress, .progress-bar {
         margin-bottom: 0;
 
-        &.is-small {
-            + .progress-value {
-                font-size: calc(#{$size-small} / 1.5);
-                line-height: $size-small;
-            }
-        }
-        &.is-medium {
-            + .progress-value {
-                font-size: calc(#{$size-medium} / 1.5);
-                line-height: $size-medium;
-            }
-        }
-        &.is-large {
-            + .progress-value {
-                font-size: calc(#{$size-large} / 1.5);
-                line-height: $size-large;
-            }
-        }
+        @include progress-size();
 
         // TODO Remove below when the following PR will be merged in Bulma:
         // https://github.com/jgthms/bulma/pull/2540
@@ -64,6 +68,36 @@
                 $color-invert: nth($pair, 2);
                 &.is-#{$name} {
                     + .progress-value {
+                        color: $color-invert;
+                    }
+                }
+            }
+        }
+    }
+
+    &.is-not-native {
+        @extend .progress;
+        white-space: nowrap;
+        background-color: $progress-bar-background-color;
+        border-radius: $progress-border-radius;
+
+        .progress-bar {
+            position: relative;
+            display: inline-block;
+            vertical-align: top;
+            height: 100%;
+            background-color: $progress-value-background-color;
+
+            .progress-value {
+                color: findColorInvert($progress-value-background-color);
+            }
+
+            @each $name, $pair in $colors {
+                $color: nth($pair, 1);
+                $color-invert: nth($pair, 2);
+                &.is-#{$name} {
+                    background-color: $color;
+                    .progress-value {
                         color: $color-invert;
                     }
                 }


### PR DESCRIPTION


<!-- Thank you for helping Buefy! -->

Fixes #2815
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Support multiple bars
  - It does not use native `progress` element
- Use a11y attributes
- Same styling as default progress

### Preview

![image](https://user-images.githubusercontent.com/12817388/92020004-7920ff80-ed25-11ea-97c0-2078e8d9979c.png)

