### PR TITLE
feat: enable click event in notification

### DIFF
--- a/docs/pages/components/notification/api/notification.js
+++ b/docs/pages/components/notification/api/notification.js
@@ -115,7 +115,12 @@ export default [
                 name: '<code>close</code>',
                 description: 'Triggers when user closes the notification',
                 parameters: '—'
-            }
+            },
+            {
+                name: '<code>click</code>',
+                description: 'Triggers when user clicks the notification',
+                parameters: '—'
+            },
         ]
     }
 ]

--- a/src/components/notification/Notification.vue
+++ b/src/components/notification/Notification.vue
@@ -3,7 +3,9 @@
         <article
             v-show="isActive"
             class="notification"
-            :class="[type, position]">
+            :class="[type, position]"
+            @click="click"
+        >
             <button
                 v-if="closable"
                 class="delete"

--- a/src/components/notification/NotificationNotice.vue
+++ b/src/components/notification/NotificationNotice.vue
@@ -2,6 +2,7 @@
     <b-notification
         v-bind="$options.propsData"
         ref="notification"
+        @click="click"
         @close="close">
         <slot />
     </b-notification>

--- a/src/scss/components/_notices.scss
+++ b/src/scss/components/_notices.scss
@@ -95,6 +95,7 @@ $snackbar-box-shadow: $notices-box-shadow !default;
         }
     }
     .notification {
+        pointer-events: auto;
         max-width: 600px;
     }
 

--- a/src/utils/MessageMixin.js
+++ b/src/utils/MessageMixin.js
@@ -85,6 +85,9 @@ export default {
             this.$emit('close')
             this.$emit('update:active', false)
         },
+        click() {
+            this.$emit('click')
+        },
         /**
          * Set timer to auto close message
          */

--- a/src/utils/NoticeMixin.js
+++ b/src/utils/NoticeMixin.js
@@ -103,7 +103,9 @@ export default {
                 this.parentBottom.childElementCount > 0
             )
         },
-
+        click() {
+            this.$emit('click')
+        },
         close() {
             if (!this.isPaused) {
                 clearTimeout(this.timer)


### PR DESCRIPTION
	- Enable click event on notification and notificationProgramatic

<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- As requested in [discord](https://discord.com/channels/370174661159419908/488689777743364096/860089083987361812) by `IceBlizz6`. Click event handler for the notification. For the notificationProgrammatic should do as with the `close` event, using `notif.$on('click', () => ... )`

