### PR TITLE
Update Sortable website link

### DIFF
--- a/docs/pages/extensions/sortablejs/Sortablejs.vue
+++ b/docs/pages/extensions/sortablejs/Sortablejs.vue
@@ -3,7 +3,7 @@
         <div class="buttons">
             <a
                 class="button"
-                href="https://sortablejs.github.io/sortablejs/"
+                href="https://sortablejs.github.io/Sortable/"
                 target="_blank">
                 Website
             </a>


### PR DESCRIPTION
The old link (https://sortablejs.github.io/sortablejs) gives a 404

Updated to a working link.
