### PR TITLE
Fix mutation of value in multiple dropdown

### DIFF
--- a/src/components/dropdown/Dropdown.spec.js
+++ b/src/components/dropdown/Dropdown.spec.js
@@ -1,9 +1,11 @@
 import { shallowMount } from '@vue/test-utils'
 import BDropdown from '@components/dropdown/Dropdown'
 
-let wrapper
-
 describe('BDropdown', () => {
+    const val1 = 'val1'
+    const val2 = 'val2'
+    let wrapper
+
     beforeEach(() => {
         wrapper = shallowMount(BDropdown, {
             slots: {
@@ -58,27 +60,38 @@ describe('BDropdown', () => {
         expect(wrapper.vm.isHoverable).toBeTruthy()
     })
 
-    it('react accordingly when an item is selected', () => {
+    it('react accordingly when new item is selected', () => {
         jest.useFakeTimers()
 
-        const val1 = 'val1'
         wrapper.vm.selectItem(val1)
-        expect(wrapper.emitted()['input']).toBeTruthy()
-
-        wrapper.vm.selectItem(val1)
-        expect(wrapper.emitted()['input']).toBeTruthy()
+        expect(wrapper.emitted().input).toHaveLength(1)
+        expect(wrapper.emitted().input[0]).toEqual([val1])
+        expect(wrapper.emitted().change).toHaveLength(1)
+        expect(wrapper.emitted().change[0]).toEqual([val1])
 
         wrapper.setProps({
             hoverable: true,
             closeOnClick: true
         })
 
-        const val2 = 'val2'
         wrapper.vm.selectItem(val2)
-        expect(wrapper.vm.selected).toBe(val2)
-        expect(wrapper.emitted()['change']).toBeTruthy()
+        expect(wrapper.emitted().input).toHaveLength(2)
+        expect(wrapper.emitted().input[1]).toEqual([val2])
+        expect(wrapper.emitted().change).toHaveLength(2)
+        expect(wrapper.emitted().change[1]).toEqual([val2])
 
         expect(wrapper.vm.isHoverable).toBeFalsy()
+    })
+
+    it('react accordingly when same item is selected', () => {
+        jest.useFakeTimers()
+
+        // will emit only input event
+        wrapper.setProps({ value: val1 })
+        wrapper.vm.selectItem(val1)
+        expect(wrapper.emitted().input).toHaveLength(1)
+        expect(wrapper.emitted().input[0]).toEqual([val1])
+        expect(wrapper.emitted().change).toBeUndefined()
     })
 
     it('react accordingly when an item is selected with multiple prop', () => {
@@ -89,19 +102,27 @@ describe('BDropdown', () => {
         wrapper.vm.selected = null
 
         // no initial value, will return an array with the only selected option
-        const val1 = 'val1'
         wrapper.vm.selectItem(val1)
-        expect(wrapper.vm.selected).toEqual([val1])
-        expect(wrapper.emitted()['change']).toBeTruthy()
+        expect(wrapper.emitted().input).toHaveLength(1)
+        expect(wrapper.emitted().input[0]).toEqual([[val1]])
+        expect(wrapper.emitted().change).toHaveLength(1)
+        expect(wrapper.emitted().change[0]).toEqual([[val1]])
 
         // will return an array with the new value appended
-        const val2 = 'val2'
+        wrapper.setProps({ value: [val1] })
         wrapper.vm.selectItem(val2)
-        expect(wrapper.vm.selected).toEqual([val1, val2])
+        expect(wrapper.emitted().input).toHaveLength(2)
+        expect(wrapper.emitted().input[1]).toEqual([[val1, val2]])
+        expect(wrapper.emitted().change).toHaveLength(2)
+        expect(wrapper.emitted().change[1]).toEqual([[val1, val2]])
 
         // will remove the last selection since it was part of the list
+        wrapper.setProps({ value: [val1, val2] })
         wrapper.vm.selectItem(val2)
-        expect(wrapper.vm.selected).toEqual([val1])
+        expect(wrapper.emitted().input).toHaveLength(3)
+        expect(wrapper.emitted().input[2]).toEqual([[val1]])
+        expect(wrapper.emitted().change).toHaveLength(3)
+        expect(wrapper.emitted().change[2]).toEqual([[val1]])
     })
 
     it('manage the whitelisted items accordingly', () => {
@@ -154,13 +175,13 @@ describe('BDropdown', () => {
 
     it('close on escape', () => {
         wrapper.vm.isActive = true
-        const event = new KeyboardEvent('keyup', {'key': 'Escape'})
+        const event = new KeyboardEvent('keyup', { 'key': 'Escape' })
         wrapper.vm.keyPress({})
         wrapper.vm.keyPress(event)
         expect(wrapper.vm.isActive).toBeFalsy()
 
         wrapper.vm.isActive = true
-        wrapper.setProps({canClose: ['click']})
+        wrapper.setProps({ canClose: ['click'] })
         wrapper.vm.keyPress(event)
         expect(wrapper.vm.isActive).toBeTruthy()
     })

--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -187,19 +187,20 @@ export default {
     },
     methods: {
         /**
-        * Click listener from DropdownItem.
-        *   1. Set new selected item.
-        *   2. Emit input event to update the user v-model.
-        *   3. Close the dropdown.
-        */
+         * Click listener from DropdownItem.
+         *   1. Set new selected item.
+         *   2. Emit input event to update the user v-model.
+         *   3. Close the dropdown.
+         */
         selectItem(value) {
             if (this.multiple) {
                 if (this.selected) {
-                    const index = this.selected.indexOf(value)
-                    if (index === -1) {
-                        this.selected.push(value)
+                    if (this.selected.indexOf(value) === -1) {
+                        // Add value
+                        this.selected = [...this.selected, value]
                     } else {
-                        this.selected.splice(index, 1)
+                        // Remove value
+                        this.selected = this.selected.filter((val) => val !== value)
                     }
                 } else {
                     this.selected = [value]


### PR DESCRIPTION
Fixes #3040

## Proposed Changes
- Create a new array instead of mutating `selected`
- ~~The 1st commit (https://github.com/buefy/buefy/pull/3047/commits/d92cf5b08d55fb54e398d6ee29299409df477743) contains a quick fix to remove the mutation of the array. However the `DropdownItem` status (`isActive`) may be desynchronized with the `value` of the `Dropdown` because `selected` is still modified.
That's why in the next commit (https://github.com/buefy/buefy/pull/3047/commits/8c9c02317c94a456d70aa9edad2002863e753850) I removed `selected` (which is actually unnecessary) and used only `value` prop.~~



Please let me know if you prefer to handle this in another way!
