### PR TITLE
Cast number type value to number when emit input event in BInput

### DIFF
--- a/src/components/input/Input.vue
+++ b/src/components/input/Input.vue
@@ -114,11 +114,7 @@ export default {
             },
             set(value) {
                 this.newValue = value
-                if (isNaN(value)) {
-                    this.$emit('input', value)
-                } else {
-                    this.$emit('input', Number(value))
-                }
+                this.$emit('input', value)
             }
         },
         rootClasses() {

--- a/src/components/input/Input.vue
+++ b/src/components/input/Input.vue
@@ -114,7 +114,11 @@ export default {
             },
             set(value) {
                 this.newValue = value
-                this.$emit('input', value)
+                if (isNaN(value)) {
+                    this.$emit('input', value)
+                } else {
+                    this.$emit('input', Number(value))
+                }
             }
         },
         rootClasses() {

--- a/src/components/numberinput/Numberinput.vue
+++ b/src/components/numberinput/Numberinput.vue
@@ -28,7 +28,7 @@
         <b-input
             type="number"
             ref="input"
-            v-model.number="computedValue"
+            v-model="computedValue"
             v-bind="$attrs"
             :step="minStepNumber"
             :max="max"
@@ -153,7 +153,9 @@ export default {
                     }
                 }
                 this.newValue = newValue
-                this.$emit('input', newValue)
+                if (!isNaN(newValue) && newValue !== null && newValue !== '-0') {
+                    this.$emit('input', Number(newValue))
+                }
                 !this.isValid && this.$refs.input.checkHtml5Validity()
             }
         },


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #3109
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- This issue is caused by this [vue behaviour](https://github.com/vuejs/vue/issues/11897)
- As per the answer in [vue behaviour](https://github.com/vuejs/vue/issues/11897), `.number` only work on native `v-model`, not on custom components. So `.number` is removed from `v-model` in `b-input`, instead `NumberInput` will be responsible to do number casting when it emits `@input`.
