### PR TITLE
emit the number of table rows in the filtered data set when newDataTo…

### DIFF
--- a/docs/pages/components/table/api/table.js
+++ b/docs/pages/components/table/api/table.js
@@ -594,6 +594,11 @@ export default [
                 parameters: '<code> row: Object </code>'
             },
             {
+                name: '<code>filtered-rows</code>',
+                description: 'Triggers when filtered row count changes',
+                parameters: '<code> count: Number </code>'
+            },
+            {
                 name: '<code>filters-change</code>',
                 description: 'Triggers when filter change',
                 parameters: '<code> filter: Object </code>'

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -764,6 +764,12 @@ export default {
     },
     watch: {
         /**
+        * When filtered row count changes, notify parent with count
+        */
+        newDataTotal(newTotal) {
+            this.$emit('filtered-rows', newTotal)
+        },
+        /**
         * When data prop change:
         *   1. Update internal value.
         *   2. Filter data if it's not backend-filtered.


### PR DESCRIPTION
emit the number of table rows in the filtered data set when newDataTotal changes

## Proposed Changes

- emit the number of rows in the filtered data set for a table when filtering is applied, either with backend filtering or built-in filtering. The use case I am interested in is displaying the current number of filtered results in the table footer.
