### PR TITLE
Reverting showX change when using hasModalCard prop

### DIFF
--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -149,7 +149,7 @@ export default {
                 : this.canCancel
         },
         showX() {
-            return this.cancelOptions.indexOf('x') >= 0 && !this.hasModalCard
+            return this.cancelOptions.indexOf('x') >= 0
         },
         customStyle() {
             if (!this.fullScreen) {


### PR DESCRIPTION
## Proposed Changes

Could we revert this change to hide the 'X' in the top right when we use the `has-modal-card` prop?

I'm not sure why this change was added (presumably as it was assumed that all modal cards would have their own close button?), but it now means we cannot use modal cards in our UI as we were using the 'X' button to close it.

You can still hide the 'X' using the `cancelOptions`.
