### PR TITLE
Document update: Use v-slot to define header slot in custom header example

### DIFF
--- a/docs/pages/components/tabs/examples/ExCustomHeaders.vue
+++ b/docs/pages/components/tabs/examples/ExCustomHeaders.vue
@@ -1,13 +1,13 @@
 <template>
     <b-tabs type="is-boxed">
         <b-tab-item>
-            <template slot="header">
+            <template #header>
                 <b-icon icon="information-outline"></b-icon>
                 <span> Issues <b-tag rounded> 3 </b-tag> </span>
             </template>
         </b-tab-item>
         <b-tab-item>
-            <template slot="header">
+            <template #header>
                 <b-icon icon="source-pull"></b-icon>
                 <span> Pull Requests <b-tag rounded> {{count}} </b-tag> </span>
             </template>


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Documents update (Tabs -> custom headers)
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Document update required from [this previous pull request](https://github.com/buefy/buefy/pull/2996)
- Buefy custom headers example under tabs should use `v-slot` or its shorthand syntax `#` which is recommended by Vue official doc
- References : 
> 
> 1. [Vue recommended way to define named slot](https://vuejs.org/v2/guide/components-slots.html#Named-Slots)
> 2. [Named Slots Shorthand](https://vuejs.org/v2/guide/components-slots.html#Named-Slots-Shorthand)
> 3. [Deprecated `slot` Attribute](https://vuejs.org/v2/guide/components-slots.html#Deprecated-Syntax)
