### PR TITLE
Update default animated property value in Tooltip docs

### DIFF
--- a/docs/pages/components/tooltip/api/tooltip.js
+++ b/docs/pages/components/tooltip/api/tooltip.js
@@ -51,7 +51,7 @@ export default [
                 description: 'Tooltip will have a little fade animation',
                 type: 'Boolean',
                 values: '—',
-                default: '<code>false</code>'
+                default: '<code>true</code>'
             },
             {
                 name: '<code>square</code>',


### PR DESCRIPTION
Fixes #3075

## Proposed Changes

- Tooltip docs : change `animated` prop default value from `false` to `true`
