### PR TITLE
Improve tabbing with autocompleted, open-on-focus taginputs

### DIFF
--- a/docs/pages/components/autocomplete/api/autocomplete.js
+++ b/docs/pages/components/autocomplete/api/autocomplete.js
@@ -100,6 +100,13 @@ export default [
                 default: '<code>mdi</code>'
             },
             {
+                name: '<code>confirm-keys</code>',
+                description: 'Array of keys (https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values) which will select an option when typing (default tab and enter)',
+                type: 'Array',
+                values: '—',
+                default: '<code>["Tab", "Enter"]</code>'
+            },
+            {
                 name: '<code>clearable</code>',
                 description: 'Add a button to clear the inputed text',
                 type: 'Boolean',

--- a/docs/pages/components/taginput/api/taginput.js
+++ b/docs/pages/components/taginput/api/taginput.js
@@ -135,10 +135,10 @@ export default [
             },
             {
                 name: '<code>confirm-keys</code>',
-                description: 'Array of key (https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values) which will add a tag when typing (default comma and enter)',
+                description: 'Array of keys (https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values) which will add a tag when typing (default comma, tab and enter)',
                 type: 'Array',
                 values: '—',
-                default: '<code>[",", "Enter"]</code>'
+                default: '<code>[",", "Tab", "Enter"]</code>'
             },
             {
                 name: '<code>on-paste-separators</code>',

--- a/src/components/autocomplete/Autocomplete.spec.js
+++ b/src/components/autocomplete/Autocomplete.spec.js
@@ -99,8 +99,8 @@ describe('BAutocomplete', () => {
 
         const itemsInDropdowm = findStringsStartingWith(DATA_LIST, VALUE_TYPED)
 
-        $input.trigger('keydown.down')
-        $input.trigger('keydown.enter')
+        $input.trigger('keydown', {'key': 'Down'})
+        $input.trigger('keydown', {'key': 'Enter'})
         await wrapper.vm.$nextTick()
 
         expect($input.element.value).toBe(itemsInDropdowm[0])
@@ -112,9 +112,9 @@ describe('BAutocomplete', () => {
 
         expect($dropdown.isVisible()).toBeTruthy()
 
-        $input.trigger('keydown.down')
-        $input.trigger('keydown.down')
-        $input.trigger('keydown.enter')
+        $input.trigger('keydown', {'key': 'Down'})
+        $input.trigger('keydown', {'key': 'Down'})
+        $input.trigger('keydown', {'key': 'Enter'})
         await wrapper.vm.$nextTick()
 
         expect($input.element.value).toBe(itemsInDropdowm[1])
@@ -168,7 +168,7 @@ describe('BAutocomplete', () => {
 
     it('manages tab pressed as expected', async () => {
         // hovered is null
-        $input.trigger('keydown.tab')
+        $input.trigger('keydown', {'key': 'Tab'})
         expect($dropdown.isVisible()).toBeFalsy()
 
         // The first element will be hovered
@@ -184,7 +184,7 @@ describe('BAutocomplete', () => {
         $input.trigger('focus')
         await wrapper.vm.$nextTick()
 
-        $input.trigger('keydown.tab')
+        $input.trigger('keydown', {'key': 'Tab'})
         expect($input.element.value).toBe(DATA_LIST[0])
     })
 
@@ -207,11 +207,11 @@ describe('BAutocomplete', () => {
         wrapper.vm.isActive = true
         expect($dropdown.isVisible()).toBeTruthy()
 
-        $input.trigger('keydown.enter')
+        $input.trigger('keydown', {'key': 'Enter'})
         expect(wrapper.vm.hovered).toBeNull()
 
-        $input.trigger('keydown.down')
-        $input.trigger('keydown.enter')
+        $input.trigger('keydown', {'key': 'Down'})
+        $input.trigger('keydown', {'key': 'Enter'})
         expect($input.element.value).toBe(data[0].name)
     })
 
@@ -224,8 +224,8 @@ describe('BAutocomplete', () => {
         wrapper.vm.isActive = true
         expect($dropdown.isVisible()).toBeTruthy()
 
-        $input.trigger('keydown.down')
-        $input.trigger('keydown.enter')
+        $input.trigger('keydown', {'key': 'Down'})
+        $input.trigger('keydown', {'key': 'Enter'})
         expect($input.element.value).toBe('')
     })
 
@@ -238,8 +238,8 @@ describe('BAutocomplete', () => {
         wrapper.vm.isActive = true
         expect($dropdown.isVisible()).toBeTruthy()
 
-        $input.trigger('keydown.down')
-        $input.trigger('keydown.enter')
+        $input.trigger('keydown', {'key': 'Down'})
+        $input.trigger('keydown', {'key': 'Enter'})
         expect($input.element.value).toBe(`${DATA_LIST[0]} formatted`)
     })
 

--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -19,8 +19,7 @@
             @focus="focused"
             @blur="onBlur"
             @keyup.native.esc.prevent="isActive = false"
-            @keydown.native.tab="tabPressed"
-            @keydown.native.enter.prevent="enterPressed"
+            @keydown.native="keydown"
             @keydown.native.up.prevent="keyArrows('up')"
             @keydown.native.down.prevent="keyArrows('down')"
             @icon-right-click="rightIconClick"
@@ -130,7 +129,11 @@ export default {
         groupOptions: String,
         iconRight: String,
         iconRightClickable: Boolean,
-        appendToBody: Boolean
+        appendToBody: Boolean,
+        confirmKeys: {
+            type: Array,
+            default: () => ['Tab', 'Enter']
+        }
     },
     data() {
         return {
@@ -373,26 +376,19 @@ export default {
             })
         },
 
-        /**
-         * Enter key listener.
-         * Select the hovered option.
-         */
-        enterPressed(event) {
+        keydown(event) {
+            const { key } = event // cannot destructure preventDefault (https://stackoverflow.com/a/49616808/2774496)
+            // Close dropdown on Tab & no hovered
+            this.isActive = key !== 'Tab'
             if (this.hovered === null) return
-            this.setSelected(this.hovered, !this.keepOpen, event)
-        },
+            if (this.confirmKeys.indexOf(key) >= 0) {
+                // If adding by comma, don't add the comma to the input
+                if (key === ',') event.preventDefault()
 
-        /**
-         * Tab key listener.
-         * Select hovered option if it exists, close dropdown, then allow
-         * native handling to move to next tabbable element.
-         */
-        tabPressed(event) {
-            if (this.hovered === null) {
-                this.isActive = false
-                return
+                // Close dropdown on select by Tab
+                const closeDropdown = !this.keepOpen || key === 'Tab'
+                this.setSelected(this.hovered, closeDropdown, event)
             }
-            this.setSelected(this.hovered, !this.keepOpen, event)
         },
 
         /**

--- a/src/components/taginput/Taginput.vue
+++ b/src/components/taginput/Taginput.vue
@@ -49,6 +49,7 @@
                 :use-html5-validation="useHtml5Validation"
                 :check-infinite-scroll="checkInfiniteScroll"
                 :append-to-body="appendToBody"
+                :confirm-keys="confirmKeys"
                 @typing="onTyping"
                 @focus="onFocus"
                 @blur="customOnBlur"
@@ -150,7 +151,7 @@ export default {
         },
         confirmKeys: {
             type: Array,
-            default: () => [',', 'Enter']
+            default: () => [',', 'Tab', 'Enter']
         },
         removeOnKeys: {
             type: Array,
@@ -334,7 +335,8 @@ export default {
             if (this.autocomplete && !this.allowNew) return
 
             if (this.confirmKeys.indexOf(key) >= 0) {
-                event.preventDefault()
+                // Allow Tab to advance to next field regardless
+                if (key !== 'Tab') event.preventDefault()
                 this.addTag()
             }
         },

--- a/src/components/taginput/__snapshots__/Taginput.spec.js.snap
+++ b/src/components/taginput/__snapshots__/Taginput.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`BTaginput render correctly 1`] = `
 <div class="taginput control">
     <div class="taginput-container is-focusable">
-        <b-autocomplete-stub usehtml5validation="true" statusicon="true" value="" data="" field="value" keepfirst="true" dropdownposition="auto"></b-autocomplete-stub>
+        <b-autocomplete-stub usehtml5validation="true" statusicon="true" value="" data="" field="value" keepfirst="true" dropdownposition="auto" confirmkeys=",,Tab,Enter"></b-autocomplete-stub>
     </div>
     <!---->
 </div>


### PR DESCRIPTION
Fixes #2871

## Issue
Tab navigation with autocompleted taginputs with `openOnFocus` always selects the hovered option.

## Proposed Changes

- Add `confirmKeys` prop to Autocomplete
- Add Tab to Taginput `confirmKeys` and pass `confirmKeys` to Autocomplete

This will allow the user to move to the next field with the Tab key by using prop `confirmKeys: [',', 'Enter']` instead of the new default `[',', 'Tab', 'Enter']`.