### PR TITLE
Fix #2879: Open DatetimePicker using the enter key

### DIFF
--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -749,10 +749,11 @@ export default {
          */
         togglePicker(active) {
             if (this.$refs.dropdown) {
-                if (this.closeOnClick) {
-                    this.$refs.dropdown.isActive = typeof active === 'boolean'
-                        ? active
-                        : !this.$refs.dropdown.isActive
+                const isActive = (typeof active === 'boolean' && active) || !this.$refs.dropdown.isActive
+                if (isActive) {
+                    this.$refs.dropdown.isActive = isActive
+                } else if (this.closeOnClick) {
+                    this.$refs.dropdown.isActive = isActive
                 }
             }
         },


### PR DESCRIPTION
- Manage toggle as expected
- Datetimepicker can now be open using the enter key

<!-- Thank you for helping Buefy! -->

Fixes fix-2879
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- `closeOnClick` was preventing the opening instead of preventing closing
- Datetimepicker can now be open using the enter key
