### PR TITLE
Better support for wrapper around Autocomplete.vue

### DIFF
--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -63,12 +63,13 @@
                             @click="setSelected(option, undefined, $event)"
                         >
                             <slot
-                                v-if="hasDefaultSlot"
                                 :option="option"
-                                :index="index" />
-                            <span v-else>
-                                {{ getValue(option, true) }}
-                            </span>
+                                :index="index"
+                            >
+                                <span>
+                                    {{ getValue(option, true) }}
+                                </span>
+                            </slot>
                         </a>
                     </template>
                     <div


### PR DESCRIPTION
We are currently trying to make a wrapper component around `<b-autocomplete>` like so:

```js

// Our custom Autocomplete wrapper

<b-autocomplete
  v-model="query"
  :data="filteredTags"
  :icon="icon"
  :placeholder="placeholder"
  :field="field"
  @select="onInput"
  @typing="onTyping"
>
  <template
    v-if="$scopedSlots.default"
    slot-scope="props"
  >
    <slot v-bind="props" />
  </template>
</b-autocomplete>
```

As you can see, we want to pass down the `default` slot when it's not empty. It's currently not possible to make it work with the current implementation. 

Instead of using the `hasDefaultSlot`, I propose the use of "default slots" to allow our use case. Was there a specific reason to use `hasDefaultSlot`?

I understand our use-case is very specific, let me know what you think! :)