### PR TITLE
Fix #2938: border-right is missing in timepicker select

### DIFF
--- a/src/scss/components/_timepicker.scss
+++ b/src/scss/components/_timepicker.scss
@@ -34,6 +34,8 @@
             font-size: 1.25em;
             margin-right: 0 !important;
             .select {
+                margin: 0 0.125em;
+
                 select {
                     font-weight: $weight-semibold;
                     padding-right: $control-padding-horizontal;


### PR DESCRIPTION


<!-- Thank you for helping Buefy! -->

Fix #2938
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Make the select breathe

### Before 
![image](https://user-images.githubusercontent.com/12817388/95205581-8feac400-07b3-11eb-9571-bdcfde663282.png)

### After
![image](https://user-images.githubusercontent.com/12817388/95205594-95480e80-07b3-11eb-8f82-96ba4137358b.png)
