### PR TITLE
Add rounded property to BUpload Component

### DIFF
--- a/docs/pages/components/upload/Upload.vue
+++ b/docs/pages/components/upload/Upload.vue
@@ -5,6 +5,8 @@
         <Example :component="ExDragDrop" :code="ExDragDropCode" title="Drag and drop" vertical/>
         
         <Example :component="ExExpanded" :code="ExExpandedCode" title="Expanded" vertical/>
+        
+        <Example :component="ExRounded" :code="ExRoundedCode" title="Rounded" vertical/>
 
         <ApiView :data="api"/>
     </div>
@@ -20,7 +22,10 @@
     import ExDragDropCode from '!!raw-loader!./examples/ExDragDrop'
 
     import ExExpanded from './examples/ExExpanded'
-    import ExExpandedCode from '!!raw-loader!./examples/ExExpanded'
+    import ExExpandedCode from '!!raw-loader!./examples/ExExpanded'    
+    
+    import ExRounded from './examples/ExRounded'
+    import ExRoundedCode from '!!raw-loader!./examples/ExRounded'
 
     export default {
         data() {
@@ -31,7 +36,9 @@
                 ExExpanded,
                 ExSimpleCode,
                 ExDragDropCode,
-                ExExpandedCode
+                ExExpandedCode,
+                ExRounded,
+                ExRoundedCode
             }
         }
     }

--- a/docs/pages/components/upload/api/upload.js
+++ b/docs/pages/components/upload/api/upload.js
@@ -81,6 +81,13 @@ export default [
                 values: '—',
                 default: '<code>false</code>'
             },
+            {
+                name: '<code>rounded</code>',
+                description: 'Upload will be rounded',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
         ],
         events: [
             {

--- a/docs/pages/components/upload/examples/ExRounded.vue
+++ b/docs/pages/components/upload/examples/ExRounded.vue
@@ -12,14 +12,14 @@
     </b-field>
 
     <b-field label="Separated filename">
-        <b-field class="file is-primary"  :class="{'has-name': !!file}">
-            <b-upload v-model="file" class="file-label" rounded>
+        <b-field class="file is-primary"  :class="{'has-name': !!file2}">
+            <b-upload v-model="file2" class="file-label" rounded>
                 <span class="file-cta">
                     <b-icon class="file-icon" icon="upload"></b-icon>
                     <span class="file-label">Click to upload</span>
                 </span>
-                <span class="file-name" v-if="file">
-                    {{ file.name }}
+                <span class="file-name" v-if="file2">
+                    {{ file2.name }}
                 </span>
             </b-upload>
         </b-field> 
@@ -32,6 +32,7 @@ export default {
   data() {
     return {
       file: {},
+      file2 : null
     };
   },
 };

--- a/docs/pages/components/upload/examples/ExRounded.vue
+++ b/docs/pages/components/upload/examples/ExRounded.vue
@@ -1,0 +1,28 @@
+<template>
+  <section>
+    <b-field class="file">
+      <b-upload v-model="file" rounded>
+        <a class="button is-primary is-rounded">
+          <b-icon icon="upload"></b-icon>
+          <span>{{ file.name || "Click to upload"}}</span>
+        </a>
+      </b-upload>
+    </b-field>
+  </section>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      file: {},
+      dropFiles: []
+    };
+  },
+  methods: {
+    deleteDropFile(index) {
+      this.dropFiles.splice(index, 1);
+    }
+  }
+};
+</script>

--- a/docs/pages/components/upload/examples/ExRounded.vue
+++ b/docs/pages/components/upload/examples/ExRounded.vue
@@ -1,6 +1,6 @@
 <template>
   <section>
-    <b-field label="Include filename">
+    <b-field label="Included filename">
       <b-field class="file is-primary" :class="{'has-name': !!file}">
         <b-upload v-model="file" class="file-label" rounded>
           <span class="file-cta">
@@ -11,7 +11,7 @@
       </b-field>
     </b-field>
 
-    <b-field label="Seperate filename">
+    <b-field label="Separated filename">
         <b-field class="file is-primary"  :class="{'has-name': !!file}">
             <b-upload v-model="file" class="file-label" rounded>
                 <span class="file-cta">

--- a/docs/pages/components/upload/examples/ExRounded.vue
+++ b/docs/pages/components/upload/examples/ExRounded.vue
@@ -1,12 +1,28 @@
 <template>
   <section>
-    <b-field class="file">
-      <b-upload v-model="file" rounded>
-        <a class="button is-primary is-rounded">
-          <b-icon icon="upload"></b-icon>
-          <span>{{ file.name || "Click to upload"}}</span>
-        </a>
-      </b-upload>
+    <b-field label="Include filename">
+      <b-field class="file is-primary" :class="{'has-name': !!file}">
+        <b-upload v-model="file" class="file-label" rounded>
+          <span class="file-cta">
+            <b-icon icon="upload"></b-icon>
+            <span class="file-label">{{ file.name || "Click to upload"}}</span>
+          </span>
+        </b-upload>
+      </b-field>
+    </b-field>
+
+    <b-field label="Seperate filename">
+        <b-field class="file is-primary"  :class="{'has-name': !!file}">
+            <b-upload v-model="file" class="file-label" rounded>
+                <span class="file-cta">
+                    <b-icon class="file-icon" icon="upload"></b-icon>
+                    <span class="file-label">Click to upload</span>
+                </span>
+                <span class="file-name" v-if="file">
+                    {{ file.name }}
+                </span>
+            </b-upload>
+        </b-field> 
     </b-field>
   </section>
 </template>

--- a/docs/pages/components/upload/examples/ExRounded.vue
+++ b/docs/pages/components/upload/examples/ExRounded.vue
@@ -16,13 +16,7 @@ export default {
   data() {
     return {
       file: {},
-      dropFiles: []
     };
   },
-  methods: {
-    deleteDropFile(index) {
-      this.dropFiles.splice(index, 1);
-    }
-  }
 };
 </script>

--- a/src/components/upload/Upload.vue
+++ b/src/components/upload/Upload.vue
@@ -1,5 +1,5 @@
 <template>
-    <label class="upload control" :class="{'is-expanded' : expanded}">
+    <label class="upload control" :class="{'is-expanded' : expanded, 'is-rounded' : rounded}">
         <template v-if="!dragDrop">
             <slot/>
         </template>
@@ -56,6 +56,10 @@ export default {
             default: false
         },
         expanded: {
+            type: Boolean,
+            default: false
+        },
+        rounded: {
             type: Boolean,
             default: false
         }

--- a/src/scss/components/_upload.scss
+++ b/src/scss/components/_upload.scss
@@ -1,7 +1,7 @@
 .upload {
     position: relative;
     display: inline-flex;
-    input[type=file] {
+    input[type="file"] {
         position: absolute;
         top: 0;
         left: 0;
@@ -53,15 +53,20 @@
     }
     &.is-rounded {
         border-radius: $radius-rounded;
+
+        .file-name {
+            border-top-right-radius: $radius-rounded;
+            border-bottom-right-radius: $radius-rounded;
+        }
     }
 }
 // temporary IE 11 hack !!!
 @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
     .upload {
-        input[type=file] {
+        input[type="file"] {
             z-index: auto;
         }
-        .upload-draggable + input[type=file] {
+        .upload-draggable + input[type="file"] {
             z-index: -1;
         }
     }

--- a/src/scss/components/_upload.scss
+++ b/src/scss/components/_upload.scss
@@ -51,6 +51,9 @@
     &.is-expanded {
         width: 100%;
     }
+    &.is-rounded {
+        border-radius: $radius-rounded;
+    }
 }
 // temporary IE 11 hack !!!
 @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

## Proposed Changes
I think it would be a great addition to be able to use rounded upload buttons as a Buefy component, without any additional CSS.
At first I thought about simply opening a feature request, but then I decided to have a look in the code and contribute something  myself, because i really like the framwork. And hey this is my first PR to an open source repo :partying_face: 

Soo what I did:
- Added the necessary scss class to make the input field rounded (the button in the slot must be still set to "is-rounded" manually tho)
- Added the property rounded to the Upload vue component
- Added the new property to the documentation and provided an example how to use it
- Run the linter (works :champagne:) and the tests (doesn't work, but fails on other files, that i haven't touched... :confused: )

Hope that is sufficient to make a quick merge possible, if not please tell me. I am still new to this open source development process and looking forward to get some feedback :)
