### PR TITLE
Fix table details transition

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -295,13 +295,13 @@
                                     </div>
                                 </td>
                             </tr>
-                            <slot
-                                v-if="isActiveCustomDetailRow(row)"
-                                name="detail"
-                                :row="row"
-                                :index="index"
-                            />
                         </transition>
+                        <slot
+                            v-if="isActiveCustomDetailRow(row)"
+                            name="detail"
+                            :row="row"
+                            :index="index"
+                        />
                     </template>
 
                     <tr


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

## Proposed Changes

- Use transition only for simple details in table
  - Displays the following warning in the console when using transition with custom details
`[Vue warn]: <transition> can only be used on a single element. Use <transition-group> for lists.`
