### PR TITLE
Add option to show all years at once

### DIFF
--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -420,6 +420,10 @@ export default {
             type: Boolean,
             default: false
         },
+        explicitYears: {
+            type: Boolean,
+            default: false
+        },
         closeOnClick: {
             type: Boolean,
             default: true
@@ -532,15 +536,27 @@ export default {
          * dates are set by props, range of years will fall within those dates.
          */
         listOfYears() {
-            let latestYear = this.focusedDateData.year + this.yearsRange[1]
-            if (this.maxDate && this.maxDate.getFullYear() < latestYear) {
-                latestYear = Math.max(this.maxDate.getFullYear(), this.focusedDateData.year)
-            }
 
-            let earliestYear = this.focusedDateData.year + this.yearsRange[0]
-            if (this.minDate && this.minDate.getFullYear() > earliestYear) {
-                earliestYear = Math.min(this.minDate.getFullYear(), this.focusedDateData.year)
+            let latestYear , earliestYear;
+
+            if(this.explicitYears){
+
+                latestYear   = this.maxDate.getFullYear();
+                earliestYear = this.minDate.getFullYear();
+
+            }else{
+
+                latestYear = this.focusedDateData.year + this.yearsRange[1]
+                if (this.maxDate && this.maxDate.getFullYear() < latestYear) {
+                    latestYear = Math.max(this.maxDate.getFullYear(), this.focusedDateData.year)
+                }
+
+                earliestYear = this.focusedDateData.year + this.yearsRange[0]
+                if (this.minDate && this.minDate.getFullYear() > earliestYear) {
+                    earliestYear = Math.min(this.minDate.getFullYear(), this.focusedDateData.year)
+                }
             }
+          
 
             const arrayOfYears = []
             for (let i = earliestYear; i <= latestYear; i++) {

--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -536,16 +536,12 @@ export default {
          * dates are set by props, range of years will fall within those dates.
          */
         listOfYears() {
+            let latestYear, earliestYear
 
-            let latestYear , earliestYear;
-
-            if(this.explicitYears){
-
-                latestYear   = this.maxDate.getFullYear();
-                earliestYear = this.minDate.getFullYear();
-
-            }else{
-
+            if (this.explicitYears) {
+                latestYear = this.maxDate.getFullYear()
+                earliestYear = this.minDate.getFullYear()
+            } else {
                 latestYear = this.focusedDateData.year + this.yearsRange[1]
                 if (this.maxDate && this.maxDate.getFullYear() < latestYear) {
                     latestYear = Math.max(this.maxDate.getFullYear(), this.focusedDateData.year)
@@ -556,7 +552,6 @@ export default {
                     earliestYear = Math.min(this.minDate.getFullYear(), this.focusedDateData.year)
                 }
             }
-          
 
             const arrayOfYears = []
             for (let i = earliestYear; i <= latestYear; i++) {


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

right now i am working on a project where user can enter his birthday and many other dates 

i am using date picker and i want to show all years user can select at once 
the current behavior right now  is : the list of years is getting updated each time the user select a year based on years range config
for the user this will be bad UX as he will think he can not select any of years not in the list which is not the case 

## Proposed Changes

- add an option to show all years in date picker at once not some of it 
