### PR TITLE
Append-to-body dropdown overlays the page when inactive

### DIFF
--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -336,6 +336,7 @@ export default {
                     parentNode.classList.forEach((item) => {
                         parent.classList.add(item)
                     })
+                    parentNode.style.zIndex = this.isActive ? '-1' : '0'
                 }
                 const rect = trigger.getBoundingClientRect()
                 let top = rect.top + window.scrollY


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #3113 

## Proposed Changes

- The fix is very simple, as the body element is already updated by the `isActive` watcher. We only have to do a simple switch on `isActive`. If it is true, use `z-index: 0` else `z-index: -1`.
