### PR TITLE
Fix #3056 - Reset time on carousel when clicking arrow

### DIFF
--- a/src/components/carousel/Carousel.vue
+++ b/src/components/carousel/Carousel.vue
@@ -265,6 +265,13 @@ export default {
                 this.timer = null
             }
         },
+        restartTimer() {
+            if (this.timer) {
+                clearInterval(this.timer)
+                this.timer = null
+            }
+            this.startTimer()
+        },
         checkPause() {
             if (this.pauseHover && this.autoplay) {
                 this.pauseTimer()
@@ -299,9 +306,11 @@ export default {
         },
         prev() {
             this.changeActive(this.activeChild - 1, -1)
+            this.restartTimer()
         },
         next() {
             this.changeActive(this.activeChild + 1, 1)
+            this.restartTimer()
         },
         // handle drag event
         dragStart(event) {

--- a/src/components/carousel/Carousel.vue
+++ b/src/components/carousel/Carousel.vue
@@ -265,7 +265,7 @@ export default {
                 this.timer = null
             }
         },
-        restartTimer(){
+        restartTimer() {
             this.pauseTimer()
             this.startTimer()
         },

--- a/src/components/carousel/Carousel.vue
+++ b/src/components/carousel/Carousel.vue
@@ -265,13 +265,6 @@ export default {
                 this.timer = null
             }
         },
-        restartTimer() {
-            if (this.timer) {
-                clearInterval(this.timer)
-                this.timer = null
-            }
-            this.startTimer()
-        },
         checkPause() {
             if (this.pauseHover && this.autoplay) {
                 this.pauseTimer()
@@ -296,6 +289,7 @@ export default {
             if (newIndex !== this.value) {
                 this.$emit('input', newIndex)
             }
+            this.pauseTimer()
             this.$emit('change', newIndex) // BC
         },
         // Indicator trigger when change active item.
@@ -306,11 +300,9 @@ export default {
         },
         prev() {
             this.changeActive(this.activeChild - 1, -1)
-            this.restartTimer()
         },
         next() {
             this.changeActive(this.activeChild + 1, 1)
-            this.restartTimer()
         },
         // handle drag event
         dragStart(event) {

--- a/src/components/carousel/Carousel.vue
+++ b/src/components/carousel/Carousel.vue
@@ -265,6 +265,10 @@ export default {
                 this.timer = null
             }
         },
+        restartTimer(){
+            this.pauseTimer()
+            this.startTimer()
+        },
         checkPause() {
             if (this.pauseHover && this.autoplay) {
                 this.pauseTimer()
@@ -289,7 +293,7 @@ export default {
             if (newIndex !== this.value) {
                 this.$emit('input', newIndex)
             }
-            this.pauseTimer()
+            this.restartTimer()
             this.$emit('change', newIndex) // BC
         },
         // Indicator trigger when change active item.


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #3056 
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes
- Add and call a `resetTimer` method to reset the timer when the carousel index is changed by clicking on the arrow
