### PR TITLE
Improve taginput usage with maxtags == 1

### DIFF
--- a/src/components/taginput/Taginput.vue
+++ b/src/components/taginput/Taginput.vue
@@ -231,7 +231,7 @@ export default {
          * Show the input field if a maxtags hasn't been set or reached.
          */
         hasInput() {
-            return this.maxtags == null || this.tagsLength < this.maxtags
+            return this.maxtags == null || this.maxtags === 1 || this.tagsLength < this.maxtags
         },
 
         tagsLength() {
@@ -281,6 +281,9 @@ export default {
                 // or previously added (if not allowDuplicates).
                 const add = !this.allowDuplicates ? this.tags.indexOf(tagToAdd) === -1 : true
                 if (add && this.beforeAdding(tagToAdd)) {
+                    if (this.maxtags === 1) {
+                        this.tags = [] // replace existing tag if only 1 is allowed
+                    }
                     this.tags.push(this.createTag(tagToAdd))
                     this.$emit('input', this.tags)
                     this.$emit('add', tagToAdd)


### PR DESCRIPTION
## Proposed Changes

This two little changes will improve the behaviour of the Taginput component in cases where `maxtags` is set to `1`:

- Show the input so the user knows that the field is editable
- Replace current tag when a user selects a tag. UX is comparable to a good old classic ´select´ where users don't have to remove their choice before they can select something else.

I didn't take a look at the tests yet, but I'd be happy to do so if you think this feature makes sense at all.