### PR TITLE
Pass message to inner BField

### DIFF
--- a/src/components/field/Field.vue
+++ b/src/components/field/Field.vue
@@ -33,6 +33,7 @@
             <b-field
                 :addons="false"
                 :type="newType"
+                :message="newMessage ? formattedMessage : ''"
                 :class="innerFieldClasses">
                 <slot/>
             </b-field>


### PR DESCRIPTION
Fixes #3429.

As described in ISSUE, the help message is disappearing when focus/blur on a `<b-field>` with addons. This is happening because when `BField` has addons, it adds some internal `BField`'s and the message is not being passed to these nested `BField`s.

<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Pass message to nested BField's