### PR TITLE
Adding accessibility attributes to a couple components (dropdown and autocomplete)

### DIFF
--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -59,6 +59,8 @@
                             v-for="(option, index) in element.items"
                             :key="groupindex + ':' + index"
                             class="dropdown-item"
+                            role="button"
+                            tabindex="0"
                             :class="{ 'is-hovered': option === hovered }"
                             @click="setSelected(option, undefined, $event)"
                         >

--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -7,6 +7,7 @@
         <div
             v-if="!inline"
             role="button"
+            tabindex="0"
             ref="trigger"
             class="dropdown-trigger"
             @click="onClick"


### PR DESCRIPTION
Fixes #
These elements are being flagged by the accessibility scanner SortSite.

## Proposed Changes

- Adding button role and tab index to autocomplete's dropdown item to make it keyboard accessible
- Adding tabindex to the dropdown trigger. The div already has a role of button and the tab index will allow for it to be keyboard accessible.