### PR TITLE
fix: avoid selecting the first element on autocomplete mode (#3262)

### DIFF
--- a/src/components/taginput/Taginput.vue
+++ b/src/components/taginput/Taginput.vue
@@ -44,7 +44,6 @@
                 :autocomplete="nativeAutocomplete"
                 :open-on-focus="openOnFocus"
                 :keep-open="openOnFocus"
-                :keep-first="!allowNew"
                 :group-field="groupField"
                 :group-options="groupOptions"
                 :use-html5-validation="useHtml5Validation"


### PR DESCRIPTION
Fixes #3262

## Proposed Changes

- Remove `allowNew` dependency of `keep-first`