### PR TITLE
Fix #2848: selected b-radio button inset shadow

### DIFF
--- a/docs/pages/components/radio/examples/ExRadioButton.vue
+++ b/docs/pages/components/radio/examples/ExRadioButton.vue
@@ -3,20 +3,21 @@
         <b-field>
             <b-radio-button v-model="radioButton"
                 native-value="Nope"
-                type="is-danger">
+                type="is-danger is-light is-outlined">
                 <b-icon icon="close"></b-icon>
                 <span>Nope</span>
             </b-radio-button>
 
             <b-radio-button v-model="radioButton"
                 native-value="Yep"
-                type="is-success">
+                type="is-success is-light is-outlined">
                 <b-icon icon="check"></b-icon>
                 <span>Yep</span>
             </b-radio-button>
 
             <b-radio-button v-model="radioButton"
-                native-value="Default">
+                native-value="Default"
+                type="is-primary is-light is-outlined">
                 Default
             </b-radio-button>
 

--- a/src/components/radio/RadioButton.vue
+++ b/src/components/radio/RadioButton.vue
@@ -3,10 +3,7 @@
         <label
             class="b-radio radio button"
             ref="label"
-            :class="[newValue === nativeValue ? type : null, size, {
-                'is-disabled': disabled,
-                'is-focused': isFocused
-            }]"
+            :class="labelClass"
             :disabled="disabled"
             @click="focus"
             @keydown.prevent.enter="$refs.label.click()">
@@ -42,6 +39,22 @@ export default {
     data() {
         return {
             isFocused: false
+        }
+    },
+    computed: {
+        isSelected() {
+            return this.newValue === this.nativeValue
+        },
+        labelClass() {
+            return [
+                this.isSelected ? this.type : null,
+                this.size,
+                {
+                    'is-selected': this.isSelected,
+                    'is-disabled': this.disabled,
+                    'is-focused': this.isFocused
+                }
+            ]
         }
     }
 }

--- a/src/components/radio/__snapshots__/RadioButton.spec.js.snap
+++ b/src/components/radio/__snapshots__/RadioButton.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BRadioButton render correctly 1`] = `<div class="control"><label class="b-radio radio button is-primary"> <input type="radio" value="false"></label></div>`;
+exports[`BRadioButton render correctly 1`] = `<div class="control"><label class="b-radio radio button is-primary is-selected"> <input type="radio" value="false"></label></div>`;

--- a/src/scss/components/_radio.scss
+++ b/src/scss/components/_radio.scss
@@ -88,6 +88,10 @@ $radio-colors: $form-colors !default;
         }
         &.button {
             display: flex;
+
+            &.is-selected {
+                z-index: 1;
+            }
         }
         &[disabled] {
             opacity: 0.5;


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #2848
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Use a computed property for the class
- Bring the selected button first (using `z-index`)

