### PR TITLE
Fix Issue 2990

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -179,7 +179,9 @@ export function multiColumnSort(inputArray, sortingPriority) {
     const fieldSorter = (fields) => (a, b) => fields.map((o) => {
         let dir = 1
         if (o[0] === '-') { dir = -1; o = o.substring(1) }
-        return a[o] > b[o] ? dir : a[o] < b[o] ? -(dir) : 0
+        const aValue = getValueByPath(a, o)
+        const bValue = getValueByPath(b, o)
+        return aValue > bValue ? dir : aValue < bValue ? -(dir) : 0
     }).reduce((p, n) => p || n, 0)
 
     return array.sort(fieldSorter(sortingPriority))


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #2990
## Proposed Changes

- When multi-sort on nested obj, sorting fields passed to `multiColumnSort` helper function is a prop path, use existing `getValueByPath` function to get the value at path of object

## Outcome
### Before fix
![multi-sort-before-fix](https://user-images.githubusercontent.com/5698884/97804245-a563e880-1ca2-11eb-8534-678259afadda.gif)
### After fix

![multi-sort-after-fix](https://user-images.githubusercontent.com/5698884/97804257-ba407c00-1ca2-11eb-8d93-e79fd45d07eb.gif)
