### PR TITLE
Improve usage example of Carousel List with Card

### DIFF
--- a/docs/pages/components/carousel/examples/ExWithCard.vue
+++ b/docs/pages/components/carousel/examples/ExWithCard.vue
@@ -1,7 +1,7 @@
 <template>
     <b-carousel-list v-model="test" :data="items" :items-to-show="2">
         <template #item="list">
-            <div class="card">
+            <b-carousel-list-item class="card">
                 <div class="card-image">
                     <figure class="image is-5by4">
                         <a @click="info(list.index)"><img :src="list.image"></a>
@@ -22,7 +22,7 @@
                         </b-field>
                     </div>
                 </div>
-            </div>
+            </b-carousel-list-item>
         </template>
     </b-carousel-list>
 </template>


### PR DESCRIPTION
## Issue
When using a Carousel List with a custom template that fills the `item` slot, we were running into rendering issues where the product title on our card did not correspond with the image.

## Proposed Changes
Wrap contents of `template` with `b-carousel-list-item` component.
