### PR TITLE
Fix close button not displaying when modal is active by default

### DIFF
--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -143,7 +143,7 @@ export default {
             newWidth: typeof this.width === 'number'
                 ? this.width + 'px'
                 : this.width,
-            animating: true,
+            animating: !this.active,
             destroyed: !this.active
         }
     },

--- a/src/components/modal/__snapshots__/Modal.spec.js.snap
+++ b/src/components/modal/__snapshots__/Modal.spec.js.snap
@@ -4,7 +4,7 @@ exports[`BModal render correctly 1`] = `
 <transition-stub name="zoom-out">
     <div tabindex="-1" class="modal is-active">
         <div class="modal-background"></div>
-        <div class="animation-content modal-content" style="max-width: 960px;"> <button type="button" class="modal-close is-large" style="display: none;"></button></div>
+        <div class="animation-content modal-content" style="max-width: 960px;"> <button type="button" class="modal-close is-large"></button></div>
     </div>
 </transition-stub>
 `;


### PR DESCRIPTION
## Proposed Changes
When the modal is active in the initial state, the close button is not displayed, so the initial value of `animating` is now dependent on the initial value of `active`.