### PR TITLE
Autocomplete keyboard navigation enhancement

### DIFF
--- a/docs/pages/components/autocomplete/api/autocomplete.js
+++ b/docs/pages/components/autocomplete/api/autocomplete.js
@@ -232,6 +232,16 @@ export default [
                 name: '<code>infinite-scroll</code>',
                 description: 'Triggers when <code>.dropdown-list</code> has reached scroll end',
                 parameters: '—'
+            },
+            {
+                name: '<code>select-header</code>',
+                description: 'Triggers when the header slot is selected',
+                parameters: '—'
+            },
+            {
+                name: '<code>select-footer</code>',
+                description: 'Triggers when the footer slot is selected',
+                parameters: '—'
             }
         ],
         methods: [

--- a/docs/pages/components/autocomplete/api/autocomplete.js
+++ b/docs/pages/components/autocomplete/api/autocomplete.js
@@ -163,6 +163,20 @@ export default [
                 default: '<code>false</code>'
             },
             {
+                name: '<code>selectable-header</code>',
+                description: 'Allows the header in the autocomplete to be selectable',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
+                name: '<code>selectable-footer</code>',
+                description: 'Allows the footer in the autocomplete to be selectable',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
                 name: 'Any native attribute',
                 description: '—',
                 type: '—',

--- a/docs/pages/components/autocomplete/api/autocomplete.js
+++ b/docs/pages/components/autocomplete/api/autocomplete.js
@@ -250,12 +250,12 @@ export default [
             {
                 name: '<code>select-header</code>',
                 description: 'Triggers when the header slot is selected',
-                parameters: '—'
+                parameters: '<code>event: $event</code>'
             },
             {
                 name: '<code>select-footer</code>',
                 description: 'Triggers when the footer slot is selected',
-                parameters: '—'
+                parameters: '<code>event: $event</code>'
             }
         ],
         methods: [

--- a/docs/pages/components/autocomplete/examples/ExFooter.vue
+++ b/docs/pages/components/autocomplete/examples/ExFooter.vue
@@ -18,7 +18,7 @@
                 @select-footer="showAddFruit"
                 :selectable-footer="selectable">
                 <template #footer>
-                    <a>
+                    <a @click="checkSelectable">
                         <span> Add new... </span>
                     </a>
                 </template>
@@ -71,6 +71,9 @@
                         this.$refs.autocomplete.setSelected(value)
                     }
                 })
+            },
+            checkSelectable(){
+                if (!this.selectable)  this.showAddFruit()
             }
         }
     }

--- a/docs/pages/components/autocomplete/examples/ExFooter.vue
+++ b/docs/pages/components/autocomplete/examples/ExFooter.vue
@@ -1,5 +1,12 @@
 <template>
     <section>
+        <b-field grouped group-multiline>
+            <div class="control">
+                <b-switch v-model="selectable">
+                    Selectable
+                </b-switch>
+            </div>
+        </b-field>
         <p class="content"><b>Selected:</b> {{ selected }}</p>
         <b-field label="Find or add a Fruit">
             <b-autocomplete
@@ -8,7 +15,8 @@
                 :data="filteredDataArray"
                 placeholder="e.g. Orange"
                 @select="option => selected = option"
-                @select-footer="showAddFruit">
+                @select-footer="showAddFruit"
+                :selectable-footer="selectable">
                 <template #footer>
                     <a>
                         <span> Add new... </span>
@@ -34,7 +42,8 @@
                     'Kiwi'
                 ],
                 name: '',
-                selected: null
+                selected: null,
+                selectable: false
             }
         },
         computed: {

--- a/docs/pages/components/autocomplete/examples/ExFooter.vue
+++ b/docs/pages/components/autocomplete/examples/ExFooter.vue
@@ -7,9 +7,10 @@
                 ref="autocomplete"
                 :data="filteredDataArray"
                 placeholder="e.g. Orange"
-                @select="option => selected = option">
+                @select="option => selected = option"
+                @select-footer="showAddFruit">
                 <template #footer>
-                    <a @click="showAddFruit">
+                    <a>
                         <span> Add new... </span>
                     </a>
                 </template>

--- a/docs/pages/components/autocomplete/examples/ExHeader.vue
+++ b/docs/pages/components/autocomplete/examples/ExHeader.vue
@@ -12,6 +12,11 @@
                     <small>(will always have first option pre-selected)</small>
                 </b-switch>
             </div>
+            <div class="control">
+                <b-switch v-model="selectable">
+                    Selectable
+                </b-switch>
+            </div>
         </b-field>
         <p class="content"><b>Selected:</b> {{ selected }}</p>
         <b-field label="Find or add a Fruit">
@@ -23,7 +28,8 @@
                 :open-on-focus="openOnFocus"
                 placeholder="e.g. Orange"
                 @select="option => selected = option"
-                @select-header="showAddFruit">
+                @select-header="showAddFruit"
+                :selectable-header="selectable">
                 <template #header>
                     <a>
                         <span> Add new... </span>
@@ -52,6 +58,7 @@
                 selected: null,
                 keepFirst: false,
                 openOnFocus: false,
+                selectable: false
             }
         },
         computed: {

--- a/docs/pages/components/autocomplete/examples/ExHeader.vue
+++ b/docs/pages/components/autocomplete/examples/ExHeader.vue
@@ -31,7 +31,7 @@
                 @select-header="showAddFruit"
                 :selectable-header="selectable">
                 <template #header>
-                    <a>
+                    <a @click="checkSelectable">
                         <span> Add new... </span>
                     </a>
                 </template>
@@ -86,6 +86,9 @@
                         this.$refs.autocomplete.setSelected(value)
                     }
                 })
+            },
+            checkSelectable(){
+                if (!this.selectable)  this.showAddFruit()
             }
         }
     }

--- a/docs/pages/components/autocomplete/examples/ExHeader.vue
+++ b/docs/pages/components/autocomplete/examples/ExHeader.vue
@@ -1,15 +1,31 @@
 <template>
     <section>
+        <b-field grouped group-multiline>
+            <div class="control">
+                <b-switch v-model="openOnFocus">
+                    Open dropdown on focus
+                </b-switch>
+            </div>
+            <div class="control">
+                <b-switch v-model="keepFirst">
+                    Keep-first
+                    <small>(will always have first option pre-selected)</small>
+                </b-switch>
+            </div>
+        </b-field>
         <p class="content"><b>Selected:</b> {{ selected }}</p>
         <b-field label="Find or add a Fruit">
             <b-autocomplete
                 v-model="name"
                 ref="autocomplete"
                 :data="filteredDataArray"
+                :keep-first="keepFirst"
+                :open-on-focus="openOnFocus"
                 placeholder="e.g. Orange"
-                @select="option => selected = option">
+                @select="option => selected = option"
+                @select-header="showAddFruit">
                 <template #header>
-                    <a @click="showAddFruit">
+                    <a>
                         <span> Add new... </span>
                     </a>
                 </template>
@@ -33,7 +49,9 @@
                     'Kiwi'
                 ],
                 name: '',
-                selected: null
+                selected: null,
+                keepFirst: false,
+                openOnFocus: false,
             }
         },
         computed: {

--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -44,7 +44,7 @@
                         role="button"
                         tabindex="0"
                         :class="{ 'is-hovered': headerHovered }"
-                        @click="selectableHeadersetSelected('header', undefined, $event)"
+                        @click="(event) => checkIfHeaderOrFooterSelected(event, true)"
                     >
                         <slot name="header" />
                     </div>
@@ -91,7 +91,7 @@
                         role="button"
                         tabindex="0"
                         :class="{ 'is-hovered': footerHovered }"
-                        @click="setSelected('footer', undefined, $event)"
+                        @click="(event) => checkIfHeaderOrFooterSelected(event, true)"
                     >
                         <slot name="footer" />
                     </div>
@@ -378,15 +378,6 @@ export default {
          */
         setSelected(option, closeDropdown = true, event = undefined) {
             if (option === undefined) return
-            if (this.selectableHeader && option === 'header') {
-                this.$emit('select-header')
-                return
-            }
-            if (this.selectableFooter && option === 'footer') {
-                this.$emit('select-footer')
-                return
-            }
-
             this.selected = option
             this.$emit('select', this.selected, event)
             if (this.selected !== null) {
@@ -429,13 +420,37 @@ export default {
             if (key === 'Escape' || key === 'Tab') {
                 this.isActive = false
             }
-            if (this.hovered === null) return
+
             if (this.confirmKeys.indexOf(key) >= 0) {
                 // If adding by comma, don't add the comma to the input
                 if (key === ',') event.preventDefault()
                 // Close dropdown on select by Tab
                 const closeDropdown = !this.keepOpen || key === 'Tab'
+                if (this.hovered === null) {
+                    // header and footer uses headerHovered && footerHovered. If header or footer
+                    // was selected then fire event otherwise just return so a value isn't selected
+                    this.checkIfHeaderOrFooterSelected(event, false, closeDropdown)
+                    return
+                }
                 this.setSelected(this.hovered, closeDropdown, event)
+            }
+        },
+
+        /**
+         * Check if header or footer was selected.
+         */
+        checkIfHeaderOrFooterSelected(event, triggeredByclick, closeDropdown = true) {
+            if (this.selectableHeader && (this.headerHovered || triggeredByclick)) {
+                this.$emit('select-header', event)
+                this.headerHovered = false
+                if (triggeredByclick) this.setHovered(null)
+                if (closeDropdown) this.isActive = false
+            }
+            if (this.selectableFooter && (this.footerHovered || triggeredByclick)) {
+                this.$emit('select-footer', event)
+                this.footerHovered = false
+                if (triggeredByclick) this.setHovered(null)
+                if (closeDropdown) this.isActive = false
             }
         },
 

--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -38,9 +38,16 @@
                     class="dropdown-content"
                     v-show="isActive"
                     :style="contentStyle">
-                    <div v-if="hasHeaderSlot" class="dropdown-item">
+                    <a
+                        v-if="hasHeaderSlot"
+                        class="dropdown-item"
+                        role="button"
+                        tabindex="0"
+                        :class="{ 'is-hovered': 'header' === hovered }"
+                        @click="setSelected('header', undefined, $event)"
+                    >
                         <slot name="header" />
-                    </div>
+                    </a>
                     <template v-for="(element, groupindex) in computedData">
                         <div
                             v-if="element.group"
@@ -78,9 +85,16 @@
                         class="dropdown-item is-disabled">
                         <slot name="empty" />
                     </div>
-                    <div v-if="hasFooterSlot" class="dropdown-item">
+                    <a
+                        v-if="hasFooterSlot"
+                        class="dropdown-item"
+                        role="button"
+                        tabindex="0"
+                        :class="{ 'is-hovered': 'footer' === hovered }"
+                        @click="setSelected('footer', undefined, $event)"
+                    >
                         <slot name="footer" />
-                    </div>
+                    </a>
                 </div>
             </div>
         </transition>
@@ -360,6 +374,14 @@ export default {
          */
         setSelected(option, closeDropdown = true, event = undefined) {
             if (option === undefined) return
+            if (option === 'header') {
+                this.$emit('select-header')
+                return
+            }
+            if (option === 'footer') {
+                this.$emit('select-footer')
+                return
+            }
 
             this.selected = option
             this.$emit('select', this.selected, event)
@@ -483,6 +505,12 @@ export default {
             if (this.isActive) {
                 const data = this.computedData.map(
                     (d) => d.items).reduce((a, b) => ([...a, ...b]), [])
+                if (this.hasHeaderSlot) {
+                    data.unshift('header')
+                }
+                if (this.hasFooterSlot) {
+                    data.push('footer')
+                }
                 let index = data.indexOf(this.hovered) + sum
                 index = index > data.length - 1 ? data.length - 1 : index
                 index = index < 0 ? 0 : index


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #3437
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Header and footer slots for autocompletes can now be navigated to with a keyboard.
- Added a select-header and select-footer event. This can be used to call a function when the appropriate slot is selected.
- I also added the keep-first and open-on-focus to the header example in the documentation so that people can see how the behavior interacts with the new slot behavior.

