### PR TITLE
Update input.js

### DIFF
--- a/docs/pages/components/input/api/input.js
+++ b/docs/pages/components/input/api/input.js
@@ -93,6 +93,13 @@ export default [
                 default: '—'
             },
             {
+                name: '<code>minlength</code>',
+                description: 'Same as native <code>minlength</code>',
+                type: 'String, Number',
+                values: '—',
+                default: '—'
+            },
+            {
                 name: '<code>has-counter</code>',
                 description: 'Show character counter when <code>maxlength</code> prop is passed',
                 type: 'Boolean',


### PR DESCRIPTION
added minlength property to api docs

<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- added minlength property of b-input  to api docs, which was previously missing.
-
-
