### PR TITLE
Fixes #2678: Override is-boxed display style in NavbarDropdown

### DIFF
--- a/src/components/navbar/NavbarDropdown.vue
+++ b/src/components/navbar/NavbarDropdown.vue
@@ -89,3 +89,8 @@ export default {
     }
 }
 </script>
+<style lang="scss" scoped>
+.is-boxed {
+    display: none;
+}
+</style>

--- a/src/components/navbar/NavbarDropdown.vue
+++ b/src/components/navbar/NavbarDropdown.vue
@@ -89,8 +89,3 @@ export default {
     }
 }
 </script>
-<style lang="scss" scoped>
-.is-boxed {
-    display: none;
-}
-</style>

--- a/src/scss/components/_navbar.scss
+++ b/src/scss/components/_navbar.scss
@@ -15,9 +15,7 @@
         transition-property: opacity, visibility, transform;
     }
 
-    .navbar-item.has-dropdown {
-        &.is-active .is-boxed {
-            visibility: visible;
-        }
+    .navbar-item.has-dropdown.is-active .is-boxed{
+        visibility: visible;
     }
 }

--- a/src/scss/components/_navbar.scss
+++ b/src/scss/components/_navbar.scss
@@ -4,9 +4,20 @@
             justify-content: center;
             margin-left: auto;
         }
-    
+
         .navbar-end {
             margin-left: 0;
+        }
+    }
+
+    .navbar-dropdown.is-boxed {
+        visibility: hidden;
+        transition-property: opacity, visibility, transform;
+    }
+
+    .navbar-item.has-dropdown {
+        &.is-active .is-boxed {
+            visibility: visible;
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #2678
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Override class `is-boxed` `display` style to `display: none` as default in NavbarDropdown
- When "box" style dropdown is opened, its div `<div class="navbar-dropdown is-boxed"></div>` will be styled as `display:block` by `.navbar-item.is-active .navbar-dropdown` as shown in following screenshot (Therefore, this issue can be resolved by neither tweaking existing transition style nor making new vue transition logic):

<img width="268" alt="Screen Shot 2020-11-07 at 11 04 53 pm" src="https://user-images.githubusercontent.com/5698884/98441050-91abfc80-2150-11eb-9457-7e59028aee13.png">


