### PR TITLE
docs: variables removed from select element's documentation

### DIFF
--- a/docs/pages/components/select/Select.vue
+++ b/docs/pages/components/select/Select.vue
@@ -9,13 +9,11 @@
         <Example :component="ExSizes" :code="ExSizesCode" title="Sizes" vertical/>
 
         <ApiView :data="api"/>
-        <VariablesView :data="variables"/>
     </div>
 </template>
 
 <script>
     import api from './api/select'
-    import variables from './variables/select'
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from '!!raw-loader!./examples/ExSimple'
@@ -33,7 +31,6 @@
         data() {
             return {
                 api,
-                variables,
                 ExSimple,
                 ExMultiple,
                 ExIcons,

--- a/docs/pages/components/select/variables/select.js
+++ b/docs/pages/components/select/variables/select.js
@@ -1,6 +1,0 @@
-export default [
-    {
-        name: '<code>$select-arrow-color</code>',
-        default: '<code>$primary</code>'
-    }
-]


### PR DESCRIPTION
## Proposed Changes

Only select variable was `$select-arrow-color` until Buefy version [0.9.2](https://github.com/buefy/buefy/releases/tag/v0.9.2) it's replaced with `input-arrow`. Since there are not customizable variables in either Buefy or Bulma, misleading variables section from documentation has been removed.
