### PR TITLE
Prevent add a tag when starts a new composition session

### DIFF
--- a/src/components/taginput/Taginput.vue
+++ b/src/components/taginput/Taginput.vue
@@ -55,6 +55,8 @@
                 @focus="onFocus"
                 @blur="customOnBlur"
                 @keydown.native="keydown"
+                @compositionstart.native="isComposing = true"
+                @compositionend.native="isComposing = false"
                 @select="onSelect"
                 @infinite-scroll="emitInfiniteScroll">
                 <template
@@ -186,6 +188,7 @@ export default {
         return {
             tags: Array.isArray(this.value) ? this.value.slice(0) : (this.value || []),
             newTag: '',
+            isComposing: false,
             _elementRef: 'autocomplete',
             _isTaginput: true
         }
@@ -339,6 +342,7 @@ export default {
             if (this.confirmKeys.indexOf(key) >= 0) {
                 // Allow Tab to advance to next field regardless
                 if (key !== 'Tab') event.preventDefault()
+                if (key === 'Enter' && this.isComposing) return
                 this.addTag()
             }
         },


### PR DESCRIPTION
## Proposed Changes
Hi, I am a Japanese developer. Most users in my country use IME when input some Japanese texts by PC.
 However, Buefy’s TagInput component does not work as expected when the IME is enabled.

In the current TagInput, it works as follows.
![before](https://user-images.githubusercontent.com/3766560/103080814-fc8a9780-4619-11eb-97b1-4ece7fb601d5.gif)

I fixed it like this.

![after](https://user-images.githubusercontent.com/3766560/103081032-715dd180-461a-11eb-96d1-90adeb79823c.gif)

Please check this PR and I want you to merge if there is no problem. 
Thank you.