### PR TITLE
Add controls-alignment prop to Numberinput

### DIFF
--- a/docs/pages/components/numberinput/Numberinput.vue
+++ b/docs/pages/components/numberinput/Numberinput.vue
@@ -14,6 +14,8 @@
 
         <Example :component="ExSizes" :code="ExSizesCode" title="Sizes" vertical/>
 
+        <Example :component="ExAlignment" :code="ExAlignmentCode" title="Alignment and position" vertical/>
+
         <Example :component="ExCustomize" :code="ExCustomizeCode" title="Customization" vertical />
 
         <ApiView :data="api"/>
@@ -42,6 +44,9 @@
     import ExSizes from './examples/ExSizes'
     import ExSizesCode from '!!raw-loader!./examples/ExSizes'
 
+    import ExAlignment from './examples/ExAlignment'
+    import ExAlignmentCode from '!!raw-loader!./examples/ExAlignment'
+
     import ExCustomize from './examples/ExCustomize'
     import ExCustomizeCode from '!!raw-loader!./examples/ExCustomize'
 
@@ -52,6 +57,7 @@
                 ExSimple,
                 ExTypes,
                 ExStep,
+                ExAlignment,
                 ExCustomize,
                 ExRange,
                 ExSizes,
@@ -60,6 +66,7 @@
                 ExStepCode,
                 ExExpon,
                 ExExponCode,
+                ExAlignmentCode,
                 ExCustomizeCode,
                 ExRangeCode,
                 ExSizesCode

--- a/docs/pages/components/numberinput/api/numberinput.js
+++ b/docs/pages/components/numberinput/api/numberinput.js
@@ -89,6 +89,13 @@ export default [
                 default: 'false'
             },
             {
+                name: '<code>controls</code>',
+                description: 'Show controls (+/-)',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>true</code>'
+            },
+            {
                 name: '<code>controls-rounded</code>',
                 description: 'Show rounded controls',
                 type: 'Boolean',
@@ -96,18 +103,18 @@ export default [
                 default: '<code>false</code>'
             },
             {
-                name: '<code>controls</code>',
-                description: 'Showing controls(+/-)',
-                type: 'Boolean',
-                values: '—',
-                default: '<code>true</code>'
-            },
-            {
                 name: '<code>controls-position</code>',
                 description: 'Position of controls',
                 type: 'String',
-                values: '<code>compact<compact>',
+                values: '<code>compact</code>',
                 default: '—'
+            },
+            {
+                name: '<code>controls-alignment</code>',
+                description: 'Alignment of controls',
+                type: 'String',
+                values: '<code>left</code>, <code>right</code>, <code>center</code>',
+                default: '<code>center</code>'
             },
             {
                 name: 'Any native attribute',

--- a/docs/pages/components/numberinput/examples/ExAlignment.vue
+++ b/docs/pages/components/numberinput/examples/ExAlignment.vue
@@ -1,0 +1,27 @@
+<template>
+    <section>
+        <b-field>
+            <b-numberinput></b-numberinput>
+        </b-field>
+
+        <b-field label="Left">
+            <b-numberinput controls-alignment="left"></b-numberinput>
+        </b-field>
+
+        <b-field label="Right">
+            <b-numberinput controls-alignment="right"></b-numberinput>
+        </b-field> 
+
+        <b-field label="Compact">
+            <b-numberinput controls-position="compact"></b-numberinput>
+        </b-field> 
+
+        <b-field label="Compact left">
+            <b-numberinput controls-alignment="left" controls-position="compact"></b-numberinput>
+        </b-field>
+
+        <b-field label="Compact right">
+            <b-numberinput controls-alignment="right" controls-position="compact"></b-numberinput>
+        </b-field>
+    </section>
+</template>

--- a/docs/pages/components/numberinput/examples/ExCustomize.vue
+++ b/docs/pages/components/numberinput/examples/ExCustomize.vue
@@ -1,20 +1,15 @@
 <template>
     <section>
-        <b-field>
-            <b-numberinput></b-numberinput>
-        </b-field>
         <b-field label="Rounded controls">
             <b-numberinput controls-rounded></b-numberinput>
         </b-field>
 
-        <b-field label="Compact">
-            <b-numberinput controls-position="compact"></b-numberinput>
+        <b-field label="Compact and rounded controls">
+            <b-numberinput controls-position="compact" controls-rounded></b-numberinput>
         </b-field>
 
-        <b-field label="Compact and rounded controls">
-            <b-numberinput controls-position="compact"
-                controls-rounded>
-            </b-numberinput>
+        <b-field label="Compact, rounded and right aligned controls">
+            <b-numberinput controls-alignment="right" controls-position="compact" controls-rounded></b-numberinput>
         </b-field>
 
         <b-field label="Grouped">
@@ -35,21 +30,31 @@
             </b-field>
         </b-field>
 
-        <b-field label="With Addons">
+        <b-field label="With addons">
             <b-field>
                 <p class="control">
                     <button class="button">Button</button>
                 </p>
-                <b-numberinput controlsPosition="compact"/>
+                <b-numberinput controls-position="compact"/>
             </b-field>
         </b-field>
 
-        <b-field label="With Addons and expanded">
+        <b-field label="With addons and expanded">
             <b-field>
                 <p class="control">
                     <button class="button">Button</button>
                 </p>
-                <b-numberinput expanded controlsPosition="compact"/>
+                <b-numberinput expanded controls-position="compact"/>
+            </b-field>
+        </b-field>
+
+
+        <b-field label="With addons, expanded and right aligned controls">
+            <b-field>
+                <p class="control">
+                    <button class="button">Button</button>
+                </p>
+                <b-numberinput expanded controls-position="compact" controls-alignment="right" />
             </b-field>
         </b-field>
     </section>

--- a/src/components/numberinput/Numberinput.vue
+++ b/src/components/numberinput/Numberinput.vue
@@ -1,25 +1,26 @@
 <template>
     <div class="b-numberinput field" :class="fieldClasses">
         <p
-            v-if="controls"
-            class="control minus"
-            @mouseup="onStopLongPress(false)"
-            @mouseleave="onStopLongPress(false)"
-            @touchend="onStopLongPress(false)"
-            @touchcancel="onStopLongPress(false)"
+            v-for="control in controlsLeft"
+            :key="control"
+            :class="['control', control]"
+            @mouseup="onStopLongPress"
+            @mouseleave="onStopLongPress"
+            @touchend="onStopLongPress"
+            @touchcancel="onStopLongPress"
         >
             <button
                 type="button"
                 class="button"
                 :class="buttonClasses"
-                :disabled="disabled || disabledMin"
-                @mousedown="onStartLongPress($event, false)"
-                @touchstart.prevent="onStartLongPress($event, false)"
-                @click="onControlClick($event, false)"
+                :disabled="disabled || control === 'plus' ? disabledMax : disabledMin"
+                @mousedown="onStartLongPress($event, control === 'plus')"
+                @touchstart.prevent="onStartLongPress($event, control === 'plus')"
+                @click="onControlClick($event, control === 'plus')"
             >
                 <b-icon
-                    icon="minus"
                     both
+                    :icon="control"
                     :pack="iconPack"
                     :size="iconSize" />
             </button>
@@ -46,26 +47,28 @@
             @focus="$emit('focus', $event)"
             @blur="$emit('blur', $event)"
         />
+
         <p
-            v-if="controls"
-            class="control plus"
-            @mouseup="onStopLongPress(true)"
-            @mouseleave="onStopLongPress(true)"
-            @touchend="onStopLongPress(true)"
-            @touchcancel="onStopLongPress(true)"
+            v-for="control in controlsRight"
+            :key="control"
+            :class="['control', control]"
+            @mouseup="onStopLongPress"
+            @mouseleave="onStopLongPress"
+            @touchend="onStopLongPress"
+            @touchcancel="onStopLongPress"
         >
             <button
                 type="button"
                 class="button"
                 :class="buttonClasses"
-                :disabled="disabled || disabledMax"
-                @mousedown="onStartLongPress($event, true)"
-                @touchstart.prevent="onStartLongPress($event, true)"
-                @click="onControlClick($event, true)"
+                :disabled="disabled || control === 'plus' ? disabledMax : disabledMin"
+                @mousedown="onStartLongPress($event, control === 'plus')"
+                @touchstart.prevent="onStartLongPress($event, control === 'plus')"
+                @click="onControlClick($event, control === 'plus')"
             >
                 <b-icon
-                    icon="plus"
                     both
+                    :icon="control"
                     :pack="iconPack"
                     :size="iconSize" />
             </button>
@@ -108,6 +111,17 @@ export default {
             type: Boolean,
             default: true
         },
+        controlsAlignment: {
+            type: String,
+            default: 'center',
+            validator: (value) => {
+                return [
+                    'left',
+                    'right',
+                    'center'
+                ].indexOf(value) >= 0
+            }
+        },
         controlsRounded: {
             type: Boolean,
             default: false
@@ -138,6 +152,18 @@ export default {
                 this.$emit('input', newValue)
                 !this.isValid && this.$refs.input.checkHtml5Validity()
             }
+        },
+        controlsLeft() {
+            if (this.controls && this.controlsAlignment !== 'right') {
+                return this.controlsAlignment === 'left' ? ['minus', 'plus'] : ['minus']
+            }
+            return []
+        },
+        controlsRight() {
+            if (this.controls && this.controlsAlignment !== 'left') {
+                return this.controlsAlignment === 'right' ? ['minus', 'plus'] : ['plus']
+            }
+            return []
         },
         fieldClasses() {
             return [


### PR DESCRIPTION
Fixes https://github.com/buefy/buefy/issues/2834

## Proposed Changes

- Add new `controls-alignment` property with possible values `left`, `right` or `center` (default). See issue.
