### PR TITLE
Added icon on the left and click-event to tag

### DIFF
--- a/docs/pages/components/tag/Tag.vue
+++ b/docs/pages/components/tag/Tag.vue
@@ -1,6 +1,8 @@
 <template>
     <div>
         <Example :component="ExSimple" :code="ExSimpleCode" vertical/>
+        
+        <Example :component="ExIcon" :code="ExIconCode" vertical/>
 
         <p class="content">Closable tags have a button that can be focused, it emits a <code>close</code> event when clicked or when <b>delete</b> key is pressed.</p>
         <Example :component="ExClosable" :code="ExClosableCode" title="Closable" vertical/>
@@ -29,6 +31,9 @@
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from '!!raw-loader!./examples/ExSimple'
 
+    import ExIcon from './examples/ExIcon'
+    import ExIconCode from '!!raw-loader!./examples/ExIcon'
+
     import ExClosable from './examples/ExClosable'
     import ExClosableCode from '!!raw-loader!./examples/ExClosable'
 
@@ -49,12 +54,14 @@
             return {
                 api,
                 ExSimple,
+                ExIcon,
                 ExClosable,
                 ExTaglist,
                 ExTaglistAttached,
                 ExFieldCombine,
                 ExSizes,
                 ExSimpleCode,
+                ExIconCode,
                 ExClosableCode,
                 ExTaglistCode,
                 ExTaglistAttachedCode,

--- a/docs/pages/components/tag/api/tag.js
+++ b/docs/pages/components/tag/api/tag.js
@@ -79,6 +79,31 @@ export default [
                 default: '-'
             },
             {
+                name: "<code>icon</code>",
+                description: "Adds an icon to the left of the tag.",
+                type: "String",
+                values: "—",
+                default: "-",
+            },
+            {
+                name: "<code>icon-pack</code>",
+                description: "Icon pack to use",
+                type: "String",
+                values: "<code>mdi</code>, <code>fa</code>, <code>fas</code>, <code>far</code>, <code>fab</code>,  <code>fad</code>, <code>fal</code>",
+                default: "<code>mdi</code>",
+            },
+            {
+                name: "<code>icon-type</code>",
+                description:
+                    "Type (color) of the icon on the left side of tag, optional",
+                type: "String",
+                values: `<code>is-white</code>, <code>is-black</code>, <code>is-light</code>,
+                    <code>is-dark</code>, <code>is-primary</code>, <code>is-info</code>, <code>is-success</code>,
+                    <code>is-warning</code>, <code>is-danger</code>,
+                    and any other colors you've set in the <code>$colors</code> list on Sass`,
+                default: "—",
+            },
+            {
                 name: '<code>close-icon</code>',
                 description: 'Replace times in close button with a customized icon. <code>closable</code> and <code>attached</code> props should be needed.',
                 type: 'String',
@@ -108,7 +133,12 @@ export default [
                 name: '<code>close</code>',
                 description: 'Triggers when close/delete button is clicked or <b>delete</b> key is pressed',
                 parameters: '—'
-            }
+            },
+            {
+                name: "<code>click</code>",
+                description: "Triggers when clicking the content of the tag",
+                parameters: "—",
+            },
         ]
     },
     {

--- a/docs/pages/components/tag/examples/ExIcon.vue
+++ b/docs/pages/components/tag/examples/ExIcon.vue
@@ -1,0 +1,7 @@
+<template>
+    <section>
+        <b-field>
+            <b-tag icon="account-check-outline">Tag with icon</b-tag>
+        </b-field>
+    </section>
+</template>

--- a/src/components/tag/Tag.vue
+++ b/src/components/tag/Tag.vue
@@ -3,7 +3,8 @@
         <span
             class="tag"
             :class="[type, size, { 'is-rounded': rounded }]">
-            <span :class="{ 'has-ellipsis': ellipsis }">
+            <b-icon custom-class="" v-if="icon" :icon="icon" :size="size" :type="iconType" :pack="iconPack" />
+            <span :class="{ 'has-ellipsis': ellipsis }" @click="click">
                 <slot/>
             </span>
         </span>
@@ -33,7 +34,8 @@
         v-else
         class="tag"
         :class="[type, size, { 'is-rounded': rounded }]">
-        <span :class="{ 'has-ellipsis': ellipsis }">
+        <b-icon custom-class="" v-if="icon" :icon="icon" :size="size" :type="iconType" :pack="iconPack" />
+        <span :class="{ 'has-ellipsis': ellipsis }" @click="click">
             <slot/>
         </span>
 
@@ -67,6 +69,9 @@ export default {
             default: true
         },
         ariaCloseLabel: String,
+        icon: String,
+        iconType: String,
+        iconPack: String,
         closeType: String,
         closeIcon: String,
         closeIconPack: String,
@@ -82,6 +87,14 @@ export default {
 
             this.$emit('close', event)
         }
+        /**
+        * Emit click event when tag is clicked.
+        */
+        click(event) {
+            if (this.disabled) return
+            
+            this.$emit('click', event)
+        },
     }
 }
 </script>

--- a/src/components/tag/Tag.vue
+++ b/src/components/tag/Tag.vue
@@ -3,7 +3,7 @@
         <span
             class="tag"
             :class="[type, size, { 'is-rounded': rounded }]">
-            <b-icon custom-class="" v-if="icon" :icon="icon" :size="size" :type="iconType" :pack="iconPack" />
+            <b-icon v-if="icon" :icon="icon" :size="size" :type="iconType" :pack="iconPack" />
             <span :class="{ 'has-ellipsis': ellipsis }" @click="click">
                 <slot/>
             </span>
@@ -34,7 +34,7 @@
         v-else
         class="tag"
         :class="[type, size, { 'is-rounded': rounded }]">
-        <b-icon custom-class="" v-if="icon" :icon="icon" :size="size" :type="iconType" :pack="iconPack" />
+        <b-icon v-if="icon" :icon="icon" :size="size" :type="iconType" :pack="iconPack" />
         <span :class="{ 'has-ellipsis': ellipsis }" @click="click">
             <slot/>
         </span>
@@ -86,7 +86,7 @@ export default {
             if (this.disabled) return
 
             this.$emit('close', event)
-        }
+        },
         /**
         * Emit click event when tag is clicked.
         */


### PR DESCRIPTION
## Reason

Tags are a beautiful way to show a specific type. With an icon on the left you can create different categories like "car" and "motorcycle" using different icons. That way the user can exactly see what type of category this tag applies to.

Click events on the other hand are useful when implementing e.g. taglists where the user can interact with different tags to emit specific tasks (like apply a search filter based on the tag clicked).

## Proposed Changes

- Added icon on the left using:

`<tag icon="cloud-tags" closable attached>Tag with icon on the left!</tag>`

![](https://cdn.heckel.cloud/uploads/electron_2021-09-25_18-41-41.jpg)

- Added click event to tag content using

`<tag icon="cloud-tags" @click="testClick">Tag with icon on the left!</tag>`

![](https://cdn.heckel.cloud/uploads/electron_2021-09-25_18-45-53.jpg)
![](https://cdn.heckel.cloud/uploads/electron_2021-09-25_18-43-08.jpg)
