### PR TITLE
Fix tooltip blinking in table with sticky header

### DIFF
--- a/src/scss/components/_table.scss
+++ b/src/scss/components/_table.scss
@@ -261,7 +261,7 @@ $table-sticky-header-height: 300px !default;
                     position: -webkit-sticky;
                     position: sticky;
                     top: 0;
-                    z-index: 2;
+                    z-index: 200;
                     background: $table-background-color;
                 }
             }


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Set `z-index: 200` for: ` .b-table .table-wrapper.has-sticky-header tr:first-child th`

This removes tooltip blinking when using b-table with sticky-header prop.

