### PR TITLE
Add support for custom datepicker (un)selectability logic

### DIFF
--- a/docs/pages/components/datepicker/Datepicker.vue
+++ b/docs/pages/components/datepicker/Datepicker.vue
@@ -54,6 +54,12 @@
             <p>Datepicker can also be shown inline with the <code>inline</code> prop, input is removed, set a <code>v-model</code> to get the date.</p>
         </Example>
 
+        <Example :component="ExUnselectable" :code="ExUnselectableCode" title="Unselectable" vertical>
+            <p>
+                Datepicker can have certain dates be unselectable with the <code>unselectable-dates</code> and <code>unselectable-days-of-week</code> props.
+            </p>
+        </Example>
+
         <Example :component="ExEvents" :code="ExEventsCode" title="Events" vertical>
             <p>Dates can be passed to the datepicker with the <code>events</code> prop and shown with indicators.</p>
         </Example>
@@ -110,6 +116,9 @@
     import ExInline from './examples/ExInline'
     import ExInlineCode from '!!raw-loader!./examples/ExInline'
 
+    import ExUnselectable from './examples/ExUnselectable'
+    import ExUnselectableCode from '!!raw-loader!./examples/ExUnselectable'
+
     import ExEvents from './examples/ExEvents'
     import ExEventsCode from '!!raw-loader!./examples/ExEvents'
 
@@ -140,6 +149,8 @@
                 ExTriggerCode,
                 ExInline,
                 ExInlineCode,
+                ExUnselectable,
+                ExUnselectableCode,
                 ExEvents,
                 ExEventsCode,
                 ExMonth,

--- a/docs/pages/components/datepicker/api/datepicker.js
+++ b/docs/pages/components/datepicker/api/datepicker.js
@@ -122,8 +122,8 @@ export default [
             },
             {
                 name: '<code>unselectable-dates</code>',
-                description: 'Array of unselectable dates',
-                type: 'Array',
+                description: 'Array of unselectable dates, or a function to identify unselectable dates',
+                type: 'Array, Function',
                 values: '—',
                 default: '-'
             },
@@ -136,8 +136,8 @@ export default [
             },
             {
                 name: '<code>selectable-dates</code>',
-                description: 'Array of selectable dates',
-                type: 'Array',
+                description: 'Array of selectable dates, or a function to identify selectable dates',
+                type: 'Array, Function',
                 values: '—',
                 default: '-'
             },

--- a/docs/pages/components/datepicker/examples/ExUnselectable.vue
+++ b/docs/pages/components/datepicker/examples/ExUnselectable.vue
@@ -1,0 +1,38 @@
+<template>
+    <section>
+        <b-field grouped group-multiline>
+            <b-field>
+                <div class="control">
+                    <b-switch v-model="disableWeekends">No weekends</b-switch>
+                </div>
+            </b-field>
+            <b-field>
+                Dates after
+                <b-input type="number" min="0" max="31" v-model.number="unselectableAfterDate" />
+                are unselectable.
+            </b-field>
+        </b-field>
+        <b-datepicker v-model="date"
+            inline
+            :unselectable-dates="unselectableDates"
+            :unselectable-days-of-week="disableWeekends ? [0, 6] : null">
+        </b-datepicker>
+    </section>
+</template>
+
+<script>
+    export default {
+        data() {
+            return {
+                date: new Date(),
+                disableWeekends: false,
+                unselectableAfterDate: 20
+            }
+        },
+        methods: {
+            unselectableDates(day) {
+                return this.unselectableAfterDate < day.getDate()
+            }
+        }
+    }
+</script>

--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -328,12 +328,12 @@ export default {
         editable: Boolean,
         disabled: Boolean,
         horizontalTimePicker: Boolean,
-        unselectableDates: Array,
+        unselectableDates: [Array, Function],
         unselectableDaysOfWeek: {
             type: Array,
             default: () => config.defaultUnselectableDaysOfWeek
         },
-        selectableDates: Array,
+        selectableDates: [Array, Function],
         dateFormatter: {
             type: Function,
             default: (date, vm) => {

--- a/src/components/datepicker/DatepickerMonth.spec.js
+++ b/src/components/datepicker/DatepickerMonth.spec.js
@@ -145,6 +145,13 @@ describe('BDatepickerMonth', () => {
         expect(wrapper.vm.selectableDate(day)).toBeTruthy()
 
         wrapper.setProps({
+            selectableDates: (d) => d.getMonth() === 7
+        })
+        expect(wrapper.vm.selectableDate(day)).toBeTruthy()
+        expect(wrapper.vm.selectableDate(new Date(2019, 6, 7))).toBeFalsy()
+        expect(wrapper.vm.selectableDate(new Date(2019, 8, 7))).toBeFalsy()
+
+        wrapper.setProps({
             minDate: null,
             maxDate: null,
             selectableDates: null,
@@ -155,6 +162,19 @@ describe('BDatepickerMonth', () => {
             unselectableDates: [day]
         })
         expect(wrapper.vm.selectableDate(day)).toBeFalsy()
+
+        wrapper.setProps({
+            unselectableDates: (d) => d.getMonth() === 7
+        })
+        expect(wrapper.vm.selectableDate(day)).toBeFalsy()
+        expect(wrapper.vm.selectableDate(new Date(2019, 6, 7))).toBeTruthy()
+        expect(wrapper.vm.selectableDate(new Date(2019, 8, 7))).toBeTruthy()
+
+        wrapper.setProps({
+            selectableDates: (d) => d.getMonth() === 7,
+            unselectableDates: (d) => true
+        })
+        expect(wrapper.vm.selectableDate(day)).toBeTruthy()
 
         wrapper.setProps({
             minDate: null,

--- a/src/components/datepicker/DatepickerMonth.vue
+++ b/src/components/datepicker/DatepickerMonth.vue
@@ -59,9 +59,9 @@ export default {
         focused: Object,
         disabled: Boolean,
         dateCreator: Function,
-        unselectableDates: Array,
+        unselectableDates: [Array, Function],
         unselectableDaysOfWeek: Array,
-        selectableDates: Array,
+        selectableDates: [Array, Function],
         range: Boolean,
         multiple: Boolean
     },
@@ -177,24 +177,36 @@ export default {
             validity.push(day.getFullYear() === this.focused.year)
 
             if (this.selectableDates) {
-                for (let i = 0; i < this.selectableDates.length; i++) {
-                    const enabledDate = this.selectableDates[i]
-                    if (day.getFullYear() === enabledDate.getFullYear() &&
-                        day.getMonth() === enabledDate.getMonth()) {
+                if (typeof this.selectableDates === 'function') {
+                    if (this.selectableDates(day)) {
                         return true
                     } else {
                         validity.push(false)
+                    }
+                } else {
+                    for (let i = 0; i < this.selectableDates.length; i++) {
+                        const enabledDate = this.selectableDates[i]
+                        if (day.getFullYear() === enabledDate.getFullYear() &&
+                            day.getMonth() === enabledDate.getMonth()) {
+                            return true
+                        } else {
+                            validity.push(false)
+                        }
                     }
                 }
             }
 
             if (this.unselectableDates) {
-                for (let i = 0; i < this.unselectableDates.length; i++) {
-                    const disabledDate = this.unselectableDates[i]
-                    validity.push(
-                        day.getFullYear() !== disabledDate.getFullYear() ||
-                            day.getMonth() !== disabledDate.getMonth()
-                    )
+                if (typeof this.unselectableDates === 'function') {
+                    validity.push(!this.unselectableDates(day))
+                } else {
+                    for (let i = 0; i < this.unselectableDates.length; i++) {
+                        const disabledDate = this.unselectableDates[i]
+                        validity.push(
+                            day.getFullYear() !== disabledDate.getFullYear() ||
+                                day.getMonth() !== disabledDate.getMonth()
+                        )
+                    }
                 }
             }
 

--- a/src/components/datepicker/DatepickerTable.vue
+++ b/src/components/datepicker/DatepickerTable.vue
@@ -64,9 +64,9 @@ export default {
         focused: Object,
         disabled: Boolean,
         dateCreator: Function,
-        unselectableDates: Array,
+        unselectableDates: [Array, Function],
         unselectableDaysOfWeek: Array,
-        selectableDates: Array,
+        selectableDates: [Array, Function],
         nearbyMonthDays: Boolean,
         nearbySelectableMonthDays: Boolean,
         showWeekNumber: Boolean,
@@ -298,26 +298,38 @@ export default {
             }
 
             if (this.selectableDates) {
-                for (let i = 0; i < this.selectableDates.length; i++) {
-                    const enabledDate = this.selectableDates[i]
-                    if (day.getDate() === enabledDate.getDate() &&
-                        day.getFullYear() === enabledDate.getFullYear() &&
-                        day.getMonth() === enabledDate.getMonth()) {
+                if (typeof this.selectableDates === 'function') {
+                    if (this.selectableDates(day)) {
                         return true
                     } else {
                         validity.push(false)
+                    }
+                } else {
+                    for (let i = 0; i < this.selectableDates.length; i++) {
+                        const enabledDate = this.selectableDates[i]
+                        if (day.getDate() === enabledDate.getDate() &&
+                            day.getFullYear() === enabledDate.getFullYear() &&
+                            day.getMonth() === enabledDate.getMonth()) {
+                            return true
+                        } else {
+                            validity.push(false)
+                        }
                     }
                 }
             }
 
             if (this.unselectableDates) {
-                for (let i = 0; i < this.unselectableDates.length; i++) {
-                    const disabledDate = this.unselectableDates[i]
-                    validity.push(
-                        day.getDate() !== disabledDate.getDate() ||
-                            day.getFullYear() !== disabledDate.getFullYear() ||
-                            day.getMonth() !== disabledDate.getMonth()
-                    )
+                if (typeof this.unselectableDates === 'function') {
+                    validity.push(!this.unselectableDates(day))
+                } else {
+                    for (let i = 0; i < this.unselectableDates.length; i++) {
+                        const disabledDate = this.unselectableDates[i]
+                        validity.push(
+                            day.getDate() !== disabledDate.getDate() ||
+                                day.getFullYear() !== disabledDate.getFullYear() ||
+                                day.getMonth() !== disabledDate.getMonth()
+                        )
+                    }
                 }
             }
 

--- a/src/components/datepicker/DatepickerTableRow.vue
+++ b/src/components/datepicker/DatepickerTableRow.vue
@@ -66,9 +66,9 @@ export default {
         minDate: Date,
         maxDate: Date,
         disabled: Boolean,
-        unselectableDates: Array,
+        unselectableDates: [Array, Function],
         unselectableDaysOfWeek: Array,
-        selectableDates: Array,
+        selectableDates: [Array, Function],
         events: Array,
         indicators: String,
         dateCreator: Function,
@@ -162,26 +162,38 @@ export default {
             }
 
             if (this.selectableDates) {
-                for (let i = 0; i < this.selectableDates.length; i++) {
-                    const enabledDate = this.selectableDates[i]
-                    if (day.getDate() === enabledDate.getDate() &&
-                        day.getFullYear() === enabledDate.getFullYear() &&
-                        day.getMonth() === enabledDate.getMonth()) {
+                if (typeof this.selectableDates === 'function') {
+                    if (this.selectableDates(day)) {
                         return true
                     } else {
                         validity.push(false)
+                    }
+                } else {
+                    for (let i = 0; i < this.selectableDates.length; i++) {
+                        const enabledDate = this.selectableDates[i]
+                        if (day.getDate() === enabledDate.getDate() &&
+                            day.getFullYear() === enabledDate.getFullYear() &&
+                            day.getMonth() === enabledDate.getMonth()) {
+                            return true
+                        } else {
+                            validity.push(false)
+                        }
                     }
                 }
             }
 
             if (this.unselectableDates) {
-                for (let i = 0; i < this.unselectableDates.length; i++) {
-                    const disabledDate = this.unselectableDates[i]
-                    validity.push(
-                        day.getDate() !== disabledDate.getDate() ||
-                            day.getFullYear() !== disabledDate.getFullYear() ||
-                            day.getMonth() !== disabledDate.getMonth()
-                    )
+                if (typeof this.unselectableDates === 'function') {
+                    validity.push(!this.unselectableDates(day))
+                } else {
+                    for (let i = 0; i < this.unselectableDates.length; i++) {
+                        const disabledDate = this.unselectableDates[i]
+                        validity.push(
+                            day.getDate() !== disabledDate.getDate() ||
+                                day.getFullYear() !== disabledDate.getFullYear() ||
+                                day.getMonth() !== disabledDate.getMonth()
+                        )
+                    }
                 }
             }
 


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

## Proposed Changes

- Allow datepicker `selectable-dates` and `unselectable-dates` props to be functions.

This enables custom logic such as "make the 29th-31st of each month unselectable" (this particular rule being common when picking a billing date which is to repeat monthly).

Example:

    <b-datepicker ... :unselectable-dates="(day) => day.getDate() > 28">