### PR TITLE
Feature 3269 transition appear

### DIFF
--- a/docs/pages/components/steps/api/steps.js
+++ b/docs/pages/components/steps/api/steps.js
@@ -17,6 +17,13 @@ export default [
                 default: '<code>true</code>'
             },
             {
+                name: '<code>appear</code>',
+                description: 'Apply animation on the initial render',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>undefined</code>'
+            },
+            {
                 name: '<code>animation</code>',
                 description: 'Custom animation (transition name)',
                 type: 'String',

--- a/docs/pages/components/steps/api/steps.js
+++ b/docs/pages/components/steps/api/steps.js
@@ -17,7 +17,7 @@ export default [
                 default: '<code>true</code>'
             },
             {
-                name: '<code>appear</code>',
+                name: '<code>animateInitially</code>',
                 description: 'Apply animation on the initial render',
                 type: 'Boolean',
                 values: '—',

--- a/docs/pages/components/tabs/api/tabs.js
+++ b/docs/pages/components/tabs/api/tabs.js
@@ -24,6 +24,13 @@ export default [
                 default: '<code>true</code>'
             },
             {
+                name: '<code>appear</code>',
+                description: 'Apply animation on the initial render',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>undefined</code>'
+            },
+            {
                 name: '<code>animation</code>',
                 description: 'Custom animation (transition name)',
                 type: 'String',

--- a/docs/pages/components/tabs/api/tabs.js
+++ b/docs/pages/components/tabs/api/tabs.js
@@ -24,7 +24,7 @@ export default [
                 default: '<code>true</code>'
             },
             {
-                name: '<code>appear</code>',
+                name: '<code>animateInitially</code>',
                 description: 'Apply animation on the initial render',
                 type: 'Boolean',
                 values: '—',

--- a/src/utils/TabbedChildMixin.js
+++ b/src/utils/TabbedChildMixin.js
@@ -75,7 +75,7 @@ export default (parentCmp) => ({
             return createElement('transition', {
                 props: {
                     'name': this.parent.animation || this.transitionName,
-                    'appear': this.parent.appear === true || undefined
+                    'appear': this.parent.animateInitially === true || undefined
                 },
                 on: {
                     'before-enter': () => { this.parent.isTransitioning = true },

--- a/src/utils/TabbedChildMixin.js
+++ b/src/utils/TabbedChildMixin.js
@@ -74,7 +74,8 @@ export default (parentCmp) => ({
         if (this.parent.animated) {
             return createElement('transition', {
                 props: {
-                    'name': this.parent.animation || this.transitionName
+                    'name': this.parent.animation || this.transitionName,
+                    'appear': this.parent.appear === true || undefined
                 },
                 on: {
                     'before-enter': () => { this.parent.isTransitioning = true },

--- a/src/utils/TabbedMixin.js
+++ b/src/utils/TabbedMixin.js
@@ -20,6 +20,10 @@ export default (cmp) => ({
             default: true
         },
         animation: String,
+        appear: {
+            type: Boolean,
+            default: undefined
+        },
         vertical: {
             type: Boolean,
             default: false

--- a/src/utils/TabbedMixin.js
+++ b/src/utils/TabbedMixin.js
@@ -20,10 +20,7 @@ export default (cmp) => ({
             default: true
         },
         animation: String,
-        appear: {
-            type: Boolean,
-            default: undefined
-        },
+        animateInitially: Boolean,
         vertical: {
             type: Boolean,
             default: false


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #3269
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Add `appear` property to TabbedMixin to support Vue's [appear - ie. transition on initial render](https://vuejs.org/v2/guide/transitions.html#Transitions-on-Initial-Render) feature
- Allows these components to render initially when SSR
- Backwards compatible
