### PR TITLE
🚸 Add clickable right icons for datepicker and datetimepicker

### DIFF
--- a/docs/pages/components/datepicker/api/datepicker.js
+++ b/docs/pages/components/datepicker/api/datepicker.js
@@ -100,6 +100,20 @@ export default [
                 default: '—'
             },
             {
+                name: '<code>icon-right</code>',
+                description: 'Icon name to be added on the right side',
+                type: 'String',
+                values: '—',
+                default: '—'
+            },
+            {
+                name: '<code>icon-right-clickable</code>',
+                description: 'Make the right icon clickable',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
                 name: '<code>icon-pack</code>',
                 description: 'Icon pack to use',
                 type: 'String',
@@ -326,6 +340,11 @@ export default [
                 name: '<code>input</code>',
                 description: 'Triggers when the value of datepicker is changed',
                 parameters: '<code>value: Date</code>'
+            },
+            {
+                name: '<code>icon-right-click</code>',
+                description: 'Triggers when the right icon is clickable and has been clicked',
+                parameters: '<code>event: $event</code>'
             },
             {
                 name: '<code>change-month</code>',

--- a/docs/pages/components/datepicker/examples/ExSimple.vue
+++ b/docs/pages/components/datepicker/examples/ExSimple.vue
@@ -31,6 +31,9 @@
                 :locale="locale"
                 placeholder="Click to select..."
                 icon="calendar-today"
+                :icon-right="selected ? 'close-circle' : ''"
+                icon-right-clickable
+                @icon-right-click="clearDate"
                 trap-focus>
             </b-datepicker>
         </b-field>
@@ -44,6 +47,11 @@ export default {
             selected: new Date(),
             showWeekNumber: false,
             locale: undefined // Browser locale
+        }
+    },
+    methods: {
+        clearDate () {
+            this.selected = null
         }
     }
 }

--- a/docs/pages/components/datetimepicker/api/datetimepicker.js
+++ b/docs/pages/components/datetimepicker/api/datetimepicker.js
@@ -72,6 +72,20 @@ export default [
                 default: '—'
             },
             {
+                name: '<code>icon-right</code>',
+                description: 'Icon name to be added on the right side',
+                type: 'String',
+                values: '—',
+                default: '—'
+            },
+            {
+                name: '<code>icon-right-clickable</code>',
+                description: 'Make the right icon clickable',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
                 name: '<code>icon-pack</code>',
                 description: 'Icon pack to use',
                 type: 'String',
@@ -163,6 +177,11 @@ export default [
             }
         ],
         events: [
+            {
+                name: '<code>icon-right-click</code>',
+                description: 'Triggers when the right icon is clickable and has been clicked',
+                parameters: '<code>event: $event</code>'
+            },
             {
                 name: '<code>change-month</code>',
                 description: 'Triggers when calendar month is changed',

--- a/docs/pages/components/datetimepicker/examples/ExSimple.vue
+++ b/docs/pages/components/datetimepicker/examples/ExSimple.vue
@@ -35,9 +35,13 @@
         </b-field>
         <b-field label="Select datetime">
             <b-datetimepicker
+                v-model="selected"
                 rounded
                 placeholder="Click to select..."
                 icon="calendar-today"
+                :icon-right="selected ? 'close-circle' : ''"
+                icon-right-clickable
+                @icon-right-click="clearDateTime"
                 :locale="locale"
                 :datepicker="{ showWeekNumber }"
                 :timepicker="{ enableSeconds, hourFormat }"
@@ -51,10 +55,16 @@
 export default {
     data() {
         return {
+            selected: new Date(),
             showWeekNumber: false,
             enableSeconds: false,
             hourFormat: undefined, // Browser locale
             locale: undefined // Browser locale
+        }
+    },
+    methods: {
+        clearDateTime () {
+            this.selected = null
         }
     }
 }

--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -26,6 +26,7 @@
                         :size="size"
                         :icon="icon"
                         :icon-right="iconRight"
+                        :icon-right-clickable="iconRightClickable"
                         :icon-pack="iconPack"
                         :rounded="rounded"
                         :loading="loading"
@@ -34,6 +35,7 @@
                         v-bind="$attrs"
                         :use-html5-validation="false"
                         @click.native="onInputClick"
+                        @icon-right-click="$emit('icon-right-click')"
                         @keyup.native.enter="togglePicker(true)"
                         @change.native="onChange($event.target.value)"
                         @focus="handleOnFocus" />
@@ -370,6 +372,7 @@ export default {
         },
         position: String,
         iconRight: String,
+        iconRightClickable: Boolean,
         events: Array,
         indicators: {
             type: String,

--- a/src/components/datetimepicker/Datetimepicker.vue
+++ b/src/components/datetimepicker/Datetimepicker.vue
@@ -17,6 +17,8 @@
         :min-date="minDate"
         :max-date="maxDate"
         :icon="icon"
+        :icon-right="iconRight"
+        :icon-right-clickable="iconRightClickable"
         :icon-pack="iconPack"
         :size="datepickerSize"
         :placeholder="placeholder"
@@ -29,6 +31,7 @@
         :append-to-body="appendToBody"
         @focus="onFocus"
         @blur="onBlur"
+        @icon-right-click="$emit('icon-right-click')"
         @change-month="$emit('change-month', $event)"
         @change-year="$emit('change-year', $event)">
         <nav class="level is-mobile">
@@ -113,6 +116,8 @@ export default {
         horizontalTimePicker: Boolean,
         disabled: Boolean,
         icon: String,
+        iconRight: String,
+        iconRightClickable: Boolean,
         iconPack: String,
         inline: Boolean,
         openOnFocus: Boolean,


### PR DESCRIPTION
## Proposed Changes

- Pass right icon props for date and datetime picker to internal input component
- Emit right icon click event from date and datetime picker
- Update examples with a "clear input when it has a value" right-side button
- Update API docs
