### PR TITLE
focusedDate & maxDate are wrongly compared

### DIFF
--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -448,7 +448,7 @@ export default {
         const focusedDate = (Array.isArray(this.value) ? this.value[0] : (this.value)) ||
             this.focusedDate || this.dateCreator()
 
-        if (!this.value && this.maxDate && this.maxDate.getFullYear() < new Date().getFullYear()) {
+        if (!this.value && this.maxDate && this.maxDate.getFullYear() < focusedDate.getFullYear()) {
             focusedDate.setFullYear(this.maxDate.getFullYear())
         }
 


### PR DESCRIPTION
`maxDate` is compared to `new Date().getFullYear()` to then set `focusedDate`. It should be compared to `focusedDate.getFullYear()`.
