### PR TITLE
Update b-table-column properties on documentation

### DIFF
--- a/docs/pages/components/table/api/table.js
+++ b/docs/pages/components/table/api/table.js
@@ -750,7 +750,7 @@ export default [
                 default: '-'
             },
             {
-                name: '<code>header-selectable</code>',
+                name: '<code>header-sortable</code>',
                 description: 'Whether the header text is selectable, works when column is <code>sortable</code>',
                 type: 'Boolean',
                 values: '—',


### PR DESCRIPTION
There are two `header-selectable` in the properties list. The last one should be `header-sortable`.

## Proposed Changes

- Fix the mistyping of header-sortable prop.