### PR TITLE
Add dropdown tag option

### DIFF
--- a/docs/pages/components/navbar/api/navbar.js
+++ b/docs/pages/components/navbar/api/navbar.js
@@ -129,6 +129,13 @@ export default [
     title: 'Dropdown',
     props: [
         {
+            name: '<code>tag</code>',
+            description: 'Sets the type of the component that have to render as navbar-item',
+            type: 'String',
+            values: '<code>a</code>, <code>router-link</code>, <code>div</code> and it\'s html attributes like href, to, etc...',
+            default: 'a'
+        },
+        {
             name: '<code>hoverable</code>',
             description: 'Dropdown will be triggered by hover instead of click',
             type: 'Boolean',

--- a/src/components/navbar/NavbarDropdown.vue
+++ b/src/components/navbar/NavbarDropdown.vue
@@ -8,19 +8,21 @@
         @mouseenter="checkHoverable"
         v-click-outside="closeMenu"
     >
-        <a
+        <component
+            :is="tag"
             class="navbar-link"
             :class="{
                 'is-arrowless': arrowless,
                 'is-active': newActive && collapsible
             }"
+            v-bind="$attrs"
+            v-on="$listeners"
             role="menuitem"
             aria-haspopup="true"
-            href="#"
             @click.prevent="newActive = !newActive">
             <template v-if="label">{{ label }}</template>
             <slot v-else name="label" />
-        </a>
+        </component>
         <div
             v-show="!collapsible || (collapsible && newActive)"
             class="navbar-dropdown"
@@ -53,8 +55,11 @@ export default {
             type: Boolean,
             default: true
         },
-        collapsible: Boolean
-
+        collapsible: Boolean,
+        tag: {
+            type: String,
+            default: 'a'
+        }
     },
     data() {
         return {


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #3445 
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Add a `tag` prop to `NavbarbarDropdown`
- Pass down `$attrs` and `$listeners`, like in `NavbarItem`
