### PR TITLE
Fix bug on loading when using fixed navbar

### DIFF
--- a/src/scss/components/_loading.scss
+++ b/src/scss/components/_loading.scss
@@ -9,7 +9,7 @@ $loading-full-page-icon-size: 5em !default;
     display: none;
     justify-content: center;
     overflow: hidden;
-    z-index: 999;
+    z-index: 29;
     &.is-active {
         display: flex
     }

--- a/src/scss/components/_loading.scss
+++ b/src/scss/components/_loading.scss
@@ -15,6 +15,7 @@ $loading-full-page-icon-size: 5em !default;
     }
     &.is-full-page {
         position: fixed;
+        z-index: 999;
         .loading-icon {
             &:after {
                 top: calc(50% - #{$loading-full-page-icon-size * 0.5});


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #3335
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Set `z-index` of `.loading-overlay` to `999` only when full page.  Otherwise, keep it smaller than the `z-index` of the fixed navigation bar.