### PR TITLE
#3278 Fix weekdays off by one day

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -223,7 +223,6 @@ export function getMonthNames(locale = undefined, format = 'long') {
 /**
  * Return weekday names according to a specified locale
  * @param  {String} locale A bcp47 localerouter. undefined will use the user browser locale
- * @param  {Number} first day of week index
  * @param  {String} format long (ex. Thursday), short (ex. Thu) or narrow (T)
  * @return {Array<String>} An array of weekday names
  */

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -234,10 +234,7 @@ export function getWeekdayNames(locale = undefined, format = 'narrow') {
     for (let i = 0; i < 7; i++) {
         dates.push(new Date(dt.getFullYear(), dt.getMonth(), dt.getDate() + i))
     }
-    const dtf = new Intl.DateTimeFormat(locale, {
-        weekday: format,
-        timeZone: 'UTC'
-    })
+    const dtf = new Intl.DateTimeFormat(locale, { weekday: format })
     return dates.map((d) => dtf.format(d))
 }
 

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -228,11 +228,9 @@ export function getMonthNames(locale = undefined, format = 'long') {
  */
 export function getWeekdayNames(locale = undefined, format = 'narrow') {
     const dates = []
-    const dt = new Date(2000, 0, 1)
-    const dayOfWeek = dt.getDay()
-    dt.setDate(dt.getDate() - dayOfWeek)
     for (let i = 0; i < 7; i++) {
-        dates.push(new Date(dt.getFullYear(), dt.getMonth(), dt.getDate() + i))
+        const dt = new Date(2000, 0, i + 1)
+        dates[dt.getDay()] = dt
     }
     const dtf = new Intl.DateTimeFormat(locale, { weekday: format })
     return dates.map((d) => dtf.format(d))


### PR DESCRIPTION
Fixes #3278

## Proposed Changes
- Remove unecessary docstring for param `firstDayOfWeek` that was not used anymore
- Remove `timeZone` option DateTimeFormat, causing weekdays to be off by one when using a timezone with positive offset (UTC+1000, UTC+2000, ...)
- Simplify code
