### PR TITLE
Fixes #3247: Remove extraneous `a` element

### DIFF
--- a/src/components/tag/Tag.vue
+++ b/src/components/tag/Tag.vue
@@ -27,8 +27,8 @@
                 :type="closeIconType"
                 :pack="closeIconPack"
             />
-            <a/>
-    </a></div>
+        </a>
+    </div>
     <span
         v-else
         class="tag"


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #3247
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Remove extraneous `a` element
