### PR TITLE
Added a delay prop to sidebar to expand with delay

### DIFF
--- a/docs/pages/components/sidebar/api/sidebar.js
+++ b/docs/pages/components/sidebar/api/sidebar.js
@@ -104,6 +104,13 @@ export default [
                 values: '<code>clip</code>, <code>keep</code>',
                 default: '<code>clip</code>'
             },
+            {
+                name: '<code>delay</code>',
+                description: 'Sidebar delay before it open (number in ms)',
+                type: 'Number',
+                values: "—",
+                default: '<code>0</code>'
+            }
       ],
       slots: [
           {

--- a/docs/pages/components/sidebar/examples/ExStatic.vue
+++ b/docs/pages/components/sidebar/examples/ExStatic.vue
@@ -6,6 +6,7 @@
                 :mobile="mobile"
                 :expand-on-hover="expandOnHover"
                 :reduce="reduce"
+                :delay="expandWithDelay ? 500 : null"
                 type="is-light"
                 open
             >
@@ -46,6 +47,9 @@
                 <b-field>
                     <b-switch v-model="expandOnHover">Expand on hover</b-switch>
                 </b-field>
+                <b-field>
+                    <b-switch v-model="expandWithDelay">Hover with delay</b-switch>
+                </b-field>
                 <b-field label="Mobile Layout">
                     <b-select v-model="mobile">
                         <option :value="null"></option>
@@ -64,6 +68,7 @@ export default {
   data() {
     return {
       expandOnHover: false,
+      expandWithDelay: false,
       mobile: "reduce",
       reduce: false
     };
@@ -93,7 +98,7 @@ export default {
         .sidebar-content {
             &.is-mini-mobile {
                 &:not(.is-mini-expand),
-                &.is-mini-expand:not(:hover) {
+                &.is-mini-expand:not(:hover):not(.is-mini-delayed) {
                     .menu-list {
                         li {
                             a {
@@ -124,7 +129,7 @@ export default {
         .sidebar-content {
             &.is-mini {
                 &:not(.is-mini-expand),
-                &.is-mini-expand:not(:hover) {
+                &.is-mini-expand:not(:hover):not(.is-mini-delayed) {
                     .menu-list {
                         li {
                             a {

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -12,7 +12,9 @@
                 v-show="isOpen"
                 ref="sidebarContent"
                 class="sidebar-content"
-                :class="rootClasses">
+                :class="rootClasses"
+                @mouseenter="onHover"
+                @mouseleave="onHoverLeave">
                 <slot />
             </div>
         </transition>
@@ -54,6 +56,10 @@ export default {
         reduce: Boolean,
         expandOnHover: Boolean,
         expandOnHoverFixed: Boolean,
+        delay: {
+            type: Number,
+            default: () => config.defaultSidebarDelay
+        },
         canCancel: {
             type: [Array, Boolean],
             default: () => ['escape', 'outside']
@@ -80,6 +86,7 @@ export default {
     data() {
         return {
             isOpen: this.open,
+            isDelayOver: false,
             transitionName: null,
             animating: true,
             savedScrollTop: null
@@ -94,9 +101,10 @@ export default {
                 'is-fullheight': this.fullheight,
                 'is-fullwidth': this.fullwidth,
                 'is-right': this.right,
-                'is-mini': this.reduce,
-                'is-mini-expand': this.expandOnHover,
-                'is-mini-expand-fixed': this.expandOnHover && this.expandOnHoverFixed,
+                'is-mini': this.reduce && !this.isDelayOver,
+                'is-mini-expand': this.expandOnHover || this.isDelayOver,
+                'is-mini-expand-fixed': (this.expandOnHover && this.expandOnHoverFixed) || this.isDelayOver,
+                'is-mini-delayed': this.delay !== null,
                 'is-mini-mobile': this.mobile === 'reduce',
                 'is-hidden-mobile': this.mobile === 'hide',
                 'is-fullwidth-mobile': this.mobile === 'fullwidth'
@@ -237,6 +245,19 @@ export default {
             document.documentElement.scrollTop = this.savedScrollTop
             document.body.style.top = null
             this.savedScrollTop = null
+        },
+        onHover() {
+            if (this.delay) {
+                this.timer = setTimeout(() => {
+                    this.isDelayOver = true
+                    this.timer = null
+                }, this.delay)
+            } else {
+                this.isDelayOver = false
+            }
+        },
+        onHoverLeave() {
+            this.isDelayOver = false
         }
     },
     created() {

--- a/src/scss/components/_sidebar.scss
+++ b/src/scss/components/_sidebar.scss
@@ -37,7 +37,7 @@ $sidebar-colors: $navbar-colors !default;
         }
         &.is-mini {
             width: $sidebar-mobile-width;
-            &.is-mini-expand:hover {
+            &.is-mini-expand:hover:not(.is-mini-delayed) {
                 transition: width $speed-slow $easing;
                 &:not(.is-fullwidth) {
                     width: $sidebar-width;

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -15,6 +15,7 @@ let config = {
     defaultNotificationPosition: null,
     defaultTooltipType: 'is-primary',
     defaultTooltipDelay: null,
+    defaultSidebarDelay: null,
     defaultInputAutocomplete: 'on',
     defaultDateFormatter: null,
     defaultDateParser: null,

--- a/types/components.d.ts
+++ b/types/components.d.ts
@@ -25,6 +25,7 @@ export declare type BuefyConfig = {
     defaultTooltipType?: ColorModifiers;
     defaultTooltipAnimated?: boolean;
     defaultTooltipDelay?: number;
+    defaultSidebarDelay?: number,
     defaultInputAutocomplete?: string;
     defaultDateFormatter?: Function;
     defaultDateParser?: Function;


### PR DESCRIPTION
## Proposed Changes

- To avoid the user to open the sidebar when he doesn't want to, i added a `delay` prop to the sidebar component.
Like the tooltip delay prop put a value in ms, it works only on reduced mode and doesn't need to enable "Expand on hover"

Preview: 
![delaySidebar](https://user-images.githubusercontent.com/4800833/122037531-f27d7080-cdd4-11eb-8e86-e33001625539.gif)

