### PR TITLE
Adds autoFocus prop to Modal and updates trap-focus related docs.

### DIFF
--- a/docs/pages/components/datepicker/api/datepicker.js
+++ b/docs/pages/components/datepicker/api/datepicker.js
@@ -259,7 +259,7 @@ export default [
                 description: `Trap focus inside the datepicker.`,
                 type: 'Boolean',
                 values: '—',
-                default: '<code>false</code>'
+                default: '<code>true</code>'
             },
             {
                 name: '<code>append-to-body</code>',

--- a/docs/pages/components/dialog/api/dialog.js
+++ b/docs/pages/components/dialog/api/dialog.js
@@ -136,7 +136,7 @@ export default [
                 description: `Trap focus inside the dialog.`,
                 type: 'Boolean',
                 values: '—',
-                default: '<code>false</code>'
+                default: '<code>true</code>'
             },
             {
                 name: '<code>aria-role</code>',

--- a/docs/pages/components/dropdown/api/dropdown.js
+++ b/docs/pages/components/dropdown/api/dropdown.js
@@ -77,7 +77,7 @@ export default [
                 description: `Trap focus inside the dropdown.`,
                 type: 'Boolean',
                 values: '—',
-                default: '<code>false</code>'
+                default: '<code>true</code>'
             },
             {
                 name: '<code>can-close</code>',

--- a/docs/pages/components/modal/api/modal.js
+++ b/docs/pages/components/modal/api/modal.js
@@ -99,7 +99,14 @@ export default [
                 description: `Trap focus inside the modal.`,
                 type: 'Boolean',
                 values: '—',
-                default: '<code>false</code>'
+                default: '<code>true</code>'
+            },
+            {
+                name: '<code>auto-focus</code>',
+                description: `Automatically focus modal when active.`,
+                type: 'Boolean',
+                values: '—',
+                default: '<code>true</code>'
             },
             {
                 name: '<code>custom-class</code>',

--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -107,6 +107,12 @@ export default {
                 return config.defaultTrapFocus
             }
         },
+        autoFocus: {
+            type: Boolean,
+            default: () => {
+                return config.defaultAutoFocus
+            }
+        },
         customClass: String,
         ariaRole: {
             type: String,
@@ -160,7 +166,7 @@ export default {
             if (value) this.destroyed = false
             this.handleScroll()
             this.$nextTick(() => {
-                if (value && this.$el && this.$el.focus) {
+                if (value && this.$el && this.$el.focus && this.autoFocus) {
                     this.$el.focus()
                 }
             })

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -42,6 +42,7 @@ let config = {
     defaultDatepickerShowWeekNumber: false,
     defaultDatepickerMobileModal: true,
     defaultTrapFocus: true,
+    defaultAutoFocus: true,
     defaultButtonRounded: false,
     defaultCarouselInterval: 3500,
     defaultTabsExpanded: false,


### PR DESCRIPTION
## Proposed Changes

Adds an `auto-focus` prop, default `true`, to the modal component;
Also, during the process I noticed that all components that had the `trap-focus` feature had their documentation say that the value defaults to `false`, when its being a few releases that it is `true`.

Sorry, I forgot to create a new branch for this one!