### PR TITLE
Updated component.d.ts by removing customClass prop

### DIFF
--- a/types/components.d.ts
+++ b/types/components.d.ts
@@ -176,11 +176,6 @@ export declare type BDialogConfig = {
     * Improve accessiblity when enabled.
     */
    ariaModal?: boolean;
-
-   /**
-    * CSS classes to be applied on modal
-    */
-   customClass?: string;
 }
 type BPromptDialogConfig = BDialogConfig & {
     /**


### PR DESCRIPTION
As @jtommy mentioned in https://github.com/buefy/buefy/issues/3439#issuecomment-894135113,  there is not `customClass` property of Dialog. The type declaration has been fixed by removing `customClass` prop from the type declaration of the Dialog's configuration.

Fixes #3439

## Proposed Changes

- Removal of the customClass prop from the type declaration of Dialog's configuration (BDialogConfig).
