### PR TITLE
Add pause on hover to notification, snackbar

### DIFF
--- a/docs/pages/components/notification/api/notification.js
+++ b/docs/pages/components/notification/api/notification.js
@@ -83,7 +83,7 @@ export default [
             },
             {
                 name: '<code>position</code>',
-                description: 'Which position the notification will appear when programmatically',
+                description: 'Which position the notification will appear when opened programmatically',
                 type: 'String',
                 values: '<code>is-top-right</code>, <code>is-top</code>, <code>is-top-left</code>, <code>is-bottom-right</code>, <code>is-bottom</code>, <code>is-bottom-left</code>',
                 default: '<code>is-top-right</code>'
@@ -97,7 +97,14 @@ export default [
             },
             {
                 name: '<code>indefinite</code>',
-                description: 'Show the Notification indefinitely until it is dismissed when programmatically',
+                description: 'Show the Notification indefinitely until it is dismissed when opened programmatically',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
+                name: '<code>pause-on-hover</code>',
+                description: 'Pause and show on hover until hover off when opened programmatically, if indefinite is false.',
                 type: 'Boolean',
                 values: '—',
                 default: '<code>false</code>'

--- a/docs/pages/components/notification/examples/ExProgrammatically.vue
+++ b/docs/pages/components/notification/examples/ExProgrammatically.vue
@@ -15,6 +15,11 @@
                 type="is-danger"
                 size="is-medium"
                 @click="danger" />
+            <b-button
+                label="Launch notification (pause on hover)"
+                type="is-link"
+                size="is-medium"
+                @click="pause" />
         </div>
     </section>
 </template>
@@ -42,7 +47,14 @@
                 notif.$on('close', () => {
                     this.$buefy.notification.open('Custom notification closed!')
                 })
-            }
+            },
+            pause() {
+                this.$buefy.notification.open({
+                    message: `I can be paused if you hover over me`,
+                    type: 'is-link',
+                    pauseOnHover: true,
+                })
+            },
         }
     }
 </script>

--- a/docs/pages/components/snackbar/api/snackbar.js
+++ b/docs/pages/components/snackbar/api/snackbar.js
@@ -47,6 +47,13 @@ export default [
                 default: '<code>false</code>'
             },
             {
+                name: '<code>pause-on-hover</code>',
+                description: 'Pause and show on hover until hover off (it works when indefinite is false)',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
                 name: '<code>container</code>',
                 description: 'DOM element the toast will be created on. Note that this also changes the <code>position</code> of the toast from <code>fixed</code> to <code>absolute</code>. Meaning that the container should be <code>fixed</code>. Also note that this will override the <code>defaultContainerElement</code> if you specified it in your Buefy Constructor Options. See Constructor options for more details.',
                 type: 'String',

--- a/docs/pages/components/snackbar/examples/ExSimple.vue
+++ b/docs/pages/components/snackbar/examples/ExSimple.vue
@@ -19,6 +19,11 @@
                 label="Launch snackbar (with cancel)"
                 size="is-medium"
                 @click="hasCancel" />
+            <b-button
+                label="Launch snackbar (pause on hover)"
+                type="is-link"
+                size="is-medium"
+                @click="pause" />
         </div>
     </section>
 </template>
@@ -66,7 +71,14 @@
                     message: 'Snackbar with a cancel button.',
                     cancelText: 'Cancel',
                 })
-            }
+            },
+            pause() {
+                this.$buefy.snackbar.open({
+                    message: 'I can be paused if you hover over me',
+                    pauseOnHover: true,
+                    type: 'is-link',
+                })
+            },
         }
     }
 </script>

--- a/src/components/notification/NotificationNotice.vue
+++ b/src/components/notification/NotificationNotice.vue
@@ -3,7 +3,9 @@
         v-bind="$options.propsData"
         ref="notification"
         @click="click"
-        @close="close">
+        @close="close"
+        @mouseenter.native="pause"
+        @mouseleave.native="removePause">
         <slot />
     </b-notification>
 </template>
@@ -11,6 +13,7 @@
 <script>
 import config from '../../utils/config'
 import NoticeMixin from '../../utils/NoticeMixin.js'
+import { removeElement } from '../../utils/helpers'
 
 export default {
     name: 'BNotificationNotice',
@@ -21,8 +24,18 @@ export default {
         }
     },
     methods: {
-        timeoutCallback() {
-            return this.$refs.notification.close()
+        close() {
+            if (!this.isPaused) {
+                clearTimeout(this.timer)
+                this.$refs.notification.isActive = false
+                this.$emit('close')
+
+                // Timeout for the animation complete before destroying
+                setTimeout(() => {
+                    this.$destroy()
+                    removeElement(this.$el)
+                }, 150)
+            }
         }
     }
 }

--- a/src/components/snackbar/Snackbar.vue
+++ b/src/components/snackbar/Snackbar.vue
@@ -6,6 +6,8 @@
             v-show="isActive"
             class="snackbar"
             :class="[type,position]"
+            @mouseenter="pause"
+            @mouseleave="removePause"
             :role="actionText ? 'alertdialog' : 'alert'">
             <template v-if="$slots.default">
                 <slot />

--- a/src/components/toast/Toast.vue
+++ b/src/components/toast/Toast.vue
@@ -3,7 +3,7 @@
         :enter-active-class="transition.enter"
         :leave-active-class="transition.leave">
         <div
-            @mouseover="pause"
+            @mouseenter="pause"
             @mouseleave="removePause"
             v-show="isActive"
             class="toast"

--- a/types/components.d.ts
+++ b/types/components.d.ts
@@ -344,6 +344,11 @@ export declare type BNoticeConfig = {
     indefinite?: boolean;
 
     /**
+     * Prevent the notice from hiding while it is being hovered.
+     */
+    pauseOnHover?: boolean;
+
+    /**
     * DOM element it will be created on.
     * Note that this also changes the position of the element from fixed
     * to absolute. Meaning that the container should be fixed.


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #667
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Add pause on hover to programmatic Notification
- Add pause on hover to Snackbar
- Add pauseOnHover to typescript defintitions.

When using Toast programmatically with typescript, I noticed the type definition for `pauseOnHover` was missing from `BNoticeConfig`. Pause on hover was added to Toast in #3396. I wanted to update the types, and realized `BNoticeConfig` is also used for programmatic Notification and for Snackbar, so I added support to those as well.

https://user-images.githubusercontent.com/16095329/132077265-d13662bf-7537-4f13-a143-3295db9ed5fa.mov