### PR TITLE
Image custom class

### DIFF
--- a/docs/pages/components/image/api/image.js
+++ b/docs/pages/components/image/api/image.js
@@ -85,6 +85,13 @@ export default [
                 values: '—',
                 default: '<code>false</code>'
             },
+            {
+                name: '<code>custom-class</code>',
+                description: 'Add custom css class to the img tag.',
+                type: 'String',
+                values: '—',
+                default: '—'
+            }
         ],
         slots: [
             {

--- a/src/components/image/Image.spec.js
+++ b/src/components/image/Image.spec.js
@@ -147,6 +147,20 @@ describe('BImage', () => {
         expect(vm.figureStyles['paddingTop']).toBe(`${8 / 16 * 100}%`)
     })
 
+    it('adds custom class to image as expected', () => {
+        const src = `my-image-source.webp`
+        let customClass = 'my-custom-class'
+        const wrapper = shallowMount(BImage, {
+            propsData: {
+                src,
+                customClass
+            }
+        })
+        const vm = wrapper.vm
+
+        expect(vm.imgClasses['my-custom-class']).toBeTruthy()
+    })
+
     it('reset events before destroy', () => {
         window.removeEventListener = jest.fn()
 

--- a/src/components/image/Image.vue
+++ b/src/components/image/Image.vue
@@ -94,7 +94,8 @@ export default {
         captionFirst: {
             type: Boolean,
             default: false
-        }
+        },
+        customClass: String
     },
     data() {
         return {
@@ -137,7 +138,8 @@ export default {
         imgClasses() {
             return {
                 'is-rounded': this.rounded,
-                'has-ratio': this.hasRatio
+                'has-ratio': this.hasRatio,
+                [this.customClass]: this.customClass
             }
         },
         srcExt() {

--- a/src/components/tag/Tag.vue
+++ b/src/components/tag/Tag.vue
@@ -3,7 +3,12 @@
         <span
             class="tag"
             :class="[type, size, { 'is-rounded': rounded }]">
-            <b-icon v-if="icon" :icon="icon" :size="size" :type="iconType" :pack="iconPack" />
+            <b-icon
+                v-if="icon"
+                :icon="icon"
+                :size="size"
+                :type="iconType"
+                :pack="iconPack" />
             <span :class="{ 'has-ellipsis': ellipsis }" @click="click">
                 <slot/>
             </span>
@@ -34,7 +39,12 @@
         v-else
         class="tag"
         :class="[type, size, { 'is-rounded': rounded }]">
-        <b-icon v-if="icon" :icon="icon" :size="size" :type="iconType" :pack="iconPack" />
+        <b-icon
+            v-if="icon"
+            :icon="icon"
+            :size="size"
+            :type="iconType"
+            :pack="iconPack" />
         <span :class="{ 'has-ellipsis': ellipsis }" @click="click">
             <slot/>
         </span>
@@ -92,9 +102,9 @@ export default {
         */
         click(event) {
             if (this.disabled) return
-            
+
             this.$emit('click', event)
-        },
+        }
     }
 }
 </script>


### PR DESCRIPTION
## Rationale

Buefy is an awesome UI lib but there are cases that we need to use `figure` + `img` instead of `b-image`.
This could be easily flexed by adding custom css class into the img tag
-
-
-
