### PR TITLE
Add v-bind="$attrs" to Datetimepicker.vue

### DIFF
--- a/src/components/datetimepicker/Datetimepicker.vue
+++ b/src/components/datetimepicker/Datetimepicker.vue
@@ -29,6 +29,7 @@
         :locale="locale"
         :focusable="focusable"
         :append-to-body="appendToBody"
+        v-bind="$attrs"
         @focus="onFocus"
         @blur="onBlur"
         @icon-right-click="$emit('icon-right-click')"


### PR DESCRIPTION
So that it's passed to DatePicker's `<input>` as well when not mobile or inline.

Required to pass an `id` attribute for accessibility purposes (with `b-field`'s `label-for`).