### PR TITLE
docs: add block for displaying empty table content

### DIFF
--- a/docs/pages/components/table/examples/ExSandbox.vue
+++ b/docs/pages/components/table/examples/ExSandbox.vue
@@ -63,6 +63,10 @@
                     {{ props.row.gender }}
                 </span>
             </b-table-column>
+            
+            <template #empty>
+                <div class="has-text-centered">No records</div>
+            </template>
 
         </b-table>
     </section>


### PR DESCRIPTION
## Proposed Changes

The [Sandbox with custom template](https://buefy.org/documentation/table/#sandbox-with-custom-template) example is missing the empty template. This adds a div that displays "no records" in the table when empty is checked.