### PR TITLE
Update tooltip.js

### DIFF
--- a/docs/pages/components/tooltip/api/tooltip.js
+++ b/docs/pages/components/tooltip/api/tooltip.js
@@ -19,6 +19,13 @@ export default [
                 default: '<code>true</code>'
             },
             {
+                name: '<code>auto-close</code>',
+                description: 'The event(s) that should trigger the tooltip to close',
+                type: 'Boolean, Array',
+                values: `Boolean <code>true</code> or <code>false</code>, or an array containing any of <code>escape</code>, <code>outside</code>, <code>inside</code>`,
+                default: '<code>true</code>'
+            },
+            {
                 name: '<code>label</code>',
                 description: 'Tooltip text',
                 type: 'String',


### PR DESCRIPTION
Added API docs for missing `auto-close` param.

<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- I've not done a PR before so I'm not sure precisely what the protocol is or what I should fill out in this template, but essentially, as I put in the commit, I've added some missing docs to the tooltip page, re: the `auto-close` param.
-
-
