### PR TITLE
fix(docs): update default slot props for b-table

### DIFF
--- a/docs/pages/components/table/api/table.js
+++ b/docs/pages/components/table/api/table.js
@@ -434,7 +434,7 @@ export default [
             {
                 name: 'default',
                 description: '<strong>Required</strong>, table body and header',
-                props: '<code>row: Object</code>, <code>column: Vue Object</code>, <code>index: Number</code>, <code>colindex: Number</code>, <code>toggleDetails: Function (row: Object)</code>'
+                props: '<code>toggleDetails: Function (row: Object)</code>'
             },
             {
                 name: '<code>header</code>',
@@ -782,7 +782,7 @@ export default [
             {
                 name: 'default',
                 description: '<strong>Required</strong>, table column body',
-                props: '-'
+                props: '<code>row: Object</code>, <code>column: Vue Object</code>, <code>index: Number</code>, <code>colindex: Number</code>'
             },
             {
                 name: '<code>header</code>',


### PR DESCRIPTION
## Proposed Changes

The slot props for `b-table` were changed in 0.9.0 but the docs still reflect the old way:
https://github.com/buefy/buefy/blob/dev/CHANGELOG.md#090

This PR updates the slots in the documentation.