### PR TITLE
Fix 2853: Sidebar closes when clicking on dynamically visible elements

### DIFF
--- a/src/components/sidebar/Sidebar.spec.js
+++ b/src/components/sidebar/Sidebar.spec.js
@@ -96,10 +96,10 @@ describe('BSidebar', () => {
 
     it('manage the whitelisted items accordingly', async () => {
         let el = wrapper.vm.$refs.sidebarContent
-        expect(wrapper.vm.whiteList).toContain(el)
+        expect(wrapper.vm.getWhiteList()).toContain(el)
 
         el = wrapper.vm.$refs.sidebarContent.querySelector('.content')
-        expect(wrapper.vm.whiteList).toContain(el)
+        expect(wrapper.vm.getWhiteList()).toContain(el)
     })
 
     it('reset events before destroy', () => {

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -101,22 +101,6 @@ export default {
         },
         isAbsolute() {
             return this.position === 'absolute'
-        },
-        /**
-         * White-listed items to not close when clicked.
-         * Add sidebar content and all children.
-         */
-        whiteList() {
-            const whiteList = []
-            whiteList.push(this.$refs.sidebarContent)
-            // Add all chidren from dropdown
-            if (this.$refs.sidebarContent !== undefined) {
-                const children = this.$refs.sidebarContent.querySelectorAll('*')
-                for (const child of children) {
-                    whiteList.push(child)
-                }
-            }
-            return whiteList
         }
     },
     watch: {
@@ -130,6 +114,22 @@ export default {
         }
     },
     methods: {
+        /**
+        * White-listed items to not close when clicked.
+        * Add sidebar content and all children.
+        */
+        getWhiteList() {
+            const whiteList = []
+            whiteList.push(this.$refs.sidebarContent)
+            // Add all chidren from dropdown
+            if (this.$refs.sidebarContent !== undefined) {
+                const children = this.$refs.sidebarContent.querySelectorAll('*')
+                for (const child of children) {
+                    whiteList.push(child)
+                }
+            }
+            return whiteList
+        },
 
         /**
         * Keypress event that is bound to the document.
@@ -167,7 +167,7 @@ export default {
             if (this.isFixed) {
                 if (this.isOpen && !this.animating) {
                     const target = isCustomElement(this) ? event.composedPath()[0] : event.target
-                    if (this.whiteList.indexOf(target) < 0) {
+                    if (this.getWhiteList().indexOf(target) < 0) {
                         this.cancel('outside')
                     }
                 }


### PR DESCRIPTION


<!-- Thank you for helping Buefy! -->

Fixes #2853
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Use method instead of computed property for whitelist
- Computed property was not updated if we added some elements dynamically
