### PR TITLE
Emit 'active-change' event when Datetimepicker active state changes

### DIFF
--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -815,6 +815,10 @@ export default {
             if (!value) {
                 this.onBlur()
             }
+            /*
+             * Emit 'active-change' when on dropdown active state change
+             */
+            this.$emit('active-change', value)
         },
 
         changeFocus(day) {

--- a/src/components/datetimepicker/Datetimepicker.vue
+++ b/src/components/datetimepicker/Datetimepicker.vue
@@ -31,6 +31,7 @@
         :append-to-body="appendToBody"
         @focus="onFocus"
         @blur="onBlur"
+        @active-change="onActiveChange"
         @icon-right-click="$emit('icon-right-click')"
         @change-month="$emit('change-month', $event)"
         @change-year="$emit('change-year', $event)">
@@ -390,6 +391,12 @@ export default {
             } else {
                 this.computedValue = null
             }
+        },
+        /*
+         * Emit 'active-change' on datepicker active state change
+         */
+        onActiveChange(value) {
+            this.$emit('active-change', value)
         },
         formatNative(value) {
             const date = new Date(value)


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #3479
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- `Datetimepicker` component now emits `active-change` events when opened/closed (conveying the `active-change` event emitted by the `Dropdown` component used internally to implement the component
- `Datepicker` component now emits `active-change` events when opened/closed (conveying the `active-change` event emitted by the `Dropdown` component used internally to implement the component
