### PR TITLE
Don't attach attrs to NavbarDropdown

### DIFF
--- a/src/components/navbar/NavbarDropdown.vue
+++ b/src/components/navbar/NavbarDropdown.vue
@@ -44,6 +44,7 @@ export default {
     directives: {
         clickOutside
     },
+    inheritAttrs: false,
     props: {
         label: String,
         hoverable: Boolean,


### PR DESCRIPTION
Fix #3475

## Proposed Changes

- Add `inheritAttrs: false,` on `NavbarDropdown` component
