### PR TITLE
Fixes #3011

### DIFF
--- a/src/components/clockpicker/Clockpicker.vue
+++ b/src/components/clockpicker/Clockpicker.vue
@@ -30,7 +30,7 @@
                         @keyup.native.enter="toggle(true)"
                         @change.native="onChange($event.target.value)"
                         @focus="handleOnFocus"
-                        @blur="onBlur() && checkHtml5Validity()"/>
+                        @blur="checkHtml5Validity()"/>
                 </slot>
             </template>
             <div


### PR DESCRIPTION
Remove default input blur event but let `onActiveChange` decide to emit blur event on behalf `ClockPicker`

<!-- Thank you for helping Buefy! -->

Fixes #3011
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- In `ClockPicker` component, blur events are triggered twice: first one is from `active-change`, the second one from default input `blur` event
- From user experience, clock picker input field blur event shall be based on dropdown active or inactive, therefore removing the default input blur event will ensure blur event only be triggered once on behalf of `ClockPicker` when dropdown is inactive 
