### PR TITLE
Autocomplete enhancements and fixes for accessibility

### DIFF
--- a/docs/pages/components/autocomplete/Autocomplete.vue
+++ b/docs/pages/components/autocomplete/Autocomplete.vue
@@ -23,7 +23,17 @@
             </div>
             <p>You can show options by groups</p>
         </Example>
-
+        
+        <Example :component="ExKeepFirst" :code="ExKeepFirstCode" title="Keep First">
+            <div class="tags has-addons">
+                <span class="tag is-success">Since</span>
+                <span class="tag is-info">0.9.9</span>
+            </div>
+            <p>You can select the first option when pressing enter or tab with <code>keep-first</code>.</p>
+            <p>Additionally, use <code>select-on-click-outside</code> to automatically select the first element when clicking outside of
+                the <code>input</code> element.</p>
+        </Example>
+        
         <Example :component="ExCustomAsync" :code="ExCustomAsyncCode" title="Async with custom template">
             <p>You can have a custom template by adding a scoped slot to it.</p>
             <p><small>API from <a href="https://www.themoviedb.org" target="_blank">TMDb</a></small>.</p>
@@ -63,6 +73,9 @@
 
     import ExInfiniteScroll from './examples/ExInfiniteScroll'
     import ExInfiniteScrollCode from '!!raw-loader!./examples/ExInfiniteScroll'
+    
+    import ExKeepFirst from './examples/ExKeepFirst'
+    import ExKeepFirstCode from '!!raw-loader!./examples/ExKeepFirst'
 
     export default {
         data() {
@@ -82,7 +95,9 @@
                 ExInfiniteScroll,
                 ExInfiniteScrollCode,
                 ExGroups,
-                ExGroupsCode
+                ExGroupsCode,
+                ExKeepFirst,
+                ExKeepFirstCode
             }
         }
     }

--- a/docs/pages/components/autocomplete/api/autocomplete.js
+++ b/docs/pages/components/autocomplete/api/autocomplete.js
@@ -156,13 +156,6 @@ export default [
                 default: '<code>false</code>'
             },
             {
-                name: '<code>native-search</code>',
-                description: 'Sets the native HTML input element\'s <code>type</code> to search instead of text',
-                type: 'Boolean',
-                values: '—',
-                default: '<code>false</code>'
-            },
-            {
                 name: '<code>select-on-click-outside</code>',
                 description: 'Trigger the <code>@select</code> event for the first pre-selected option when clicking outside and <code>keep-first</code> is enabled',
                 type: 'Boolean',

--- a/docs/pages/components/autocomplete/api/autocomplete.js
+++ b/docs/pages/components/autocomplete/api/autocomplete.js
@@ -156,6 +156,20 @@ export default [
                 default: '<code>false</code>'
             },
             {
+                name: '<code>native-search</code>',
+                description: 'Sets the native HTML input element\'s <code>type</code> to search instead of text',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
+                name: '<code>select-on-click-outside</code>',
+                description: 'Trigger the <code>@select</code> event for the first pre-selected option when clicking outside and <code>keep-first</code> is enabled',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
                 name: 'Any native attribute',
                 description: '—',
                 type: '—',

--- a/docs/pages/components/autocomplete/examples/ExKeepFirst.vue
+++ b/docs/pages/components/autocomplete/examples/ExKeepFirst.vue
@@ -1,0 +1,55 @@
+<template>
+    <section>
+        <b-field grouped group-multiline>
+            <div class="control">
+                <b-switch v-model="selectOutside">
+                    Select On Clicking Outside
+                </b-switch>
+            </div>
+        </b-field>
+        <p class="content"><b>Selected:</b> {{ selected }}</p>
+        <b-field label="Find a fruit and press Enter or Tab to select">
+            <b-autocomplete
+                v-model="name"
+                ref="autocomplete"
+                :data="filteredDataArray"
+                :select-on-click-outside="selectOutside"
+                placeholder="e.g. Orange"
+                keep-first
+                @select="option => selected = option">
+                <template #empty>No results for {{name}}</template>
+            </b-autocomplete>
+        </b-field>
+    </section>
+</template>
+
+<script>
+export default {
+    data() {
+        return {
+            data: [
+                'Orange',
+                'Apple',
+                'Banana',
+                'Pear',
+                'Lemon',
+                'Strawberry',
+                'Kiwi'
+            ],
+            name: '',
+            selected: null,
+            selectOutside: false
+        }
+    },
+    computed: {
+        filteredDataArray() {
+            return this.data.filter((option) => {
+                return option
+                    .toString()
+                    .toLowerCase()
+                    .indexOf(this.name.toLowerCase()) >= 0
+            })
+        }
+    }
+}
+</script>

--- a/src/components/autocomplete/Autocomplete.spec.js
+++ b/src/components/autocomplete/Autocomplete.spec.js
@@ -128,7 +128,7 @@ describe('BAutocomplete', () => {
         wrapper.vm.isActive = true
         expect($dropdown.isVisible()).toBeTruthy()
 
-        $input.trigger('keyup.esc')
+        $input.trigger('keydown', {'key': 'Escape'})
 
         expect($dropdown.isVisible()).toBeFalsy()
 

--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -387,19 +387,13 @@ export default {
         },
 
         keydown(event) {
-            const { key, which } = event // cannot destructure preventDefault (https://stackoverflow.com/a/49616808/2774496)
-
-            // Use Keycodes to detect input as it can cause adverse effects
-            // with other Keyboard layouts
-            // see https://css-tricks.com/snippets/javascript/javascript-keycodes/
-            // see also https://unixpapa.com/js/key.html
-            // test keycodes with https://www.w3.org/2002/09/tests/keys.html
+            const { key } = event // cannot destructure preventDefault (https://stackoverflow.com/a/49616808/2774496)
 
             // prevent emit submit event
-            if (which === 13 || key === 'Enter') event.preventDefault()
+            if (key === 'Enter') event.preventDefault()
 
             // Close dropdown on Tab & no hovered
-            if (which === 9 || which === 27 || key === 'Escape' || key === 'Tab') {
+            if (key === 'Escape' || key === 'Tab') {
                 event.preventDefault()
                 this.isActive = false
             }
@@ -409,7 +403,7 @@ export default {
                 if (key === ',') event.preventDefault()
 
                 // Close dropdown on select by Tab
-                const closeDropdown = !this.keepOpen || which === 9
+                const closeDropdown = !this.keepOpen || key === 'Tab'
                 this.setSelected(this.hovered, closeDropdown, event)
             }
         },

--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -396,11 +396,12 @@ export default {
             // test keycodes with https://www.w3.org/2002/09/tests/keys.html
 
             // prevent emit submit event
-            if (which === 13) event.preventDefault()
+            if (which === 13 || key === 'Enter') event.preventDefault()
+
             // Close dropdown on Tab & no hovered
-            if (which === 9 || which === 27) {
-                this.isActive = false
+            if (which === 9 || which === 27 || key === 'Escape' || key === 'Tab') {
                 event.preventDefault()
+                this.isActive = false
             }
             if (this.hovered === null) return
             if (this.confirmKeys.indexOf(key) >= 0) {

--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -3,7 +3,7 @@
         <b-input
             v-model="newValue"
             ref="input"
-            :type="newType"
+            :type="type"
             :size="size"
             :loading="loading"
             :rounded="rounded"
@@ -115,7 +115,6 @@ export default {
             type: String,
             default: 'value'
         },
-        nativeSearch: Boolean,
         keepFirst: Boolean,
         clearOnSelect: Boolean,
         openOnFocus: Boolean,
@@ -134,6 +133,10 @@ export default {
         iconRight: String,
         iconRightClickable: Boolean,
         appendToBody: Boolean,
+        type: {
+            type: String,
+            default: 'text'
+        },
         confirmKeys: {
             type: Array,
             default: () => ['Tab', 'Enter']
@@ -147,7 +150,6 @@ export default {
             newValue: this.value,
             newAutocomplete: this.autocomplete || 'off',
             ariaAutocomplete: this.keepFirst ? 'both' : 'list',
-            newType: this.nativeSearch ? 'search' : 'text',
             isListInViewportVertically: true,
             hasFocus: false,
             style: {},
@@ -308,6 +310,12 @@ export default {
             this.$emit('input', value)
             // Check if selected is invalid
             const currentValue = this.getValue(this.selected)
+
+            // Fixes #3185
+            if (!currentValue) {
+                this.setSelected(null, false)
+            }
+
             if (currentValue && currentValue !== value) {
                 this.setSelected(null, false)
             }

--- a/src/components/autocomplete/__snapshots__/Autocomplete.spec.js.snap
+++ b/src/components/autocomplete/__snapshots__/Autocomplete.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BAutocomplete render correctly 1`] = `
 <div class="autocomplete control">
-    <div class="control is-clearfix"><input type="text" autocomplete="off" class="input">
+    <div class="control is-clearfix"><input type="text" autocomplete="off" aria-autocomplete="list" class="input">
         <!---->
         <!---->
         <!---->

--- a/src/components/taginput/__snapshots__/Taginput.spec.js.snap
+++ b/src/components/taginput/__snapshots__/Taginput.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`BTaginput render correctly 1`] = `
 <div class="taginput control">
     <div class="taginput-container is-focusable">
-        <b-autocomplete-stub usehtml5validation="true" statusicon="true" value="" data="" field="value" dropdownposition="auto" confirmkeys=",,Tab,Enter"></b-autocomplete-stub>
+        <b-autocomplete-stub usehtml5validation="true" statusicon="true" value="" data="" field="value" dropdownposition="auto" type="text" confirmkeys=",,Tab,Enter"></b-autocomplete-stub>
     </div>
     <!---->
 </div>


### PR DESCRIPTION
# Autocomplete
## Bug Fixes
- Fixed Bug when pressing esc which briefly toggled/expanded the suggestion list
- Moved esc input event from key up to key down
- Use of keycodes to detect esc, tab and enter keys
## Accesibility
- Add aria-autocomplete to the input element as "list" or "both" depending if keep-first is enabled or not
- Add native-search prop which changes the input element's type to "search" or "text"

# Documentation
## Autocomplete
- Added example of Keep First and select on clicking outside

<!-- Thank you for helping Buefy! -->

# Fixes
Fixes #3357 

## Proposed Changes
It is all on my changelog above