### PR TITLE
Update modal example to use :active instead of v-model

### DIFF
--- a/docs/pages/components/modal/examples/ExComponent.vue
+++ b/docs/pages/components/modal/examples/ExComponent.vue
@@ -7,7 +7,7 @@
             @click="isComponentModalActive = true" />
 
         <b-modal
-            v-model="isComponentModalActive"
+            :active="isComponentModalActive"
             has-modal-card
             trap-focus
             :destroy-on-hide="false"


### PR DESCRIPTION
The current Modal example uses `v-model` which doesn't work anymore. `:active` should be used instead.

## Proposed Changes

- Use `:active` instead of `v-model` in modal example