### PR TITLE
Correct b-navbar tag documentation

### DIFF
--- a/docs/pages/components/navbar/api/navbar.js
+++ b/docs/pages/components/navbar/api/navbar.js
@@ -113,7 +113,7 @@ export default [
             name: '<code>tag</code>',
             description: 'Sets the type of the component that have to render as navbar-item',
             type: 'String',
-            values: '<code>a</code>, <code>router-link</code>, <code>div</code> and his html attributes like href, to, etc...',
+            values: '<code>a</code>, <code>router-link</code>, <code>div</code> and it\'s html attributes like href, to, etc...',
             default: 'a'
         },
         {


### PR DESCRIPTION
Correct a small grammatical error.

<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Corrected text for the 'tag' value. Previously the use of "his" made no sense.
