### PR TITLE
"tooltip-always" prop added for BSlider component

### DIFF
--- a/docs/pages/components/slider/api/slider.js
+++ b/docs/pages/components/slider/api/slider.js
@@ -129,6 +129,13 @@ export default [
                 type: 'Boolean',
                 values: '—',
                 default: '<code>false</code>'
+            },
+            {
+                name: '<code>tooltip-always</code>',
+                description: 'Tooltip displays always',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
             }
         ],
         slots: [

--- a/docs/pages/components/slider/examples/ExCustomize.vue
+++ b/docs/pages/components/slider/examples/ExCustomize.vue
@@ -4,6 +4,10 @@
             <b-slider v-model="sliderValue" :tooltip-type="sliderType"></b-slider>
         </b-field>
 
+        <b-field label="Tooltip Always">
+            <b-slider tooltip-always></b-slider>
+        </b-field>
+        
         <b-field label="Hide tooltip">
             <b-slider :tooltip="false"></b-slider>
         </b-field>

--- a/src/components/slider/Slider.spec.js
+++ b/src/components/slider/Slider.spec.js
@@ -93,9 +93,14 @@ describe('BSlider', () => {
 
     describe('When biggerSliderFocus is set to true', () => {
         it('renders a component with sliderFocus class', () => {
-            wrapper.setProps({biggerSliderFocus: true})
+            wrapper.setProps({ biggerSliderFocus: true })
             const subject = wrapper.find('.slider-focus')
             expect(subject.exists()).toBeTruthy()
         })
+    })
+
+    it('passes tooltip-always prop to b-slider-thumb component', () => {
+        wrapper.setProps({ tooltipAlways: true })
+        expect(wrapper.find('b-slider-thumb-stub').props().tooltipAlways).toBe(true)
     })
 })

--- a/src/components/slider/Slider.vue
+++ b/src/components/slider/Slider.vue
@@ -17,6 +17,7 @@
             </template>
             <slot/>
             <b-slider-thumb
+                :tooltip-always="tooltipAlways"
                 v-model="value1"
                 :type="newTooltipType"
                 :tooltip="tooltip"
@@ -35,6 +36,7 @@
                 @dragstart="onDragStart"
                 @dragend="onDragEnd" />
             <b-slider-thumb
+                :tooltip-always="tooltipAlways"
                 v-model="value2"
                 :type="newTooltipType"
                 :tooltip="tooltip"
@@ -137,6 +139,10 @@ export default {
             default: () => {
                 return config.defaultLocale
             }
+        },
+        tooltipAlways: {
+            type: Boolean,
+            default: false
         }
     },
     data() {

--- a/src/components/slider/SliderThumb.spec.js
+++ b/src/components/slider/SliderThumb.spec.js
@@ -91,4 +91,9 @@ describe('BSliderThumb', () => {
         expect(document.removeEventListener).toHaveBeenCalledWith('touchend', expect.any(Function))
         expect(document.removeEventListener).toHaveBeenCalledWith('contextmenu', expect.any(Function))
     })
+
+    it('passes tooltip-always prop to b-tooltip component', () => {
+        wrapper.setProps({ tooltipAlways: true })
+        expect(wrapper.find('b-tooltip-stub').props().always).toBe(true)
+    })
 })

--- a/src/components/slider/SliderThumb.vue
+++ b/src/components/slider/SliderThumb.vue
@@ -6,7 +6,7 @@
         <b-tooltip
             :label="formattedValue"
             :type="type"
-            :always="dragging || isFocused"
+            :always="dragging || isFocused || tooltipAlways"
             :active="!disabled && tooltip">
             <div
                 class="b-slider-thumb"
@@ -71,6 +71,10 @@ export default {
             default: () => {
                 return config.defaultLocale
             }
+        },
+        tooltipAlways: {
+            type: Boolean,
+            default: false
         }
     },
     data() {


### PR DESCRIPTION
## Summary
`tooltip-always` prop added into `b-slider` component.

## Why Buefy needs this?
Currently only way to display tooltip on screen is either dragging or hovering the slider thumb. 

## Motivation
It's coming from Quasar Framework's `slider` component's `label-always` prop.
https://quasar.dev/vue-components/slider#Example--Always-display-label

## Examples
![ezgif-6-55543c0c1fa7](https://user-images.githubusercontent.com/51219535/96376799-b6ccd100-1189-11eb-9e2d-c15f4be72173.gif)


## Documentation
<img width="1102" alt="Ekran Resmi 2020-10-18 21 27 11" src="https://user-images.githubusercontent.com/51219535/96376810-c0eecf80-1189-11eb-8827-59c3ca2abbf3.png">


## Checklist
- [x] Documentation updated
- [x] New Example added
- [x] Unit Tests added