### PR TITLE
Add mouse click event to b-table row click

### DIFF
--- a/docs/pages/components/table/api/table.js
+++ b/docs/pages/components/table/api/table.js
@@ -462,7 +462,7 @@ export default [
             {
                 name: '<code>click</code>',
                 description: 'Triggers when a row is clicked',
-                parameters: '<code>row: Object</code>'
+                parameters: '<code>row: Object</code>, <code> event: Event </code>'
             },
             {
                 name: '<code>dblclick</code>',

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -210,7 +210,7 @@
                                 'is-selected': isRowSelected(row, selected),
                                 'is-checked': isRowChecked(row),
                             }]"
-                            @click="selectRow(row)"
+                            @click="selectRow(row,$event)"
                             @dblclick="$emit('dblclick', row)"
                             @mouseenter="emitEventForRow('mouseenter', $event, row)"
                             @mouseleave="emitEventForRow('mouseleave', $event, row)"
@@ -1067,8 +1067,8 @@ export default {
         * Row click listener.
         * Emit all necessary events.
         */
-        selectRow(row, index) {
-            this.$emit('click', row)
+        selectRow(row, event) {
+            this.$emit('click', {row, event})
 
             if (this.selected === row) return
             if (!this.isRowSelectable(row)) return


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

## Proposed Changes
-Simply add mouse click event to the b-table row click. This will allow users to create more powerful extensions such as multi select via ctrl or shift click. 

