### PR TITLE
Datepicker close-on-click prop in documentation.

### DIFF
--- a/docs/pages/components/datepicker/api/datepicker.js
+++ b/docs/pages/components/datepicker/api/datepicker.js
@@ -269,6 +269,13 @@ export default [
                 default: '<code>true</code>'
             },
             {
+                name: '<code>close-on-click</code>',
+                description: 'Choose whether the Datepicker should close after selecting a date',
+                type: 'Boolean',
+                values: '-',
+                default: '<code>true</code>'
+            },
+            {
                 name: '<code>append-to-body</code>',
                 description: 'Append datepicker calendar to body',
                 type: 'Boolean',


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

There are gaps in the documentation. The Datepicker component supports prop close-on-click but there is no such record in the documentation.
