### PR TITLE
Split ConfigComponent into a dedicated entry

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -30,6 +30,7 @@ const components = fs
 const entries = {
     'index': './src/index.js',
     'helpers': './src/utils/helpers.js',
+    'config': './src/utils/ConfigComponent.js',
     ...components.reduce((obj, name) => {
         obj[name] = (baseFolder + componentsFolder + name)
         return obj


### PR DESCRIPTION
Previously, ConfigComponent would be inlined into index.js, causing it to capture every component imported above. This meant that importing ConfigComponent/ConfigProgrammatic would break tree shaking.

<!-- Thank you for helping Buefy! -->

Fixes #3124 
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Add a new entry to rollup.config.js
- Restore tree shaking 🙌 