### PR TITLE
Modify DialogProgrammatic to be able to recieve Number.

### DIFF
--- a/src/components/dialog/index.js
+++ b/src/components/dialog/index.js
@@ -38,6 +38,10 @@ const DialogProgrammatic = {
             params = {
                 message: params
             }
+        } else if (typeof params === 'number') {
+            params = {
+                message: params.toString()
+            }
         }
         const defaultParam = {
             canCancel: false


### PR DESCRIPTION
When I pass number as argument to DialogProgrammatic, it shows nothing.
It can confuse someone else.
So I change DialogProgrammatic to be able to recieve Number.
```
import { DialogProgrammatic as Dialog } from 'buefy';

Dialog.alert(1); // Nothing is shown.
Dialog.alert("1"); // 1 is shown
Dialog.alert((1).toString()); // 1 is shown
```

<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

-
-
-
