### PR TITLE
Fix NumberInput increment bug

### DIFF
--- a/src/components/numberinput/Numberinput.spec.js
+++ b/src/components/numberinput/Numberinput.spec.js
@@ -91,6 +91,16 @@ describe('BNumberinput', () => {
 
             expect(wrapper.vm.computedValue).toBe(val)
         })
+
+        it('increments/decrements after manually set value on input', async () => {
+            wrapper.setProps({exponential: true, value: 1, step: 1})
+            const BASE_VALUE = Math.floor(Math.random() * 10 + 1)
+            wrapper.find('input').setValue(BASE_VALUE)
+            wrapper.find('.control.plus button').trigger('click')
+            wrapper.find('.control.minus button').trigger('click')
+
+            expect(wrapper.vm.computedValue).toEqual(BASE_VALUE)
+        })
     })
 
     describe('Rendered (shallow)', () => {

--- a/src/components/numberinput/Numberinput.vue
+++ b/src/components/numberinput/Numberinput.vue
@@ -160,7 +160,7 @@ export default {
                 return this.newValue
             },
             set(value) {
-                let newValue = value
+                let newValue = Number(value) || null
                 if (value === '' || value === undefined || value === null) {
                     if (this.minNumber !== undefined) {
                         newValue = this.minNumber


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #3507
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

As described in ISSUE, if you manually set the input value and click to increment, an exception is thrown. This is because `computedValue` becomes a `string`. 

Because of this, the following statement returns a string:

```js
const value = this.computedValue + this.stepNumber
```

and, the next statement crashes when try to run `.toFixed()` on a `string`.

```js
this.computedValue = parseFloat(value.toFixed(this.stepDecimals))
```

### Why doesn't it fail in decrement?
This does not happen in `decrement` because of the nature of JavaScript. Using the `-` operator will convert operands to `number`, but the `+` operator will convert operands to `string`.

```js
console.log('2' - 2) // Prints: 0
console.log('2' + 2) // Prints: '22'
```

## Proposed Changes

- Cast computedValue as a number
