### PR TITLE
Add new prop to allow column drag&drop

### DIFF
--- a/docs/pages/components/table/Table.vue
+++ b/docs/pages/components/table/Table.vue
@@ -124,10 +124,10 @@
             <p><small>API from <a href="https://www.themoviedb.org" target="_blank">TMDb</a>.</small></p>
         </Example>
 
-        <Example :component="ExDraggableRows" :code="ExDraggableRowsCode" title="Draggable rows">
+        <Example :component="ExDraggableRows" :code="ExDraggableRowsCode" title="Draggable rows/columns">
             <p>
-                Use <code>draggable</code> prop to allow rows to be draggable. Manage dragging using <code>dragstart</code>,
-                <code>dragover</code> and <code>drop</code> events
+                Use <code>draggable</code>/<code>draggable-column</code> prop to allow rows and columns to be draggable. Manage dragging using <code>dragstart</code>/<code>columndragstart</code>,
+                <code>dragover</code>/<code>columndragover</code> and <code>drop</code>/<code>columndrop</code> events
             </p>
         </Example>
 

--- a/docs/pages/components/table/api/table.js
+++ b/docs/pages/components/table/api/table.js
@@ -332,6 +332,13 @@ export default [
                 default: '<code>false</code>'
             },
             {
+                name: '<code>draggable-column</code>',
+                description: 'Allows columns to be draggable',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
                 name: '<code>backend-filtering</code>',
                 description: `Columns won't be filtered with Javascript, use with <code>searchable</code> prop to the columns to filter in your backend`,
                 type: 'Boolean',

--- a/docs/pages/components/table/api/table.js
+++ b/docs/pages/components/table/api/table.js
@@ -552,6 +552,31 @@ export default [
                 parameters: '<code> row: Object </code>, <code> dragover: Event </code>, <code> index: Number </code>'
             },
             {
+                name: '<code>columndragstart</code>',
+                description: 'Triggers when starting to drag a column',
+                parameters: '<code> column: Object </code>, <code> dragEvent: Event </code>, <code> index: Number </code>'
+            },
+            {
+                name: '<code>columndragend</code>',
+                description: 'Triggers when ending to drag a column',
+                parameters: '<code> column: Object </code>, <code> dragEvent: Event </code>, <code> index: Number </code>'
+            },
+            {
+                name: '<code>columndrop</code>',
+                description: 'Triggers when dropping on a column',
+                parameters: '<code> column: Object </code>, <code> drop: Event </code>, <code> index: Number </code>'
+            },
+            {
+                name: '<code>columndragover</code>',
+                description: 'Triggers when dragging over a column',
+                parameters: '<code> column: Object </code>, <code> dragover: Event </code>, <code> index: Number </code>'
+            },
+            {
+                name: '<code>columndragleave</code>',
+                description: 'Triggers after dragging over a column',
+                parameters: '<code> column: Object </code>, <code> dragover: Event </code>, <code> index: Number </code>'
+            },
+            {
                 name: '<code>mouseenter</code>',
                 description: 'Triggers when mouse enters a row',
                 parameters: '<code> row: Object </code>, <code> event: Event </code>'

--- a/docs/pages/components/table/examples/ExDraggableRows.vue
+++ b/docs/pages/components/table/examples/ExDraggableRows.vue
@@ -97,7 +97,7 @@
         columndrop(payload) {
           payload.event.target.closest('th').classList.remove('is-selected')
           const droppedOnColumnIndex = payload.index
-          this.$buefy.toast.open(`Moved ${this.draggingColumn.field} from row ${this.draggingColumnIndex + 1} to ${droppedOnColumnIndex + 1}`)
+          this.$buefy.toast.open(`Moved ${this.draggingColumn.field} from column ${this.draggingColumnIndex + 1} to ${droppedOnColumnIndex + 1}`)
         }
       }
   }

--- a/docs/pages/components/table/examples/ExDraggableRows.vue
+++ b/docs/pages/components/table/examples/ExDraggableRows.vue
@@ -4,12 +4,17 @@
       :data="data"
       :columns="columns"
       draggable
+      draggable-column
       @dragstart="dragstart"
       @drop="drop"
       @dragover="dragover"
-      @dragleave="dragleave">
+      @dragleave="dragleave"
+      @columndragstart="columndragstart"
+      @columndrop="columndrop"
+      @columndragover="columndragover"
+      @columndragleave="columndragleave">
     </b-table>
-  </div> 
+  </div>
 </template>
 
 <script>
@@ -49,11 +54,13 @@
                   }
               ],
               draggingRow: null,
-              draggingRowIndex: null
+              draggingRowIndex: null,
+              draggingColumn: null,
+              draggingColumnIndex: null
           }
       },
       methods: {
-        dragstart (payload) {
+        dragstart(payload) {
           this.draggingRow = payload.row
           this.draggingRowIndex = payload.index
           payload.event.dataTransfer.effectAllowed = 'copy'
@@ -71,6 +78,26 @@
           payload.event.target.closest('tr').classList.remove('is-selected')
           const droppedOnRowIndex = payload.index
           this.$buefy.toast.open(`Moved ${this.draggingRow.first_name} from row ${this.draggingRowIndex + 1} to ${droppedOnRowIndex + 1}`)
+        },
+
+        columndragstart(payload) {
+          this.draggingColumn = payload.column
+          this.draggingColumnIndex = payload.index
+          payload.event.dataTransfer.effectAllowed = 'copy'
+        },
+        columndragover(payload) {
+          payload.event.dataTransfer.dropEffect = 'copy'
+          payload.event.target.closest('th').classList.add('is-selected')
+          payload.event.preventDefault()
+        },
+        columndragleave(payload) {
+          payload.event.target.closest('th').classList.remove('is-selected')
+          payload.event.preventDefault()
+        },
+        columndrop(payload) {
+          payload.event.target.closest('th').classList.remove('is-selected')
+          const droppedOnColumnIndex = payload.index
+          this.$buefy.toast.open(`Moved ${this.draggingColumn.field} from row ${this.draggingColumnIndex + 1} to ${droppedOnColumnIndex + 1}`)
         }
       }
   }

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -72,7 +72,13 @@
                                 'is-current-sort': !sortMultiple && currentSortColumn === column,
                             }]"
                             :style="column.thStyle"
-                            @click.stop="sort(column, null, $event)">
+                            @click.stop="sort(column, null, $event)"
+                            :draggable="canDragColumn"
+                            @dragstart="handleColumnDragStart($event, column, index)"
+                            @dragend="handleColumnDragEnd($event, column, index)"
+                            @drop="handleColumnDrop($event, column, index)"
+                            @dragover="handleColumnDragOver($event, column, index)"
+                            @dragleave="handleColumnDragLeave($event, column, index)">
                             <div
                                 class="th-wrap"
                                 :class="{
@@ -215,7 +221,7 @@
                             @mouseenter="emitEventForRow('mouseenter', $event, row)"
                             @mouseleave="emitEventForRow('mouseleave', $event, row)"
                             @contextmenu="$emit('contextmenu', row, $event)"
-                            :draggable="draggable"
+                            :draggable="canDragRow"
                             @dragstart="handleDragStart($event, row, index)"
                             @dragend="handleDragEnd($event, row, index)"
                             @drop="handleDrop($event, row, index)"
@@ -532,6 +538,10 @@ export default {
             type: Boolean,
             default: false
         },
+        draggableColumn: {
+            type: Boolean,
+            default: false
+        },
         scrollable: Boolean,
         ariaNextLabel: String,
         ariaPreviousLabel: String,
@@ -565,7 +575,9 @@ export default {
             filters: {},
             defaultSlots: [],
             firstTimeSort: true, // Used by first time initSort
-            _isTable: true // Used by TableColumn
+            _isTable: true, // Used by TableColumn
+            isDraggingRow: false,
+            isDraggingColumn: false
         }
     },
     computed: {
@@ -728,6 +740,12 @@ export default {
                     vnode.componentInstance.$data &&
                     vnode.componentInstance.$data._isTableColumn)
                 .map((vnode) => vnode.componentInstance)
+        },
+        canDragRow() {
+            return this.draggable && !this.isDraggingColumn
+        },
+        canDragColumn() {
+            return this.draggableColumn && !this.isDraggingRow
         }
     },
     watch: {
@@ -1281,43 +1299,87 @@ export default {
             }
         },
         /**
-        * Emits drag start event
+        * Emits drag start event (row)
         */
         handleDragStart(event, row, index) {
-            if (!this.draggable) return
+            if (!this.canDragRow) return
+            this.isDraggingRow = true
             this.$emit('dragstart', {event, row, index})
         },
         /**
-        * Emits drag leave event
+        * Emits drag leave event (row)
         */
         handleDragEnd(event, row, index) {
-            if (!this.draggable) return
+            if (!this.canDragRow) return
+            this.isDraggingRow = false
             this.$emit('dragend', {event, row, index})
         },
         /**
-        * Emits drop event
+        * Emits drop event (row)
         */
         handleDrop(event, row, index) {
-            if (!this.draggable) return
+            if (!this.canDragRow) return
             this.$emit('drop', {event, row, index})
         },
         /**
-        * Emits drag over event
+        * Emits drag over event (row)
         */
         handleDragOver(event, row, index) {
-            if (!this.draggable) return
+            if (!this.canDragRow) return
             this.$emit('dragover', {event, row, index})
         },
         /**
-        * Emits drag leave event
+        * Emits drag leave event (row)
         */
         handleDragLeave(event, row, index) {
-            if (!this.draggable) return
+            if (!this.canDragRow) return
             this.$emit('dragleave', {event, row, index})
         },
 
         emitEventForRow(eventName, event, row) {
             return this.$listeners[eventName] ? this.$emit(eventName, row, event) : null
+        },
+
+        /**
+        * Emits drag start event (column)
+        */
+        handleColumnDragStart(event, column, index) {
+            if (!this.canDragColumn) return
+            this.isDraggingColumn = true
+            this.$emit('columndragstart', {event, column, index})
+        },
+
+        /**
+        * Emits drag leave event (column)
+        */
+        handleColumnDragEnd(event, column, index) {
+            if (!this.canDragColumn) return
+            this.isDraggingColumn = false
+            this.$emit('columndragend', {event, column, index})
+        },
+
+        /**
+        * Emits drop event (column)
+        */
+        handleColumnDrop(event, column, index) {
+            if (!this.canDragColumn) return
+            this.$emit('columndrop', {event, column, index})
+        },
+
+        /**
+        * Emits drag over event (column)
+        */
+        handleColumnDragOver(event, column, index) {
+            if (!this.canDragColumn) return
+            this.$emit('columndragover', {event, column, index})
+        },
+
+        /**
+        * Emits drag leave event (column)
+        */
+        handleColumnDragLeave(event, column, index) {
+            if (!this.canDragColumn) return
+            this.$emit('columndragleave', {event, column, index})
         },
 
         refreshSlots() {


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #2569
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Adding a new prop `draggable-column` to allow column drag&drop
- Keep internal state dragging entity (row or column) to avoid dropping rows into columns and vice versa. 


![screen-capture](https://user-images.githubusercontent.com/5289520/106407118-331db400-6409-11eb-8c6c-9b9e521ea9e5.gif)


