### PR TITLE
Fix arrow order in the expandable menu item example

### DIFF
--- a/docs/pages/components/menu/examples/ExSimple.vue
+++ b/docs/pages/components/menu/examples/ExSimple.vue
@@ -5,7 +5,7 @@
       <b-menu-item icon="settings" :active="isActive" expanded>
         <template #label="props">
           Administrator
-          <b-icon class="is-pulled-right" :icon="props.expanded ? 'menu-down' : 'menu-up'"></b-icon>
+          <b-icon class="is-pulled-right" :icon="props.expanded ? 'menu-up' : 'menu-down'"></b-icon>
         </template>
         <b-menu-item icon="account" label="Users"></b-menu-item>
         <b-menu-item icon="cellphone-link">


### PR DESCRIPTION
## Proposed Changes

- The up and down arrows in the expandable menu item example were reversed, this PR fixes the order.
