### PR TITLE
Add default option in constructor for Switch rounded prop

### DIFF
--- a/docs/pages/installation/api/constructor-options.js
+++ b/docs/pages/installation/api/constructor-options.js
@@ -333,6 +333,13 @@ export default [
                 default: '<code>false</code>'
             },
             {
+                name: '<code>defaultSwitchRounded</code>',
+                description: 'Default config to make all switch rounded.',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>true</code>'
+            },
+            {
                 name: '<code>defaultCarouselInterval</code>',
                 description: 'Default carousel <code>interval</code> attribute',
                 type: 'Number',

--- a/src/components/switch/Switch.vue
+++ b/src/components/switch/Switch.vue
@@ -29,6 +29,8 @@
 </template>
 
 <script>
+import config from '../../utils/config'
+
 export default {
     name: 'BSwitch',
     props: {
@@ -50,7 +52,9 @@ export default {
         },
         rounded: {
             type: Boolean,
-            default: true
+            default: () => {
+                return config.defaultSwitchRounded
+            }
         },
         outlined: {
             type: Boolean,

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -45,6 +45,7 @@ let config = {
     defaultTrapFocus: true,
     defaultAutoFocus: true,
     defaultButtonRounded: false,
+    defaultSwitchRounded: true,
     defaultCarouselInterval: 3500,
     defaultTabsExpanded: false,
     defaultTabsAnimated: true,

--- a/types/components.d.ts
+++ b/types/components.d.ts
@@ -53,6 +53,7 @@ export declare type BuefyConfig = {
     defaultClockpickerMinutesLabel?: string;
     defaultTrapFocus?: boolean;
     defaultButtonRounded?: boolean;
+    defaultSwitchRounded?: boolean;
     defaultCarouselInterval?: number;
     defaultTabsExpanded?: boolean;
     defaultTabsAnimated?: boolean;


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes N/A
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Add default option in constructor for Switch `rounded` prop
