### PR TITLE
Resolved issue 3329 by disabling autocompletion on b-table checkboxes

### DIFF
--- a/src/components/checkbox/Checkbox.vue
+++ b/src/components/checkbox/Checkbox.vue
@@ -12,6 +12,7 @@
             type="checkbox"
             ref="input"
             @click.stop
+            :autocomplete="autocomplete"
             :disabled="disabled"
             :required="required"
             :name="name"
@@ -38,6 +39,10 @@ export default {
         falseValue: {
             type: [String, Number, Boolean, Function, Object, Array],
             default: false
+        },
+        autocomplete: {
+            type: String,
+            default: 'on'
         }
     }
 }

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -59,6 +59,7 @@
                             v-if="checkable && checkboxPosition === 'left'">
                             <template v-if="headerCheckable">
                                 <b-checkbox
+                                    autocomplete="off"
                                     :value="isAllChecked"
                                     :disabled="isAllUncheckable"
                                     @change.native="checkAll"/>
@@ -140,6 +141,7 @@
                             v-if="checkable && checkboxPosition === 'right'">
                             <template v-if="headerCheckable">
                                 <b-checkbox
+                                    autocomplete="off"
                                     :value="isAllChecked"
                                     :disabled="isAllUncheckable"
                                     @change.native="checkAll"/>
@@ -248,6 +250,7 @@
                                 :class="['checkbox-cell', { 'is-sticky': stickyCheckbox } ]"
                                 v-if="checkable && checkboxPosition === 'left'">
                                 <b-checkbox
+                                    autocomplete="off"
                                     :disabled="!isRowCheckable(row)"
                                     :value="isRowChecked(row)"
                                     @click.native.prevent.stop="checkRow(row, index, $event)"
@@ -278,6 +281,7 @@
                                 :class="['checkbox-cell', { 'is-sticky': stickyCheckbox } ]"
                                 v-if="checkable && checkboxPosition === 'right'">
                                 <b-checkbox
+                                    autocomplete="off"
                                     :disabled="!isRowCheckable(row)"
                                     :value="isRowChecked(row)"
                                     @click.native.prevent.stop="checkRow(row, index, $event)"


### PR DESCRIPTION
Fixes #3329

## Proposed Changes

- I propose `Checkbox.vue` has an autocomplete prop which is, by default, [what it is in HTML -- on](https://www.w3schools.com/tags/att_input_autocomplete.asp), but can be manually overriden to `off`, if necessary.
- I propose `Table.vue` uses `autocomplete=off` so that back-navigation can operate as expected.

Thank you for considering!