### PR TITLE
Add light variant to tooltip

### DIFF
--- a/docs/pages/components/tooltip/examples/ExStyles.vue
+++ b/docs/pages/components/tooltip/examples/ExStyles.vue
@@ -31,6 +31,12 @@
             square>
             <button class="button">Square</button>
         </b-tooltip>
+
+        <b-tooltip label="You love the light variant, dont you?"
+            type="is-primary is-light"
+            position="is-bottom">
+            <button class="button">Primary light variant</button>
+        </b-tooltip>
     </section>
 </template>
 

--- a/src/scss/components/_tooltip.scss
+++ b/src/scss/components/_tooltip.scss
@@ -89,6 +89,15 @@ $tooltip-multiline-sizes: (
                 .tooltip-content::before {
                     @include tooltip-arrow($direction, $color)
                 }
+                // If light and dark colors are provided
+                @if length($pair) >= 4 {
+                    $color-light: nth($pair, 3);
+                    &.is-light {
+                        .tooltip-content::before {
+                            @include tooltip-arrow($direction, $color-light)
+                        }
+                    }
+                }
             }
         }
         &.is-multiline {
@@ -126,7 +135,7 @@ $tooltip-multiline-sizes: (
         position: absolute;
         content: "";
         pointer-events: none;
-        z-index: 38; 
+        z-index: 38;
     }
     .tooltip-trigger {
         width: 100%;
@@ -139,6 +148,17 @@ $tooltip-multiline-sizes: (
             .tooltip-content {
                 background: $color;
                 color: $color-invert;
+            }
+            // If light and dark colors are provided
+            @if length($pair) >= 4 {
+                $color-light: nth($pair, 3);
+                $color-dark: nth($pair, 4);
+                &.is-light {
+                    .tooltip-content {
+                        background: $color-light;
+                        color: $color-dark;
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Bulma now support light color variant for many element. Someone asked about the light color support in tooltip in the Discord channel.

## Proposed Changes

- Add light variant to tooltip component
- Can be used like this `is-primary is-light`

### preview

![image](https://user-images.githubusercontent.com/12817388/92240841-3d07af00-ee8b-11ea-8e48-574d5d6132f0.png)

