### PR TITLE
Document update: Change slot to v-slot

### DIFF
--- a/docs/pages/components/autocomplete/examples/ExFooter.vue
+++ b/docs/pages/components/autocomplete/examples/ExFooter.vue
@@ -8,12 +8,12 @@
                 :data="filteredDataArray"
                 placeholder="e.g. Orange"
                 @select="option => selected = option">
-                <template slot="footer">
+                <template #footer>
                     <a @click="showAddFruit">
                         <span> Add new... </span>
-                    </a> 
+                    </a>
                 </template>
-                <template slot="empty">No results for {{name}}</template>
+                <template #empty>No results for {{name}}</template>
             </b-autocomplete>
         </b-field>
     </section>

--- a/docs/pages/components/autocomplete/examples/ExHeader.vue
+++ b/docs/pages/components/autocomplete/examples/ExHeader.vue
@@ -8,12 +8,12 @@
                 :data="filteredDataArray"
                 placeholder="e.g. Orange"
                 @select="option => selected = option">
-                <template slot="header">
+                <template #header>
                     <a @click="showAddFruit">
                         <span> Add new... </span>
-                    </a> 
+                    </a>
                 </template>
-                <template slot="empty">No results for {{name}}</template>
+                <template #empty>No results for {{name}}</template>
             </b-autocomplete>
         </b-field>
     </section>

--- a/docs/pages/components/autocomplete/examples/ExInfiniteScroll.vue
+++ b/docs/pages/components/autocomplete/examples/ExInfiniteScroll.vue
@@ -27,7 +27,7 @@
                         </div>
                     </div>
                 </template>
-                <template slot="footer">
+                <template #footer>
                     <span v-show="page > totalPages" class="has-text-grey"> Thats it! No more movies found. </span>
                 </template>
             </b-autocomplete>
@@ -75,7 +75,7 @@
                 this.$http.get(`https://api.themoviedb.org/3/search/movie?api_key=bb6f51bef07465653c3e553d6ab161a8&query=${name}&page=${this.page}`)
                     .then(({ data }) => {
                         data.results.forEach((item) => this.data.push(item))
-                        
+
                         this.page++
                         this.totalPages = data.total_pages
                     })

--- a/docs/pages/components/autocomplete/examples/ExSimple.vue
+++ b/docs/pages/components/autocomplete/examples/ExSimple.vue
@@ -10,7 +10,7 @@
                 icon="magnify"
                 clearable
                 @select="option => selected = option">
-                <template slot="empty">No results found</template>
+                <template #empty>No results found</template>
             </b-autocomplete>
         </b-field>
     </section>

--- a/docs/pages/components/carousel/examples/ExCustomIndicator.vue
+++ b/docs/pages/components/carousel/examples/ExCustomIndicator.vue
@@ -5,7 +5,7 @@
               <img :src="getImgUrl(i)">
             </span>
         </b-carousel-item>
-        <template slot="indicators" slot-scope="props">
+        <template #indicators="props">
             <span class="al image">
                <img :src="getImgUrl(props.i)" :title="props.i">
             </span>

--- a/docs/pages/components/carousel/examples/ExCustomIndicator.vue
+++ b/docs/pages/components/carousel/examples/ExCustomIndicator.vue
@@ -7,7 +7,7 @@
         </b-carousel-item>
         <template slot="indicators" slot-scope="props">
             <span class="al image">
-                <img :src="getImgUrl(props.i)" :title="props.i">
+               <img :src="getImgUrl(props.i)" :title="props.i">
             </span>
         </template>
     </b-carousel>

--- a/docs/pages/components/carousel/examples/ExGallery.vue
+++ b/docs/pages/components/carousel/examples/ExGallery.vue
@@ -6,7 +6,7 @@
             </a>
         </b-carousel-item>
         <span v-if="gallery" @click="switchGallery(false)" class="modal-close is-large"/>
-        <template slot="indicators" slot-scope="props">
+        <template #indicators="props">
             <figure class="al image" :draggable="false">
                 <img :draggable="false" :src="getImgUrl(props.i)" :title="props.i">
             </figure>

--- a/docs/pages/components/carousel/examples/ExWithCard.vue
+++ b/docs/pages/components/carousel/examples/ExWithCard.vue
@@ -1,6 +1,6 @@
 <template>
     <b-carousel-list v-model="test" :data="items" :items-to-show="2">
-        <template slot="item" slot-scope="list">
+        <template #item="list">
             <div class="card">
                 <div class="card-image">
                     <figure class="image is-5by4">

--- a/docs/pages/components/carousel/examples/ExWithList.vue
+++ b/docs/pages/components/carousel/examples/ExWithList.vue
@@ -11,7 +11,7 @@
             </figure>
         </b-carousel-item>
         <span v-if="gallery" @click="switchGallery(false)" class="modal-close is-large"/>
-        <template slot="list" slot-scope="props">
+        <template #list="props">
             <b-carousel-list
                 v-model="props.active"
                 :data="items"
@@ -19,7 +19,7 @@
                 @switch="props.switch($event, false)"
                 as-indicator />
         </template>
-        <template slot="overlay">
+        <template #overlay>
             <div class="has-text-centered has-text-white">
                 Hello i'am overlay!
             </div>

--- a/docs/pages/components/collapse/examples/ExAccordion.vue
+++ b/docs/pages/components/collapse/examples/ExAccordion.vue
@@ -8,20 +8,21 @@
             :key="index"
             :open="isOpen == index"
             @open="isOpen = index">
-            <div
-                slot="trigger"
-                slot-scope="props"
-                class="card-header"
-                role="button">
-                <p class="card-header-title">
-                    {{ collapse.title }}
-                </p>
-                <a class="card-header-icon">
-                    <b-icon
-                        :icon="props.open ? 'menu-down' : 'menu-up'">
-                    </b-icon>
-                </a>
-            </div>
+            <template #trigger="props">
+                <div
+                    class="card-header"
+                    role="button"
+                >
+                    <p class="card-header-title">
+                        {{ collapse.title }}
+                    </p>
+                    <a class="card-header-icon">
+                        <b-icon
+                            :icon="props.open ? 'menu-down' : 'menu-up'">
+                        </b-icon>
+                    </a>
+                </div>
+            </template>
             <div class="card-content">
                 <div class="content">
                     {{ collapse.text }}

--- a/docs/pages/components/collapse/examples/ExCardTemplate.vue
+++ b/docs/pages/components/collapse/examples/ExCardTemplate.vue
@@ -2,21 +2,22 @@
     <section>
 
         <b-collapse class="card" animation="slide" aria-id="contentIdForA11y3">
-            <div
-                slot="trigger" 
-                slot-scope="props"
-                class="card-header"
-                role="button"
-                aria-controls="contentIdForA11y3">
-                <p class="card-header-title">
-                    Component
-                </p>
-                <a class="card-header-icon">
-                    <b-icon
-                        :icon="props.open ? 'menu-down' : 'menu-up'">
-                    </b-icon>
-                </a>
-            </div>
+            <template #trigger="props">
+                <div
+                    class="card-header"
+                    role="button"
+                    aria-controls="contentIdForA11y3">
+                    <p class="card-header-title">
+                        Component
+                    </p>
+                    <a class="card-header-icon">
+                        <b-icon
+                            :icon="props.open ? 'menu-down' : 'menu-up'">
+                        </b-icon>
+                    </a>
+                </div>
+            </template>
+
             <div class="card-content">
                 <div class="content">
                     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus nec iaculis mauris.

--- a/docs/pages/components/collapse/examples/ExPanelTemplate.vue
+++ b/docs/pages/components/collapse/examples/ExPanelTemplate.vue
@@ -15,13 +15,14 @@
             class="panel"
             animation="slide"
             v-model="isOpen">
-            <div
-                slot="trigger"
-                class="panel-heading"
-                role="button"
-                aria-controls="contentIdForA11y2">
-                <strong>Title</strong>
-            </div>
+            <template #trigger>
+                <div
+                    class="panel-heading"
+                    role="button"
+                    aria-controls="contentIdForA11y2">
+                    <strong>Title</strong>
+                </div>
+            </template>
             <p class="panel-tabs">
                 <a class="is-active">All</a>
                 <a>Public</a>

--- a/docs/pages/components/collapse/examples/ExPosition.vue
+++ b/docs/pages/components/collapse/examples/ExPosition.vue
@@ -11,10 +11,12 @@
             </p>
         </div>
         <b-collapse :open="false" position="is-bottom" aria-id="contentIdForA11y1">
-            <a slot="trigger" slot-scope="props" aria-controls="contentIdForA11y1">
-                <b-icon :icon="!props.open ? 'menu-down' : 'menu-up'"></b-icon>
-                {{ !props.open ? 'All options' : 'Fewer options' }}
-            </a>
+            <template #trigger="props">
+                <a aria-controls="contentIdForA11y1">
+                    <b-icon :icon="!props.open ? 'menu-down' : 'menu-up'"></b-icon>
+                    {{ !props.open ? 'All options' : 'Fewer options' }}
+                </a>
+            </template>
             <p>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. <br/>
                 Nulla accumsan, metus ultrices eleifend gravida, nulla nunc varius lectus, nec rutrum justo nibh eu lectus. <br/>

--- a/docs/pages/components/collapse/examples/ExSimple.vue
+++ b/docs/pages/components/collapse/examples/ExSimple.vue
@@ -2,11 +2,12 @@
     <section>
 
         <b-collapse :open="false" aria-id="contentIdForA11y1">
-            <b-button
-                slot="trigger"
-                label="Click me!"
-                type="is-primary"
-                aria-controls="contentIdForA11y1" />
+            <template #trigger>
+                <b-button
+                    label="Click me!"
+                    type="is-primary"
+                    aria-controls="contentIdForA11y1" />
+            </template>
             <div class="notification">
                 <div class="content">
                     <h3>

--- a/docs/pages/components/datepicker/examples/ExHeader.vue
+++ b/docs/pages/components/datepicker/examples/ExHeader.vue
@@ -4,7 +4,7 @@
             :first-day-of-week="1"
             placeholder="Click to select...">
 
-            <template slot="header">
+            <template #header>
                 <b-field>
                     <b-autocomplete
                         open-on-focus

--- a/docs/pages/components/datetimepicker/examples/ExFooter.vue
+++ b/docs/pages/components/datetimepicker/examples/ExFooter.vue
@@ -3,7 +3,7 @@
         <b-datetimepicker v-model="datetime"
             placeholder="Click to select...">
 
-            <template slot="left">
+            <template #left>
                 <b-button
                     label="Now"
                     type="is-primary"
@@ -11,7 +11,7 @@
                     @click="datetime = new Date()" />
             </template>
 
-            <template slot="right">
+            <template #right>
                 <b-button
                     label="Clear"
                     type="is-danger"

--- a/docs/pages/components/dropdown/examples/ExContentPosition.vue
+++ b/docs/pages/components/dropdown/examples/ExContentPosition.vue
@@ -11,13 +11,15 @@
         <div class="navbar-menu">
             <div class="navbar-end">
                 <b-dropdown position="is-bottom-left" append-to-body aria-role="menu" trap-focus>
-                    <a
-                        class="navbar-item"
-                        slot="trigger"
-                        role="button">
-                        <span>Login</span>
-                        <b-icon icon="menu-down"></b-icon>
-                    </a>
+                    <template #trigger>
+                        <a
+                            class="navbar-item"
+                            role="button">
+                            <span>Login</span>
+                            <b-icon icon="menu-down"></b-icon>
+                        </a>
+                    </template>
+
 
                     <b-dropdown-item
                         aria-role="menu-item"

--- a/docs/pages/components/dropdown/examples/ExCustomize.vue
+++ b/docs/pages/components/dropdown/examples/ExCustomize.vue
@@ -1,20 +1,22 @@
 <template>
     <b-dropdown v-model="isPublic" aria-role="list">
 
-        <b-button
-            v-if="isPublic"
-            slot="trigger"
-            label="Public"
-            type="is-primary"
-            icon-left="earth"
-            icon-right="menu-down" />
-        <b-button
-            v-else
-            slot="trigger"
-            label="Friends"
-            type="is-primary"
-            icon-left="account-multiple"
-            icon-right="menu-down" />
+        <template v-if="isPublic" #trigger>
+            <b-button
+                label="Public"
+                type="is-primary"
+                icon-left="earth"
+                icon-right="menu-down" />
+        </template>
+
+        <template v-else #trigger>
+            <b-button
+                label="Friends"
+                type="is-primary"
+                icon-left="account-multiple"
+                icon-right="menu-down" />
+        </template>
+
 
         <b-dropdown-item :value="true" aria-role="listitem">
             <div class="media">

--- a/docs/pages/components/dropdown/examples/ExCustomizeMultiple.vue
+++ b/docs/pages/components/dropdown/examples/ExCustomizeMultiple.vue
@@ -5,12 +5,14 @@
             v-model="selectedOptions"
             multiple
             aria-role="list">
-            <b-button
-                slot="trigger"
-                type="is-primary"
-                icon-right="menu-down">
-                Selected ({{ selectedOptions.length }})
-            </b-button>
+            <template #trigger>
+                <b-button
+                    type="is-primary"
+                    icon-right="menu-down">
+                    Selected ({{ selectedOptions.length }})
+                </b-button>
+            </template>
+
 
             <b-dropdown-item value="option1" aria-role="listitem">
                 <span>Option 1</span>

--- a/docs/pages/components/dropdown/examples/ExCustomizeScrollable.vue
+++ b/docs/pages/components/dropdown/examples/ExCustomizeScrollable.vue
@@ -23,12 +23,14 @@
             v-model="currentMenu"
             aria-role="list"
         >
-            <b-button
-                slot="trigger"
-                :label="currentMenu.text"
-                type="is-primary"
-                :icon-left="currentMenu.icon"
-                icon-right="menu-down" />
+            <template #trigger>
+                <b-button
+                    :label="currentMenu.text"
+                    type="is-primary"
+                    :icon-left="currentMenu.icon"
+                    icon-right="menu-down" />
+            </template>
+
 
             <b-dropdown-item
                 v-for="(menu, index) in menus"

--- a/docs/pages/components/dropdown/examples/ExHasLinkDisabled.vue
+++ b/docs/pages/components/dropdown/examples/ExHasLinkDisabled.vue
@@ -10,18 +10,20 @@
 
         <div class="navbar-menu">
             <div class="navbar-end">
-                <b-dropdown                    
+                <b-dropdown
                     v-model="navigation"
                     position="is-bottom-left"
                     append-to-body
                     aria-role="menu">
-                    <a
-                        class="navbar-item"
-                        slot="trigger"
-                        role="button">
-                        <span>Menu</span>
-                        <b-icon icon="menu-down"></b-icon>
-                    </a>
+                    <template #trigger>
+                        <a
+                            class="navbar-item"
+                            role="button">
+                            <span>Menu</span>
+                            <b-icon icon="menu-down"></b-icon>
+                        </a>
+                    </template>
+
 
                     <b-dropdown-item custom aria-role="menuitem">
                         Logged as <b>Rafael Beraldo</b>

--- a/docs/pages/components/dropdown/examples/ExSimple.vue
+++ b/docs/pages/components/dropdown/examples/ExSimple.vue
@@ -2,12 +2,13 @@
     <section>
 
         <b-dropdown aria-role="list">
-            <b-button
-                slot="trigger"
-                slot-scope="{ active }"
-                label="Click me!"
-                type="is-primary"
-                :icon-right="active ? 'menu-up' : 'menu-down'" />
+            <template #trigger="{ active }">
+                <b-button
+                    label="Click me!"
+                    type="is-primary"
+                    :icon-right="active ? 'menu-up' : 'menu-down'" />
+            </template>
+
 
             <b-dropdown-item aria-role="listitem">Action</b-dropdown-item>
             <b-dropdown-item aria-role="listitem">Another action</b-dropdown-item>
@@ -15,11 +16,13 @@
         </b-dropdown>
 
         <b-dropdown :triggers="['hover']" aria-role="list">
-            <b-button
-                slot="trigger"
-                label="Hover me!"
-                type="is-info"
-                icon-right="menu-down" />
+            <template #trigger>
+                <b-button
+                    label="Hover me!"
+                    type="is-info"
+                    icon-right="menu-down" />
+            </template>
+
 
             <b-dropdown-item aria-role="listitem">Action</b-dropdown-item>
             <b-dropdown-item aria-role="listitem">Another action</b-dropdown-item>
@@ -27,10 +30,12 @@
         </b-dropdown>
 
         <b-dropdown disabled aria-role="list">
-            <b-button
-                slot="trigger"
-                label="Disabled"
-                icon-right="menu-down" />
+            <template #trigger>
+                <b-button
+                    label="Disabled"
+                    icon-right="menu-down" />
+            </template>
+
 
             <b-dropdown-item aria-role="listitem">Action</b-dropdown-item>
             <b-dropdown-item aria-role="listitem">Another action</b-dropdown-item>
@@ -38,12 +43,14 @@
         </b-dropdown>
 
         <b-dropdown aria-role="list">
-            <p
-                class="tag is-success"
-                slot="trigger"
-                role="button">
-                Custom trigger
-            </p>
+            <template #trigger>
+                <p
+                    class="tag is-success"
+                    role="button">
+                    Custom trigger
+                </p>
+            </template>
+
 
             <b-dropdown-item aria-role="listitem">Action</b-dropdown-item>
             <b-dropdown-item aria-role="listitem">Another action</b-dropdown-item>
@@ -51,10 +58,12 @@
         </b-dropdown>
 
         <b-dropdown :triggers="['contextmenu']" aria-role="list">
-            <b-button
-                slot="trigger"
-                type="is-link"
-                label="Right click" />
+            <template #trigger>
+                <b-button
+                    type="is-link"
+                    label="Right click" />
+            </template>
+
 
             <b-dropdown-item aria-role="listitem">Action</b-dropdown-item>
             <b-dropdown-item aria-role="listitem">Another action</b-dropdown-item>

--- a/docs/pages/components/field/examples/ExAddons.vue
+++ b/docs/pages/components/field/examples/ExAddons.vue
@@ -59,7 +59,9 @@
             </p>
             <p class="control">
                 <b-dropdown>
-                    <b-button slot="trigger" type="is-primary" icon-left="menu-down" />
+                    <template #trigger>
+                        <b-button type="is-primary" icon-left="menu-down" />
+                    </template>
 
                     <b-dropdown-item>Action</b-dropdown-item>
                     <b-dropdown-item>Another action</b-dropdown-item>
@@ -71,7 +73,9 @@
         <b-field>
             <p class="control">
                 <b-dropdown>
-                    <b-button slot="trigger" label="Filters" icon-right="menu-down" />
+                    <template #trigger>
+                        <b-button label="Filters" icon-right="menu-down" />
+                    </template>
 
                     <b-dropdown-item value="open_issues">Open Issues and Pull Requests</b-dropdown-item>
                     <b-dropdown-item value="your_issues">Your Issues</b-dropdown-item>

--- a/docs/pages/components/field/examples/ExLabelPosition.vue
+++ b/docs/pages/components/field/examples/ExLabelPosition.vue
@@ -36,7 +36,7 @@
             :label-position="labelPosition"
             type="is-warning">
             <b-input value="123" type="password" maxlength="30"></b-input>
-            <template slot="message">
+            <template #message>
                 <div>Password is too short</div>
                 <div>Password must have at least 8 characters</div>
             </template>
@@ -63,7 +63,7 @@
                 icon="magnify"
                 clearable
                 @select="option => selected = option">
-                <template slot="empty">No results found</template>
+                <template #empty>No results found</template>
             </b-autocomplete>
         </b-field>
 

--- a/docs/pages/components/field/examples/ExLabelSlot.vue
+++ b/docs/pages/components/field/examples/ExLabelSlot.vue
@@ -3,7 +3,7 @@
         <b-field
             custom-class="is-medium"
             horizontal>
-            <template slot="label">
+            <template #label>
                With tooltip
                 <b-tooltip type="is-dark" label="Help text here for explanation">
                     <b-icon size="is-small" icon="help-circle-outline"></b-icon>
@@ -13,7 +13,7 @@
         </b-field>
 
         <b-field>
-            <template slot="label">
+            <template #label>
                 Label with custom <span class="has-text-primary is-italic">style</span>
             </template>
             <b-input></b-input>

--- a/docs/pages/components/image/examples/ExPlaceholder.vue
+++ b/docs/pages/components/image/examples/ExPlaceholder.vue
@@ -16,11 +16,12 @@
             src="https://picsum.photos/id/1062/800/400"
             ratio="2by1"
         >
-            <b-skeleton
-                class="skeleton-placeholder"
-                slot="placeholder"
-                height="100%"
-            ></b-skeleton>
+            <template #placeholder>
+                <b-skeleton
+                    class="skeleton-placeholder"
+                    height="100%"
+                ></b-skeleton>
+            </template>
         </b-image>
     </section>
 </template>

--- a/docs/pages/components/menu/examples/ExSimple.vue
+++ b/docs/pages/components/menu/examples/ExSimple.vue
@@ -3,19 +3,21 @@
     <b-menu-list label="Menu">
       <b-menu-item icon="information-outline" label="Info"></b-menu-item>
       <b-menu-item icon="settings" :active="isActive" expanded>
-        <template slot="label" slot-scope="props">
+        <template #label="props">
           Administrator
           <b-icon class="is-pulled-right" :icon="props.expanded ? 'menu-down' : 'menu-up'"></b-icon>
         </template>
         <b-menu-item icon="account" label="Users"></b-menu-item>
         <b-menu-item icon="cellphone-link">
-          <template slot="label">
+          <template #label>
             Devices
             <b-dropdown aria-role="list" class="is-pulled-right" position="is-bottom-left">
-              <b-icon icon="dots-vertical" slot="trigger"></b-icon>
-              <b-dropdown-item aria-role="listitem">Action</b-dropdown-item>
-              <b-dropdown-item aria-role="listitem">Another action</b-dropdown-item>
-              <b-dropdown-item aria-role="listitem">Something else</b-dropdown-item>
+                <template #trigger>
+                    <b-icon icon="dots-vertical"></b-icon>
+                </template>
+                <b-dropdown-item aria-role="listitem">Action</b-dropdown-item>
+                <b-dropdown-item aria-role="listitem">Another action</b-dropdown-item>
+                <b-dropdown-item aria-role="listitem">Something else</b-dropdown-item>
             </b-dropdown>
           </template>
         </b-menu-item>

--- a/docs/pages/components/navbar/examples/ExSimple.vue
+++ b/docs/pages/components/navbar/examples/ExSimple.vue
@@ -1,6 +1,6 @@
 <template>
     <b-navbar>
-        <template slot="brand">
+        <template #brand>
             <b-navbar-item tag="router-link" :to="{ path: '/' }">
                 <img
                     src="https://raw.githubusercontent.com/buefy/buefy/dev/static/img/buefy-logo.png"
@@ -8,7 +8,7 @@
                 >
             </b-navbar-item>
         </template>
-        <template slot="start">
+        <template #start>
             <b-navbar-item href="#">
                 Home
             </b-navbar-item>
@@ -25,7 +25,7 @@
             </b-navbar-dropdown>
         </template>
 
-        <template slot="end">
+        <template #end>
             <b-navbar-item tag="div">
                 <div class="buttons">
                     <a class="button is-primary">

--- a/docs/pages/components/pagination/examples/ExSlot.vue
+++ b/docs/pages/components/pagination/examples/ExSlot.vue
@@ -5,32 +5,34 @@
             v-model="current"
             :per-page="10">
 
-            <b-pagination-button
-                slot-scope="props"
-                :page="props.page"
-                :id="`page${props.page.number}`"
-                tag="router-link"
-                :to="`/documentation/pagination#page${props.page.number}`">
-                {{ convertToRoman(props.page.number) }}
-            </b-pagination-button>
+            <template #default="props">
+                <b-pagination-button
+                    :page="props.page"
+                    :id="`page${props.page.number}`"
+                    tag="router-link"
+                    :to="`/documentation/pagination#page${props.page.number}`">
+                    {{ convertToRoman(props.page.number) }}
+                </b-pagination-button>
+            </template>
 
-            <b-pagination-button
-                slot="previous"
-                slot-scope="props"
-                :page="props.page"
-                tag="router-link"
-                :to="`/documentation/pagination#page${props.page.number}`">
-                Previous
-            </b-pagination-button>
 
-            <b-pagination-button
-                slot="next"
-                slot-scope="props"
-                :page="props.page"
-                tag="router-link"
-                :to="`/documentation/pagination#page${props.page.number}`">
-                Next
-            </b-pagination-button>
+            <template #previous="props">
+                <b-pagination-button
+                    :page="props.page"
+                    tag="router-link"
+                    :to="`/documentation/pagination#page${props.page.number}`">
+                    Previous
+                </b-pagination-button>
+            </template>
+
+            <template #next="props">
+                <b-pagination-button
+                    :page="props.page"
+                    tag="router-link"
+                    :to="`/documentation/pagination#page${props.page.number}`">
+                    Next
+                </b-pagination-button>
+            </template>
 
         </b-pagination>
     </section>

--- a/docs/pages/components/progress/examples/ExBars.vue
+++ b/docs/pages/components/progress/examples/ExBars.vue
@@ -1,19 +1,25 @@
 <template>
     <section>
         <b-progress format="percent" :max="80">
-            <b-progress-bar slot="bar" :value="10" show-value></b-progress-bar>
-            <b-progress-bar slot="bar" :value="20" type="is-primary" show-value></b-progress-bar>
-            <b-progress-bar slot="bar" :value="30" type="is-warning" show-value></b-progress-bar>
+            <template #bar>
+                <b-progress-bar :value="10" show-value></b-progress-bar>
+                <b-progress-bar :value="20" type="is-primary" show-value></b-progress-bar>
+                <b-progress-bar :value="30" type="is-warning" show-value></b-progress-bar>
+            </template>
         </b-progress>
         <b-progress size="is-medium" type="is-success" show-value>
-            <b-progress-bar slot="bar" :value="10"></b-progress-bar>
-            <b-progress-bar slot="bar" :value="20" type="is-primary"></b-progress-bar>
-            <b-progress-bar slot="bar" :value="30" type="is-warning">Wow!</b-progress-bar>
+            <template #bar>
+                <b-progress-bar :value="10"></b-progress-bar>
+                <b-progress-bar :value="20" type="is-primary"></b-progress-bar>
+                <b-progress-bar :value="30" type="is-warning">Wow!</b-progress-bar>
+            </template>
         </b-progress>
         <b-progress size="is-large">
-            <b-progress-bar slot="bar" :value="10" show-value></b-progress-bar>
-            <b-progress-bar slot="bar" :value="20" type="is-primary" show-value></b-progress-bar>
-            <b-progress-bar slot="bar" :value="30" type="is-warning"></b-progress-bar>
+            <template #bar>
+                <b-progress-bar :value="10" show-value></b-progress-bar>
+                <b-progress-bar :value="20" type="is-primary" show-value></b-progress-bar>
+                <b-progress-bar :value="30" type="is-warning"></b-progress-bar>
+            </template>
         </b-progress>
     </section>
 </template>

--- a/docs/pages/components/sidebar/examples/ExSimple.vue
+++ b/docs/pages/components/sidebar/examples/ExSimple.vue
@@ -17,19 +17,21 @@
           <b-menu-list label="Menu">
             <b-menu-item icon="information-outline" label="Info"></b-menu-item>
             <b-menu-item icon="settings">
-              <template slot="label" slot-scope="props">
+              <template #label="props">
                 Administrator
                 <b-icon class="is-pulled-right" :icon="props.expanded ? 'menu-down' : 'menu-up'"></b-icon>
               </template>
               <b-menu-item icon="account" label="Users"></b-menu-item>
               <b-menu-item icon="cellphone-link">
-                <template slot="label">
+                <template #label>
                   Devices
                   <b-dropdown aria-role="list" class="is-pulled-right" position="is-bottom-left">
-                    <b-icon icon="dots-vertical" slot="trigger"></b-icon>
-                    <b-dropdown-item aria-role="listitem">Action</b-dropdown-item>
-                    <b-dropdown-item aria-role="listitem">Another action</b-dropdown-item>
-                    <b-dropdown-item aria-role="listitem">Something else</b-dropdown-item>
+                        <template #trigger>
+                            <b-icon icon="dots-vertical"></b-icon>
+                        </template>
+                        <b-dropdown-item aria-role="listitem">Action</b-dropdown-item>
+                        <b-dropdown-item aria-role="listitem">Another action</b-dropdown-item>
+                        <b-dropdown-item aria-role="listitem">Something else</b-dropdown-item>
                   </b-dropdown>
                 </template>
               </b-menu-item>

--- a/docs/pages/components/steps/examples/ExSimple.vue
+++ b/docs/pages/components/steps/examples/ExSimple.vue
@@ -86,8 +86,7 @@
 
             <template
                 v-if="customNavigation"
-                slot="navigation"
-                slot-scope="{previous, next}">
+                #navigation="{previous, next}">
                 <b-button
                     outlined
                     type="is-danger"

--- a/docs/pages/components/table/examples/ExCheckable.vue
+++ b/docs/pages/components/table/examples/ExCheckable.vue
@@ -24,7 +24,7 @@
                     checkable
                     :checkbox-position="checkboxPosition">
 
-                    <template slot="bottom-left">
+                    <template #bottom-left>
                         <b>Total checked</b>: {{ checkedRows.length }}
                     </template>
                 </b-table>

--- a/docs/pages/components/table/examples/ExDetailedRow.vue
+++ b/docs/pages/components/table/examples/ExDetailedRow.vue
@@ -56,7 +56,7 @@
                 </span>
             </b-table-column>
 
-            <template slot="detail" slot-scope="props">
+            <template #detail="props">
                 <article class="media">
                     <figure class="media-left">
                         <p class="image is-64x64">

--- a/docs/pages/components/table/examples/ExFooter.vue
+++ b/docs/pages/components/table/examples/ExFooter.vue
@@ -28,12 +28,12 @@
             </b-table-column>
 
 
-            <template slot="footer" v-if="!isCustom">
+            <template #footer v-if="!isCustom">
                 <div class="has-text-right">
                     Footer
                 </div>
             </template>
-            <template slot="footer" v-else>
+            <template #footer v-else>
                 <th class="is-hidden-mobile" style="width:40px">
                     <div class="th-wrap is-numeric"> ID </div>
                 </th>

--- a/docs/pages/components/table/examples/ExSearchable.vue
+++ b/docs/pages/components/table/examples/ExSearchable.vue
@@ -18,8 +18,7 @@
                 <b-table-column :key="column.id" v-bind="column">
                     <template
                         v-if="column.searchable && !column.numeric"
-                        slot="searchable"
-                        slot-scope="props">
+                        #searchable="props">
                         <b-input
                             v-model="props.filters[props.column.field]"
                             placeholder="Search..."

--- a/docs/pages/components/taginput/examples/ExSelected.vue
+++ b/docs/pages/components/taginput/examples/ExSelected.vue
@@ -12,10 +12,10 @@
                 <template slot-scope="props">
                     <strong>{{props.option.id}}</strong>: {{props.option.user.first_name}}
                 </template>
-                <template slot="empty">
+                <template #empty>
                     There are no items
                 </template>
-                <template slot="selected" slot-scope="props">
+                <template #selected="props">
                     <b-tag
                         v-for="(tag, index) in props.tags"
                         :key="index"

--- a/docs/pages/components/taginput/examples/ExTemplatedAutocomplete.vue
+++ b/docs/pages/components/taginput/examples/ExTemplatedAutocomplete.vue
@@ -9,10 +9,10 @@
                 icon="label"
                 placeholder="Add a tag"
                 @typing="getFilteredTags">
-                <template slot-scope="props">
+                <template v-slot="props">
                     <strong>{{props.option.id}}</strong>: {{props.option.user.first_name}}
                 </template>
-                <template slot="empty">
+                <template #empty>
                     There are no items
                 </template>
             </b-taginput>


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- According to [Deprecated `slot` Attribute](https://vuejs.org/v2/guide/components-slots.html#Deprecated-Syntax), `slot` & `slot-scope` attributes should not be further encouraged from buefy doc
- Using `slot` & `slot-scope` could lead to difficult issue, e.g. issue [2944](https://github.com/buefy/buefy/issues/2944)
- Replace `slot` & `slot-scope` with `v-slot` or  its [shorthand](https://vuejs.org/v2/guide/components-slots.html#Named-Slots-Shorthand) in buefy document
