### PR TITLE
Added 'sticky-checkbox' option to b-table (#2635)

### DIFF
--- a/docs/pages/components/table/api/table.js
+++ b/docs/pages/components/table/api/table.js
@@ -101,6 +101,13 @@ export default [
                 default: '<code>left</code>'
             },
             {
+                name: '<code>sticky-checkbox</code>',
+                description: 'Make the checkbox column sticky when <code>checkable</code>',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
                 name: '<code>checked-rows</code>',
                 description: 'Set which rows are checked, use the <code>.sync</code> modifier to make it two-way binding',
                 type: 'Array<Object>',

--- a/docs/pages/components/table/examples/ExSticky.vue
+++ b/docs/pages/components/table/examples/ExSticky.vue
@@ -13,6 +13,17 @@
             :columns="columns"
             :sticky-header="stickyHeaders"
         ></b-table>
+        <br />
+        Use <code>checkable</code> and <code>sticky-checkbox</code> to make a sticky checkbox column.
+        <br />
+        <br />
+        <b-table
+            :data="data"
+            :columns="checkableColumns"
+            :sticky-header="stickyHeaders"
+            checkable
+            sticky-checkbox
+        ></b-table>
     </section>
 </template>
 
@@ -172,7 +183,89 @@ export default {
                     label: "Column O"
                 }
             ];
-        }
+        },
+        checkableColumns() {
+            return [
+                {
+                    field: "id",
+                    label: "ID",
+                    width: "40",
+                    numeric: true,
+                    sticky: false,
+                },
+                {
+                    field: "user.first_name",
+                    label: "First Name"
+                },
+                {
+                    field: "user.last_name",
+                    label: "Last Name"
+                },
+                {
+                    field: "date",
+                    label: "Date",
+                    searchable: this.dateSearchable,
+                    centered: true,
+                    sticky: false,
+                },
+                {
+                    field: "gender",
+                    label: "Gender"
+                },
+                {
+                    field: "id",
+                    label: "Column A"
+                },
+                {
+                    field: "id",
+                    label: "Column B"
+                },
+                {
+                    field: "id",
+                    label: "Column C"
+                },
+                {
+                    field: "id",
+                    label: "Column D"
+                },
+                {
+                    field: "id",
+                    label: "Column E"
+                },
+                {
+                    field: "id",
+                    label: "Column F"
+                },
+                {
+                    field: "id",
+                    label: "Column G"
+                },
+                {
+                    field: "id",
+                    label: "Column H"
+                },
+                {
+                    field: "id",
+                    label: "Column I"
+                },
+                {
+                    field: "id",
+                    label: "Column L"
+                },
+                {
+                    field: "id",
+                    label: "Column M"
+                },
+                {
+                    field: "id",
+                    label: "Column N"
+                },
+                {
+                    field: "id",
+                    label: "Column O"
+                }
+            ];
+        },
     }
 };
 </script>

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -49,7 +49,9 @@
                 <thead v-if="newColumns.length && showHeader">
                     <tr>
                         <th v-if="showDetailRowIcon" width="40px"/>
-                        <th class="checkbox-cell" v-if="checkable && checkboxPosition === 'left'">
+                        <th
+                            :class="'checkbox-cell' + ( stickyCheckbox ? ' is-sticky' : '' )"
+                            v-if="checkable && checkboxPosition === 'left'">
                             <template v-if="headerCheckable">
                                 <b-checkbox
                                     :value="isAllChecked"
@@ -124,7 +126,9 @@
                                 </template>
                             </div>
                         </th>
-                        <th class="checkbox-cell" v-if="checkable && checkboxPosition === 'right'">
+                        <th
+                            :class="'checkbox-cell' + ( stickyCheckbox ? ' is-sticky' : '' )"
+                            v-if="checkable && checkboxPosition === 'right'">
                             <template v-if="headerCheckable">
                                 <b-checkbox
                                     :value="isAllChecked"
@@ -231,7 +235,7 @@
                             </td>
 
                             <td
-                                class="checkbox-cell"
+                                :class="'checkbox-cell' + ( stickyCheckbox ? ' is-sticky' : '' )"
                                 v-if="checkable && checkboxPosition === 'left'">
                                 <b-checkbox
                                     :disabled="!isRowCheckable(row)"
@@ -260,7 +264,7 @@
                             </template>
 
                             <td
-                                class="checkbox-cell"
+                                :class="'checkbox-cell' + ( stickyCheckbox ? ' is-sticky' : '' )"
                                 v-if="checkable && checkboxPosition === 'right'">
                                 <b-checkbox
                                     :disabled="!isRowCheckable(row)"
@@ -401,6 +405,10 @@ export default {
                     'right'
                 ].indexOf(value) >= 0
             }
+        },
+        stickyCheckbox: {
+            type: Boolean,
+            default: false
         },
         selected: Object,
         isRowSelectable: {


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #2635 
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Add a `sticky-checkbox` prop to the `<b-table>` component, which, if the table is `checkable`, will make the checkbox column sticky. 
- Add example and explanation of use to the Table documentation page.

![Peek 2020-10-12 13-56](https://user-images.githubusercontent.com/5216912/95781388-54f4fe80-0c93-11eb-834b-02ed0a312989.gif)

![Screenshot from 2020-10-12 14-03-42](https://user-images.githubusercontent.com/5216912/95781596-c6cd4800-0c93-11eb-8e13-e749877f1fed.png)

