### PR TITLE
Fix autocomplete with keepFirst

### DIFF
--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -388,11 +388,8 @@ export default {
                     (element) => element.items && element.items.length
                 )
                 if (nonEmptyElements.length) {
-                    // If has visible data or open on focus, keep updating the hovered
                     const option = nonEmptyElements[0].items[0]
-                    if (this.openOnFocus || (this.newValue !== '' && this.hovered !== option)) {
-                        this.setHovered(option)
-                    }
+                    this.setHovered(option)
                 } else {
                     this.setHovered(null)
                 }
@@ -526,6 +523,7 @@ export default {
             if (this.openOnFocus) {
                 this.isActive = true
                 if (this.keepFirst) {
+                    // If open on focus, update the hovered
                     this.selectFirstOption(this.computedData)
                 }
             }

--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -343,6 +343,8 @@ export default {
                 this.$nextTick(() => {
                     if (this.isActive) {
                         this.selectFirstOption(this.computedData)
+                    } else {
+                        this.setHovered(null)
                     }
                 })
             }
@@ -380,11 +382,14 @@ export default {
         /**
          * Select first option
          */
-        selectFirstOption(element) {
+        selectFirstOption(computedData) {
             this.$nextTick(() => {
-                if (element.length) {
+                const nonEmptyElements = computedData.filter(
+                    (element) => element.items && element.items.length
+                )
+                if (nonEmptyElements.length) {
                     // If has visible data or open on focus, keep updating the hovered
-                    const option = element[0].items[0]
+                    const option = nonEmptyElements[0].items[0]
                     if (this.openOnFocus || (this.newValue !== '' && this.hovered !== option)) {
                         this.setHovered(option)
                     }


### PR DESCRIPTION
Fixes #3469

## Proposed Changes

Fix some autocomplete behavior with the `keepFirst` option

- item preselected even if there is no match with search text
- item preselected even if the dropdown does not show ( no `openonfocus` and empty search text )

this PR would also works if the filter function return empty group arrays like : 
````
     [
                {
                    type: 'Fruit',
                    items: []
                },
                {
                    type: 'Vegetables',
                    items: ['Carrot', 'Broccoli', 'Cucumber', 'Onion']
                }
       ]
```