### PR TITLE
Fix #2865: table visible column count

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -646,7 +646,7 @@ export default {
         * Return total column count based if it's checkable or expanded
         */
         columnCount() {
-            let count = this.newColumns.length
+            let count = this.visibleColumns.length
             count += this.checkable ? 1 : 0
             count += (this.detailed && this.showDetailIcon) ? 1 : 0
 


### PR DESCRIPTION
Fix #2865
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- For empty row, footer row and details rows, we used colspan to take the entire width
  - We we're using the number of columns as a value
  - We needed to use the number of `visible` columns instead
