### PR TITLE
Improve modal a11y

### DIFF
--- a/docs/pages/components/modal/api/modal.js
+++ b/docs/pages/components/modal/api/modal.js
@@ -130,6 +130,13 @@ export default [
                 default: '—'
             },
             {
+                name: '<code>aria-label</code>',
+                description: `Aria label attribute to be passed to modal container for better accessibility.`,
+                type: 'String',
+                values: '—',
+                default: '—'
+            },
+            {
                 name: '<code>aria-modal</code>',
                 description: `Improve accessiblity when enabled.`,
                 type: 'Boolean',

--- a/docs/pages/components/modal/examples/ExComponent.vue
+++ b/docs/pages/components/modal/examples/ExComponent.vue
@@ -12,6 +12,7 @@
             trap-focus
             :destroy-on-hide="false"
             aria-role="dialog"
+            aria-label="Example Modal"
             aria-modal>
             <template #default="props">
                 <modal-form v-bind="formProps" @close="props.close"></modal-form>

--- a/src/components/modal/Modal.spec.js
+++ b/src/components/modal/Modal.spec.js
@@ -27,11 +27,15 @@ describe('BModal', () => {
 
     it('manage props validator', () => {
         const ariaRole = wrapper.vm.$options.props.ariaRole
+        const ariaLabel = wrapper.vm.$options.props.ariaLabel
 
         expect(ariaRole.type).toBe(String)
         expect(ariaRole.validator && ariaRole.validator('d')).toBeFalsy()
         expect(ariaRole.validator && ariaRole.validator('dialog')).toBeTruthy()
         expect(ariaRole.validator && ariaRole.validator('alertdialog')).toBeTruthy()
+        expect(ariaLabel.type).toBe(String)
+        expect(ariaLabel.validator && ariaLabel.validator('')).toBeFalsy()
+        expect(ariaLabel.validator && ariaLabel.validator('d')).toBeTruthy()
     })
 
     it('manage default config props values', () => {

--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -13,6 +13,7 @@
             v-trap-focus="trapFocus"
             tabindex="-1"
             :role="ariaRole"
+            :aria-label="ariaLabel"
             :aria-modal="ariaModal">
             <div class="modal-background" @click="cancel('outside')"/>
             <div
@@ -124,6 +125,12 @@ export default {
             }
         },
         ariaModal: Boolean,
+        ariaLabel: {
+            type: String,
+            validator: (value) => {
+                return Boolean(value)
+            }
+        },
         destroyOnHide: {
             type: Boolean,
             default: true

--- a/types/components.d.ts
+++ b/types/components.d.ts
@@ -166,6 +166,11 @@ export declare type BDialogConfig = {
     ariaRole?: 'dialog' | 'alertdialog';
 
    /**
+    * Aria label attribute to be passed to modal container for better accessibility.
+    */
+   ariaLabel?: string;
+
+   /**
     * Improve accessiblity when enabled.
     */
    ariaModal?: boolean;


### PR DESCRIPTION
Adds aria-label prop to the modal component.

Currently the modal fails [jest-axe](https://github.com/nickcolley/jest-axe) accessibility tests because the rendered html does not have an aria-label attribute.

![image](https://user-images.githubusercontent.com/49884912/103823103-4154fc00-5026-11eb-944d-34890346e9c9.png)

