### PR TITLE
Show switch control label if slot exists

### DIFF
--- a/src/components/switch/Switch.spec.js
+++ b/src/components/switch/Switch.spec.js
@@ -5,7 +5,13 @@ let wrapper
 
 describe('BSwitch', () => {
     beforeEach(() => {
-        wrapper = shallowMount(BSwitch)
+        wrapper = shallowMount(BSwitch, {
+            slots: {
+                default: [
+                    'Control label'
+                ]
+            }
+        })
     })
 
     it('is called', () => {

--- a/src/components/switch/Switch.vue
+++ b/src/components/switch/Switch.vue
@@ -24,7 +24,7 @@
         <span
             class="check"
             :class="checkClasses"/>
-        <span class="control-label"><slot/></span>
+        <span v-if="showControlLabel" class="control-label"><slot/></span>
     </label>
 </template>
 
@@ -98,6 +98,9 @@ export default {
                 (this.passiveType && `${this.passiveType}-passive`),
                 this.type
             ]
+        },
+        showControlLabel() {
+            return !!this.$slots.default
         }
     },
     watch: {

--- a/src/components/switch/__snapshots__/Switch.spec.js.snap
+++ b/src/components/switch/__snapshots__/Switch.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BSwitch render correctly 1`] = `<label class="switch is-rounded"><input type="checkbox" true-value="true" value="false"> <span class="check"></span> <span class="control-label"></span></label>`;
+exports[`BSwitch render correctly 1`] = `<label class="switch is-rounded"><input type="checkbox" true-value="true" value="false"> <span class="check"></span> <span class="control-label">Control label</span></label>`;


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

## Proposed Changes

The switch component contains a control label for all slot content. If there's no slot content, hide the HTML element for the correct width of the component.


Before: 
Purple is width of control label element:
<img width="353" alt="CleanShot 2021-07-16 at 07 35 06@2x" src="https://user-images.githubusercontent.com/15246256/125862488-ac34c1e4-f74d-429f-b316-e730317f9d00.png">


After:
<img width="333" alt="CleanShot 2021-07-16 at 07 45 46@2x" src="https://user-images.githubusercontent.com/15246256/125862533-3ce2f6f3-a5f8-4919-a27f-6ff022511bd1.png">

