### PR TITLE
Add slot in documentation of Loading

### DIFF
--- a/docs/pages/components/loading/api/loading.js
+++ b/docs/pages/components/loading/api/loading.js
@@ -37,6 +37,13 @@ export default [
                 default: '—'
             }
         ],
+        slots: [
+            {
+                name: 'default',
+                description: 'Loading icon',
+                props: '—'
+            },
+        ],
         events: [
             {
                 name: '<code>close</code>',


### PR DESCRIPTION
Although there is [an example](https://buefy.org/documentation/loading#templated) to use the slot of Loading, the information is missing in the [API section](https://buefy.org/documentation/loading#api-view).

## Proposed Changes
- Add slot in API section
