### PR TITLE
These elements are being flagged by the accessibility scanner SortSite.

### DIFF
--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -59,6 +59,8 @@
                             v-for="(option, index) in element.items"
                             :key="groupindex + ':' + index"
                             class="dropdown-item"
+                            role="button"
+                            tabindex="0"
                             :class="{ 'is-hovered': option === hovered }"
                             @click="setSelected(option, undefined, $event)"
                         >

--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -7,6 +7,7 @@
         <div
             v-if="!inline"
             role="button"
+            tabindex="0"
             ref="trigger"
             class="dropdown-trigger"
             @click="onClick"

--- a/src/components/dropdown/__snapshots__/Dropdown.spec.js.snap
+++ b/src/components/dropdown/__snapshots__/Dropdown.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BDropdown render correctly 1`] = `
 <div class="dropdown dropdown-menu-animation is-mobile-modal">
-    <div role="button" aria-haspopup="true" class="dropdown-trigger"><button class="trigger">trigger</button></div>
+    <div role="button" tabindex="0" aria-haspopup="true" class="dropdown-trigger"><button class="trigger">trigger</button></div>
     <div aria-hidden="true" class="background" style="display: none;" name="fade"></div>
     <div aria-hidden="true" class="dropdown-menu" style="display: none;" name="fade">
         <div class="dropdown-content"></div>


### PR DESCRIPTION
Fixes #
These elements are being flagged by the accessibility scanner SortSite.

Proposed Changes

Adding button role and tab index to autocomplete's dropdown item to make it keyboard accessible
Adding tab index to the dropdown trigger. The div already has a role of a button and the tab index will allow for it to be keyboard accessible.