### PR TITLE
Programmatically notification fade on timeout.

### DIFF
--- a/src/components/notification/NotificationNotice.vue
+++ b/src/components/notification/NotificationNotice.vue
@@ -1,6 +1,7 @@
 <template>
     <b-notification
         v-bind="$options.propsData"
+        ref="notification"
         @close="close">
         <slot />
     </b-notification>
@@ -16,6 +17,11 @@ export default {
     data() {
         return {
             newDuration: this.duration || config.defaultNotificationDuration
+        }
+    },
+    methods: {
+        timeoutCallback() {
+            return this.$refs.notification.close()
         }
     }
 }

--- a/src/utils/NoticeMixin.js
+++ b/src/utils/NoticeMixin.js
@@ -100,6 +100,10 @@ export default {
             }, 150)
         },
 
+        timeoutCallback() {
+            return this.close()
+        },
+
         showNotice() {
             if (this.shouldQueue()) {
                 // Call recursively if should queue
@@ -110,7 +114,7 @@ export default {
             this.isActive = true
 
             if (!this.indefinite) {
-                this.timer = setTimeout(() => this.close(), this.newDuration)
+                this.timer = setTimeout(() => this.timeoutCallback(), this.newDuration)
             }
         },
 


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #3366
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- NoticeMixin provide a `timeoutCallback()` to set `this.timer`
- NotificationNotice override `timeoutCallback()` to call `b-notification.close()`

