### PR TITLE
Fix datepicker tab navigation with nearby-selectable-month-days property

### DIFF
--- a/src/components/checkbox/__snapshots__/Checkbox.spec.js.snap
+++ b/src/components/checkbox/__snapshots__/Checkbox.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BCheckbox render correctly 1`] = `<label class="b-checkbox checkbox"><input type="checkbox" true-value="true" value="false"> <span class="check"></span> <span class="control-label"></span></label>`;
+exports[`BCheckbox render correctly 1`] = `<label class="b-checkbox checkbox"><input type="checkbox" autocomplete="on" true-value="true" value="false"> <span class="check"></span> <span class="control-label"></span></label>`;

--- a/src/components/datepicker/DatepickerTableRow.vue
+++ b/src/components/datepicker/DatepickerTableRow.vue
@@ -20,7 +20,7 @@
                 @click.prevent="emitChosenDate(weekDay)"
                 @mouseenter="setRangeHoverEndDate(weekDay)"
                 @keydown="manageKeydown($event, weekDay)"
-                :tabindex="day === weekDay.getDate() ? null : -1">
+                :tabindex="day === weekDay.getDate() && month === weekDay.getMonth() ? null : -1">
                 <span>{{ weekDay.getDate() }}</span>
                 <div class="events" v-if="eventsDateMatch(weekDay)">
                     <div


### PR DESCRIPTION
Fix datepicker tab navigation with nearby-selectable-month-days property.
**Problem**: with property nearby-selectable-month-days you can navigate by Tab to the same day in different months.

<!-- Thank you for helping Buefy! -->

## Proposed Changes

- add check for a month
