### PR TITLE
fix combination of filters with custom searches

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -1165,7 +1165,7 @@ export default {
                 const input = this.filters[key]
                 const column = this.newColumns.filter((c) => c.field === key)[0]
                 if (column && column.customSearch && typeof column.customSearch === 'function') {
-                    return column.customSearch(row, input)
+                    if (!column.customSearch(row, input)) return false
                 } else {
                     let value = this.getValueByPath(row, key)
                     if (value == null) return false


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes
When I used the **custom search** I noticed that two or more filters combined together were not filtering correctly, with the effect of obtaining an **OR** and not **AND** filter as expected.

I fixed it by simply returning false when `customSearch()` is false.

