### PR TITLE
Fix TablePagination

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -346,7 +346,6 @@ import { VueInstance } from '../../utils/config'
 import Checkbox from '../checkbox/Checkbox'
 import Icon from '../icon/Icon'
 import Input from '../input/Input'
-import Pagination from '../pagination/Pagination'
 import Loading from '../loading/Loading'
 import SlotComponent from '../../utils/SlotComponent'
 import TableMobileSort from './TableMobileSort'
@@ -359,7 +358,6 @@ export default {
         [Checkbox.name]: Checkbox,
         [Icon.name]: Icon,
         [Input.name]: Input,
-        [Pagination.name]: Pagination,
         [Loading.name]: Loading,
         [SlotComponent.name]: SlotComponent,
         [TableMobileSort.name]: TableMobileSort,

--- a/src/components/table/TablePagination.vue
+++ b/src/components/table/TablePagination.vue
@@ -25,8 +25,13 @@
 </template>
 
 <script>
+import Pagination from '../pagination/Pagination'
+
 export default {
     name: 'BTablePagination',
+    components: {
+        [Pagination.name]: Pagination
+    },
     props: {
         paginated: Boolean,
         total: [Number, String],


### PR DESCRIPTION
The following error occurs if the `b-pagination` component is not registered globally.

```
[Vue warn]: Unknown custom element: <b-pagination> - did you register the component correctly? For recursive components, make sure to provide the "name" option.
```
