### PR TITLE
Provide an iconRightType prop

### DIFF
--- a/src/components/input/Input.vue
+++ b/src/components/input/Input.vue
@@ -93,7 +93,8 @@ export default {
             default: ''
         },
         iconRight: String,
-        iconRightClickable: Boolean
+        iconRightClickable: Boolean,
+        iconRightType: String,
     },
     data() {
         return {
@@ -150,7 +151,7 @@ export default {
             if (this.passwordReveal) {
                 return 'is-primary'
             } else if (this.iconRight) {
-                return null
+                return this.iconRightType || null
             }
             return this.statusType
         },

--- a/src/components/input/Input.vue
+++ b/src/components/input/Input.vue
@@ -94,7 +94,7 @@ export default {
         },
         iconRight: String,
         iconRightClickable: Boolean,
-        iconRightType: String,
+        iconRightType: String
     },
     data() {
         return {


### PR DESCRIPTION
## Proposed Changes

- Add an `icon-right-type` prop to `BInput`

## Reason

I'd like to have a colored right icon inside my input. I don't think there's a proper way to do this without resorting to the input's general `type` property. However, that also colors the input border which is undesired.
