### PR TITLE
Fix b-carousel variable documentation 

### DIFF
--- a/docs/pages/components/carousel/variables/carousel.js
+++ b/docs/pages/components/carousel/variables/carousel.js
@@ -30,19 +30,14 @@ export default [
         default: '<code>rgba($scheme-invert, 0.45)</code>'
     },
     {
-        name: '<code>$carousel-indicator-color</code>',
-        description: 'The carousel indicator color',
+        name: '<code>$carousel-indicator-border</code>',
+        description: 'The carousel indicator color border',
         default: '<code>$scheme-main</code>'
     },
     {
-        name: '<code>$carousel-indicator-border</code>',
-        description: 'The carousel indicator color border',
-        default: '<code>$primary</code>'
-    },
-    {
         name: '<code>$carousel-indicator-color</code>',
-        description: 'The carousel indicator background',
-        default: '<code>$white</code>'
+        description: 'The carousel indicator color',
+        default: '<code>$primary</code>'
     },
     {
         name: '<code>$carousel-indicator-spaced</code>',


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

The variable documentation for b-carousel includes a duplicate item and incorrect values when you look at the defaults in `/src/scss/components/_carousel.scss` - specifically:
- `$carousel-indicator-color` was repeated (one with an incorrect value and description) and,
- `$carousel-indicator-border` had the wrong default.

Very small changes, but one I noticed when looking at the documentation, and something I figured would be a quick fix! Thank you for buefy!