### PR TITLE
Avoid error when trying to read property of undefined

### DIFF
--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -740,7 +740,8 @@ export default {
             const currentDate = Array.isArray(value)
                 ? (!value.length ? this.dateCreator() : value[value.length - 1])
                 : (!value ? this.dateCreator() : value)
-            if (Array.isArray(value) && value.length > this.dateSelected.length) {
+            if (Array.isArray(value) &&
+                this.dateSelected && value.length > this.dateSelected.length) {
                 this.focusedDateData = {
                     day: currentDate.getDate(),
                     month: currentDate.getMonth(),


### PR DESCRIPTION
## Proposed Fix
If the `dateSelected` is not set for a Datepicker with range selection, trying to select any date will cause a JS error (`this.dateSelected.length`). This PR fixes that and `focusedDateData` will not get changed when `dateSelected` is not present.

