### PR TITLE
Update material design icons cdn

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Vue.use(Input)
 ### 3 Include Material Design Icons
 
 ```html
-<link rel="stylesheet" href="//cdn.materialdesignicons.com/2.0.46/css/materialdesignicons.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@5.8.55/css/materialdesignicons.min.css">
 ```
 
 If you want to customize the icons or the theme, refer to the [customization section on the documentation](https://buefy.org/documentation/customization).

--- a/docs/components/CodepenEdit.vue
+++ b/docs/components/CodepenEdit.vue
@@ -34,7 +34,7 @@ export default {
             ],
             externalStyles: [
                 'https://unpkg.com/buefy/dist/buefy.min.css',
-                'https://cdn.materialdesignicons.com/2.0.46/css/materialdesignicons.min.css'
+                'https://cdn.jsdelivr.net/npm/@mdi/font@5.8.55/css/materialdesignicons.min.css'
             ]
         }
     },

--- a/docs/pages/installation/Start.vue
+++ b/docs/pages/installation/Start.vue
@@ -181,7 +181,7 @@
                     </\script>
                 </body>
                 </html>`,
-                materialIcons: '<link rel="stylesheet" href="https://cdn.materialdesignicons.com/5.3.45/css/materialdesignicons.min.css">',
+                materialIcons: '<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@5.8.55/css/materialdesignicons.min.css">',
                 fontAwesome5: '<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.2.0/css/all.css">'
             }
         },


### PR DESCRIPTION
Apparently `cdn.materialdesignicons.com` has been shutdown.

Maintainers recommend `cdn.jsdelivr.net` instead.