### PR TITLE
left-label prop added for b-switch component

### DIFF
--- a/docs/pages/components/switch/examples/ExStyles.vue
+++ b/docs/pages/components/switch/examples/ExStyles.vue
@@ -30,11 +30,16 @@
                 <option value="is-large">is-large</option>
             </b-select>
         </b-field>
+        <b-field label="Left Label">
+            <b-radio v-model='leftLabel' :native-value='false'>False</b-radio>
+            <b-radio v-model='leftLabel' :native-value='true'>True</b-radio>
+        </b-field>
         <b-switch
             :rounded="isRounded"
             :outlined="isOutlined"
             :size="size"
             :type="type"
+            :left-label='leftLabel'
             :passive-type='passiveType'>Sample</b-switch>
     </section>
 </template>
@@ -48,6 +53,7 @@
                 passiveType: null,
                 isRounded: false,
                 isOutlined: false,
+                leftLabel: false,
             }
         }
     }

--- a/src/components/switch/Switch.spec.js
+++ b/src/components/switch/Switch.spec.js
@@ -52,4 +52,17 @@ describe('BSwitch', () => {
         const switchElement = wrapper.find('.check')
         expect(switchElement.classes()).toContain('is-danger-passive')
     })
+
+    it('does not have a label at left by default', () => {
+        const value = false
+        wrapper.setProps({ value })
+        expect(wrapper.classes()).not.toContain('has-left-label')
+    })
+
+    it('has label at left is left-label prop has been sent', () => {
+        const leftLabel = true
+        const value = false
+        wrapper.setProps({ leftLabel, value })
+        expect(wrapper.classes()).toContain('has-left-label')
+    })
 })

--- a/src/components/switch/Switch.vue
+++ b/src/components/switch/Switch.vue
@@ -55,6 +55,10 @@ export default {
         outlined: {
             type: Boolean,
             default: false
+        },
+        leftLabel: {
+            type: Boolean,
+            default: false
         }
     },
     data() {
@@ -79,7 +83,8 @@ export default {
                 {
                     'is-disabled': this.disabled,
                     'is-rounded': this.rounded,
-                    'is-outlined': this.outlined
+                    'is-outlined': this.outlined,
+                    'has-left-label': this.leftLabel
                 }
             ]
         },

--- a/src/scss/components/_switch.scss
+++ b/src/scss/components/_switch.scss
@@ -94,9 +94,20 @@ $switch-active-background-color: $primary !default;
             }
         }
     }
-    .control-label {
-        padding-left: $control-padding-horizontal;
+
+    &.has-left-label {
+        flex-direction: row-reverse;
+        .control-label {
+            padding-right: $control-padding-horizontal;
+        }
     }
+
+    &:not(.has-left-label) {
+        .control-label {
+            padding-left: $control-padding-horizontal;
+        }
+    }
+
     &:hover {
         input[type=checkbox] + .check {
             background: rgba($grey-light, 0.9);


### PR DESCRIPTION
## Summary
`left-label` prop added into `b-switch` component.

## Why Buefy needs this?
Currently label of switch component is displaying at right of the component. If for some reasons users need to display them at left, they need to write custom CSS instead.

## Motivation
It's coming from Quasar Framework's `toggle` component's `left-label` prop.
https://quasar.dev/vue-components/toggle#With-labels

## Examples
![Ekran-Kayd-2020-09-26-200155](https://user-images.githubusercontent.com/51219535/94346505-b8e1bb00-0035-11eb-83b1-38fce8d020b3.gif)

## Documentation
<img width="258" alt="documentation" src="https://user-images.githubusercontent.com/51219535/94346450-643e4000-0035-11eb-9701-39a7f75a5b89.png">

## Checklist
- [x] Documentation updated
- [x] New Example added
- [x] Unit Tests added