### PR TITLE
add cellClick event to b-table

### DIFF
--- a/docs/pages/components/table/api/table.js
+++ b/docs/pages/components/table/api/table.js
@@ -399,7 +399,7 @@ export default [
             {
                 name: 'default',
                 description: '<strong>Required</strong>, table body and header',
-                props: '<code>row: Object</code>, <code>index: Number</code>'
+                props: '<code>row: Object</code>, <code>column: Vue Object</code>, <code>rowIndex: Number</code>, <code>columnIndex: Number</code>,'
             },
             {
                 name: '<code>header</code>',
@@ -447,6 +447,11 @@ export default [
                 name: '<code>dblclick</code>',
                 description: 'Triggers when a row is double clicked',
                 parameters: '<code>row: Object</code>'
+            },
+            {
+                name: '<code>cellClick</code>',
+                description: 'Triggers when a cell is clicked',
+                parameters: '<code>row: Object</code>, <code>column: Vue Object</code>, <code>rowIndex: Number</code>, <code>columnIndex: Number</code>,'
             },
             {
                 name: '<code>sort</code>',

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -251,7 +251,9 @@
                                         tag="td"
                                         :class="column.rootClasses"
                                         :data-label="column.label"
-                                        :props="{ row, column, index }"
+                                        :props="{ row, column, index, colindex }"
+                                        @click.native="$emit('cellClick',row, column,
+                                                             index, colindex, $event)"
                                     />
                                 </template>
 


### PR DESCRIPTION
## Proposed Changes

add a `cellClick` event triggered on a click of a `<td>` element in the main content of a b-table
with parameters : row, column, rowIndex, columnIndex 

- Use case : 
to detect click event on a cell where it is not possible to set the event listener on the content of the cell, 
ex: empty cell or content of the cell not the full size of the `<td>` element and be able to click aside of the content.

- As a side change, added colindex to b-table-column props
