### PR TITLE
Update: redundant css class removal

### DIFF
--- a/src/components/numberinput/Numberinput.vue
+++ b/src/components/numberinput/Numberinput.vue
@@ -3,7 +3,7 @@
         <p
             v-for="control in controlsLeft"
             :key="control"
-            :class="['control', control]"
+            :class="['control']"
             @mouseup="onStopLongPress"
             @mouseleave="onStopLongPress"
             @touchend="onStopLongPress"
@@ -58,7 +58,7 @@
         <p
             v-for="control in controlsRight"
             :key="control"
-            :class="['control', control]"
+            :class="['control']"
             @mouseup="onStopLongPress"
             @mouseleave="onStopLongPress"
             @touchend="onStopLongPress"


### PR DESCRIPTION
Issue: Provokes an error if using an external a non-default icon pack.  
Fix: Removing undesired "minus" and "plus" classes from the <p class="control XXX ",