### PR TITLE
data binds an `object[]`, there is a TypeError

### DIFF
--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -351,7 +351,7 @@ export default {
         setSelected(option, closeDropdown = true, event = undefined) {
             if (option === undefined) return
 
-            this.selected = option
+            this.selected = option === null ? {} : option
             this.$emit('select', this.selected, event)
             if (this.selected !== null) {
                 this.newValue = this.clearOnSelect ? '' : this.getValue(this.selected)


### PR DESCRIPTION
When data binds an array of objects, the value thrown by the select event should be an object, not an error caused by null, null when used, such as
```vue
<b-autocomplete @select="handleSelectChange"></b-autocomplete>
 handleSelectChange(option) {
          console.log('option',option) // null 
            this.url = option.url // Error in v-on handler: "TypeError: Cannot read property 'url' of null"
        }
```

<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

-
-
-
