### PR TITLE
Fixes #2889 - moved trigger behind tooltip appended to body

### DIFF
--- a/src/components/tooltip/Tooltip.vue
+++ b/src/components/tooltip/Tooltip.vue
@@ -19,7 +19,8 @@
             @contextmenu="onContextMenu"
             @mouseenter="onHover"
             @focus.capture="onFocus"
-            @mouseleave="close">
+            @mouseleave="close"
+            :style="triggerStyle">
             <slot ref="slot" />
         </div>
     </span>
@@ -88,6 +89,9 @@ export default {
         return {
             isActive: false,
             style: {},
+            triggerStyle: {
+                zIndex: this.appendToBody ? '100' : 'auto'
+            },
             timer: null,
             _bodyEl: undefined // Used to append to body
         }

--- a/src/components/tooltip/Tooltip.vue
+++ b/src/components/tooltip/Tooltip.vue
@@ -19,8 +19,7 @@
             @contextmenu="onContextMenu"
             @mouseenter="onHover"
             @focus.capture="onFocus"
-            @mouseleave="close"
-            :style="triggerStyle">
+            @mouseleave="close">
             <slot ref="slot" />
         </div>
     </span>
@@ -89,9 +88,6 @@ export default {
         return {
             isActive: false,
             style: {},
-            triggerStyle: {
-                zIndex: this.appendToBody ? '100' : undefined
-            },
             timer: null,
             _bodyEl: undefined // Used to append to body
         }
@@ -102,7 +98,8 @@ export default {
                 'is-square': this.square,
                 'is-always': this.always,
                 'is-multiline': this.multilined,
-                'is-dashed': this.dashed
+                'is-dashed': this.dashed,
+                'is-trigger': this.appendToBody
             }]
         },
         newAnimation() {

--- a/src/components/tooltip/Tooltip.vue
+++ b/src/components/tooltip/Tooltip.vue
@@ -90,7 +90,7 @@ export default {
             isActive: false,
             style: {},
             triggerStyle: {
-                zIndex: this.appendToBody ? '100' : 'auto'
+                zIndex: this.appendToBody ? '100' : undefined
             },
             timer: null,
             _bodyEl: undefined // Used to append to body

--- a/src/scss/components/_tooltip.scss
+++ b/src/scss/components/_tooltip.scss
@@ -189,4 +189,7 @@ $tooltip-colors: $colors !default;
             border-radius: 0;
         }
     }
+    &.is-trigger {
+        z-index: 100;
+    }
 }


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #2889

## Proposed Changes 
When a tooltip uses append-to-body (FYI this is not documented), make the trigger element z-index deeper than the appended element so that the hover isn't falsely triggered. This change only affects style when append-to-body is used on a tooltip.