### PR TITLE
So that the component can be re-encapsulated.

### DIFF
--- a/src/components/pagination/PaginationButton.vue
+++ b/src/components/pagination/PaginationButton.vue
@@ -7,7 +7,7 @@
         class="pagination-link"
         :class="{ 'is-current': page.isCurrent, [page.class]: true }"
         v-bind="$attrs"
-        @click.prevent="page.click"
+        @click.prevent="()=>(page.click(),$emit('update:page',page + 1))"
         :aria-label="page['aria-label']"
         :aria-current="page.isCurrent">
         <slot>{{ page.number }}</slot>


### PR DESCRIPTION
[codepen](https://codepen.io/valar123/pen/qBawNYL?editors=1011)
I found that there was no emit event in the paginationButton component, which made it impossible for me to re-encapsulate it.

<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

-
-
-
