### PR TITLE
added '@' to events ([any].native) for clarification

### DIFF
--- a/docs/pages/components/checkbox/api/checkbox.js
+++ b/docs/pages/components/checkbox/api/checkbox.js
@@ -84,7 +84,7 @@ export default [
             },
             {
                 name: '<code>[any].native</code>',
-                description: 'Listen to any event using this syntax, e.g <code>click.native</code>',
+                description: 'Listen to any event using this syntax, e.g <code>@click.native</code>',
                 parameters: '<code>event: $event</code>'
             }
         ]


### PR DESCRIPTION
As mentioned in [this](https://github.com/buefy/buefy/issues/1818#issuecomment-538619362) by @jtommy I was able to call a native event. 

Before I tried it like it's mentioned in the documentation but it didn't work without the '@' that's why I'd mention `@click.native` explicitly. If this wasn't the case and an error on my side let me know, although I'd still add some explanation.

<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

-  add `@` to `click.native` so that it's clear 
