### PR TITLE
Fix #3028: Use aria labels on default pagination next/previous buttons

### DIFF
--- a/src/components/pagination/Pagination.vue
+++ b/src/components/pagination/Pagination.vue
@@ -18,7 +18,8 @@
             v-else
             class="pagination-previous"
             :disabled="!hasPrev"
-            :page="getPage(current - 1)">
+            :page="getPage(current - 1)"
+            :aria-label="ariaPreviousLabel">
             <b-icon
                 :icon="iconPrev"
                 :pack="iconPack"
@@ -43,7 +44,8 @@
             v-else
             class="pagination-next"
             :disabled="!hasNext"
-            :page="getPage(current + 1)">
+            :page="getPage(current + 1)"
+            :aria-label="ariaNextLabel">
             <b-icon
                 :icon="iconNext"
                 :pack="iconPack"


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #3028
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Use aria labels on default pagination next/previous buttons
