### PR TITLE
Prevent emitting the prompt value when inputted text is compositing

### DIFF
--- a/src/components/dialog/Dialog.vue
+++ b/src/components/dialog/Dialog.vue
@@ -45,7 +45,9 @@
                                         ref="input"
                                         :class="{ 'is-danger': validationMessage }"
                                         v-bind="inputAttrs"
-                                        @keyup.enter="confirm">
+                                        @compositionstart="isCompositing = true"
+                                        @compositionend="isCompositing = false"
+                                        @keydown.enter="confirm">
                                 </div>
                                 <p class="help is-danger">{{ validationMessage }}</p>
                             </div>
@@ -161,7 +163,8 @@ export default {
         return {
             prompt,
             isActive: false,
-            validationMessage: ''
+            validationMessage: '',
+            isCompositing: false
         }
     },
     computed: {
@@ -198,6 +201,7 @@ export default {
         */
         confirm() {
             if (this.$refs.input !== undefined) {
+                if (this.isCompositing) return
                 if (!this.$refs.input.checkValidity()) {
                     this.validationMessage = this.$refs.input.validationMessage
                     this.$nextTick(() => this.$refs.input.select())


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Prevent the emit event when the event "compositionstart" is occurring<br>(Because it was unexpected behavior for [IME](https://en.wikipedia.org/wiki/Input_method) users)

| Before | After |
|:---:|:---:|
| ![before](https://user-images.githubusercontent.com/4921350/124883076-f1261900-e00b-11eb-8321-7596ba5bba07.gif) | ![after](https://user-images.githubusercontent.com/4921350/124883242-16b32280-e00c-11eb-91c8-c66322c15569.gif) |