### PR TITLE
fix: class binding prop might be String, Array or Object

### DIFF
--- a/src/components/navbar/Navbar.vue
+++ b/src/components/navbar/Navbar.vue
@@ -48,7 +48,7 @@ export default {
             default: false
         },
         wrapperClass: {
-            type: String
+            type: [String, Array, Object]
         },
         closeOnClick: {
             type: Boolean,


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
wrapperClass Prop might be String, Array or Object types

## Proposed Changes

- add Array and Object to the wrapperClass type
