### PR TITLE
Remove common code from tooltip mixins

### DIFF
--- a/src/scss/components/_tooltip.scss
+++ b/src/scss/components/_tooltip.scss
@@ -7,23 +7,15 @@ $tooltip-multiline-sizes: (
     large: 300px
 ) !default;
 
-@mixin tooltip-arrow($direction, $color) {
+@mixin tooltip-arrow-color($direction, $color) {
     @if ($direction == "is-top") {
-        border-top: $tooltip-arrow-size solid $color;
-        border-right: $tooltip-arrow-size solid transparent;
-        border-left: $tooltip-arrow-size solid transparent;
+        border-top-color: $color;
     } @else if ($direction == "is-bottom") {
-        border-right: $tooltip-arrow-size solid transparent;
-        border-bottom: $tooltip-arrow-size solid $color;
-        border-left: $tooltip-arrow-size solid transparent;
+        border-bottom-color: $color;
     } @else if ($direction == "is-right") {
-        border-top: $tooltip-arrow-size solid transparent;
-        border-right: $tooltip-arrow-size solid $color;
-        border-bottom: $tooltip-arrow-size solid transparent;
+        border-right-color: $color;
     } @else if ($direction == "is-left") {
-        border-top: $tooltip-arrow-size solid transparent;
-        border-bottom: $tooltip-arrow-size solid transparent;
-        border-left: $tooltip-arrow-size solid $color;
+        border-left-color: $color;
     }
 }
 
@@ -63,48 +55,51 @@ $tooltip-multiline-sizes: (
                 bottom: 100%;
                 left: 50%;
                 transform: translateX(-50%);
+                border-right: $tooltip-arrow-size solid transparent;
+                border-bottom: $tooltip-arrow-size solid $primary;
+                border-left: $tooltip-arrow-size solid transparent;
             } @else if ($direction == "is-top") {
                 top: 100%;
                 right: auto;
                 bottom: auto;
                 left: 50%;
                 transform: translateX(-50%);
+                border-top: $tooltip-arrow-size solid $primary;
+                border-right: $tooltip-arrow-size solid transparent;
+                border-left: $tooltip-arrow-size solid transparent;
             } @else if ($direction == "is-left") {
                 top: 50%;
                 right: auto;
                 bottom: auto;
                 left: 100%;
                 transform: translateY(-50%);
+                border-top: $tooltip-arrow-size solid transparent;
+                border-bottom: $tooltip-arrow-size solid transparent;
+                border-left: $tooltip-arrow-size solid $primary;
             } @else if ($direction == "is-right") {
                 top: 50%;
                 right: 100%;
                 bottom: auto;
                 left: auto;
                 transform: translateY(-50%);
+                border-top: $tooltip-arrow-size solid transparent;
+                border-right: $tooltip-arrow-size solid $primary;
+                border-bottom: $tooltip-arrow-size solid transparent;
             }
         }
         @each $name, $pair in $colors {
             $color: nth($pair, 1);
             &.is-#{$name} {
                 .tooltip-content::before {
-                    @include tooltip-arrow($direction, $color)
+                    @include tooltip-arrow-color($direction, $color)
                 }
                 // If light and dark colors are provided
                 @if length($pair) >= 4 {
                     $color-light: nth($pair, 3);
                     &.is-light {
                         .tooltip-content::before {
-                            @include tooltip-arrow($direction, $color-light)
+                            @include tooltip-arrow-color($direction, $color-light)
                         }
-                    }
-                }
-            }
-        }
-        &.is-multiline {
-            @each $name, $size in $tooltip-multiline-sizes {
-                &.is-#{$name} {
-                    .tooltip-content {
-                        width: $size;
                     }
                 }
             }
@@ -174,6 +169,13 @@ $tooltip-multiline-sizes: (
             display: flex-block;
             text-align: center;
             white-space: normal;
+        }
+        @each $name, $size in $tooltip-multiline-sizes {
+            &.is-#{$name} {
+                .tooltip-content {
+                    width: $size;
+                }
+            }
         }
     }
     &.is-dashed {


### PR DESCRIPTION


## Proposed Changes

- Reduce CSS build size
- Tooltip took *516* lines of uncompressed CSS before
- Tooltip takes *373* lines of uncompressed CSS now
