### PR TITLE
Fix emitting autocomplete header and footer events

### DIFF
--- a/docs/pages/components/autocomplete/examples/ExFooter.vue
+++ b/docs/pages/components/autocomplete/examples/ExFooter.vue
@@ -18,9 +18,7 @@
                 @select-footer="showAddFruit"
                 :selectable-footer="selectable">
                 <template #footer>
-                    <a @click="checkSelectable">
-                        <span> Add new... </span>
-                    </a>
+                    <a><span> Add new... </span></a>
                 </template>
                 <template #empty>No results for {{name}}</template>
             </b-autocomplete>
@@ -71,9 +69,6 @@
                         this.$refs.autocomplete.setSelected(value)
                     }
                 })
-            },
-            checkSelectable(){
-                if (!this.selectable)  this.showAddFruit()
             }
         }
     }

--- a/docs/pages/components/autocomplete/examples/ExHeader.vue
+++ b/docs/pages/components/autocomplete/examples/ExHeader.vue
@@ -31,9 +31,7 @@
                 @select-header="showAddFruit"
                 :selectable-header="selectable">
                 <template #header>
-                    <a @click="checkSelectable">
-                        <span> Add new... </span>
-                    </a>
+                    <a><span> Add new... </span></a>
                 </template>
                 <template #empty>No results for {{name}}</template>
             </b-autocomplete>
@@ -86,9 +84,6 @@
                         this.$refs.autocomplete.setSelected(value)
                     }
                 })
-            },
-            checkSelectable(){
-                if (!this.selectable)  this.showAddFruit()
             }
         }
     }

--- a/src/components/autocomplete/Autocomplete.spec.js
+++ b/src/components/autocomplete/Autocomplete.spec.js
@@ -26,13 +26,7 @@ describe('BAutocomplete', () => {
         stubs = {'b-icon': true}
         wrapper = mount(BAutocomplete, {
             propsData: {
-                checkInfiniteScroll: true,
-                selectableHeader: true,
-                selectableFooter: true
-            },
-            slots: {
-                header: '<h1>SLOT HEADER</h1>',
-                footer: '<h1>SLOT FOOTER</h1>'
+                checkInfiniteScroll: true
             },
             stubs
         })
@@ -95,9 +89,19 @@ describe('BAutocomplete', () => {
 
     it('can emit select-header by keyboard and click', async () => {
         const VALUE_TYPED = 'test'
-        wrapper.setProps({
-            data: []
+        const wrapper = mount(BAutocomplete, {
+            propsData: {
+                checkInfiniteScroll: true,
+                selectableHeader: true,
+                selectableFooter: true
+            },
+            slots: {
+                header: '<h1>SLOT HEADER</h1>',
+                footer: '<h1>SLOT FOOTER</h1>'
+            },
+            stubs
         })
+        const $input = wrapper.find('input')
 
         $input.trigger('focus')
         $input.setValue(VALUE_TYPED)
@@ -107,19 +111,31 @@ describe('BAutocomplete', () => {
         $input.trigger('keydown', {'key': 'Enter'})
         await wrapper.vm.$nextTick()
 
-        let $header = wrapper.find('.dropdown-item.dropdown-header')
+        const $header = wrapper.find('.dropdown-item.dropdown-header')
         $header.trigger('click')
         await wrapper.vm.$nextTick()
 
-        expect(wrapper.emitted()['select-header']).toBeTruthy()
-        expect(wrapper.emitted()['select-header']).toHaveLength(2)
+        const emitted = wrapper.emitted()
+
+        expect(emitted['select-header']).toBeTruthy()
+        expect(emitted['select-header']).toHaveLength(2)
     })
 
     it('can emit select-footer by keyboard and click', async () => {
         const VALUE_TYPED = 'test'
-        wrapper.setProps({
-            data: []
+        const wrapper = mount(BAutocomplete, {
+            propsData: {
+                checkInfiniteScroll: true,
+                selectableHeader: true,
+                selectableFooter: true
+            },
+            slots: {
+                header: '<h1>SLOT HEADER</h1>',
+                footer: '<h1>SLOT FOOTER</h1>'
+            },
+            stubs
         })
+        const $input = wrapper.find('input')
 
         $input.trigger('focus')
         $input.setValue(VALUE_TYPED)
@@ -131,12 +147,14 @@ describe('BAutocomplete', () => {
         $input.trigger('blur')
         await wrapper.vm.$nextTick()
 
-        let $footer = wrapper.find('.dropdown-item.dropdown-footer')
+        const $footer = wrapper.find('.dropdown-item.dropdown-footer')
         $footer.trigger('click')
         await wrapper.vm.$nextTick()
 
-        expect(wrapper.emitted()['select-footer']).toBeTruthy()
-        expect(wrapper.emitted()['select-footer']).toHaveLength(2)
+        const emitted = wrapper.emitted()
+
+        expect(emitted['select-footer']).toBeTruthy()
+        expect(emitted['select-footer']).toHaveLength(2)
     })
 
     it('can autocomplete with keydown', async () => {

--- a/src/components/autocomplete/Autocomplete.spec.js
+++ b/src/components/autocomplete/Autocomplete.spec.js
@@ -26,7 +26,13 @@ describe('BAutocomplete', () => {
         stubs = {'b-icon': true}
         wrapper = mount(BAutocomplete, {
             propsData: {
-                checkInfiniteScroll: true
+                checkInfiniteScroll: true,
+                selectableHeader: true,
+                selectableFooter: true
+            },
+            slots: {
+                header: '<h1>SLOT HEADER</h1>',
+                footer: '<h1>SLOT FOOTER</h1>'
             },
             stubs
         })
@@ -85,6 +91,52 @@ describe('BAutocomplete', () => {
 
         $input.trigger('blur')
         expect(wrapper.emitted()['blur']).toBeTruthy()
+    })
+
+    it('can emit select-header by keyboard and click', async () => {
+        const VALUE_TYPED = 'test'
+        wrapper.setProps({
+            data: []
+        })
+
+        $input.trigger('focus')
+        $input.setValue(VALUE_TYPED)
+        await wrapper.vm.$nextTick()
+
+        $input.trigger('keydown', {'key': 'Down'})
+        $input.trigger('keydown', {'key': 'Enter'})
+        await wrapper.vm.$nextTick()
+
+        let $header = wrapper.find('.dropdown-item.dropdown-header')
+        $header.trigger('click')
+        await wrapper.vm.$nextTick()
+
+        expect(wrapper.emitted()['select-header']).toBeTruthy()
+        expect(wrapper.emitted()['select-header']).toHaveLength(2)
+    })
+
+    it('can emit select-footer by keyboard and click', async () => {
+        const VALUE_TYPED = 'test'
+        wrapper.setProps({
+            data: []
+        })
+
+        $input.trigger('focus')
+        $input.setValue(VALUE_TYPED)
+        await wrapper.vm.$nextTick()
+
+        $input.trigger('keydown', {'key': 'Down'})
+        $input.trigger('keydown', {'key': 'Down'})
+        $input.trigger('keydown', {'key': 'Enter'})
+        $input.trigger('blur')
+        await wrapper.vm.$nextTick()
+
+        let $footer = wrapper.find('.dropdown-item.dropdown-footer')
+        $footer.trigger('click')
+        await wrapper.vm.$nextTick()
+
+        expect(wrapper.emitted()['select-footer']).toBeTruthy()
+        expect(wrapper.emitted()['select-footer']).toHaveLength(2)
     })
 
     it('can autocomplete with keydown', async () => {

--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -44,7 +44,7 @@
                         role="button"
                         tabindex="0"
                         :class="{ 'is-hovered': headerHovered }"
-                        @click="(event) => checkIfHeaderOrFooterSelected(event, true)"
+                        @click="selectHeaderOrFoterByClick($event, 'header')"
                     >
                         <slot name="header" />
                     </div>
@@ -91,7 +91,7 @@
                         role="button"
                         tabindex="0"
                         :class="{ 'is-hovered': footerHovered }"
-                        @click="(event) => checkIfHeaderOrFooterSelected(event, true)"
+                        @click="selectHeaderOrFoterByClick($event, 'footer')"
                     >
                         <slot name="footer" />
                     </div>
@@ -429,27 +429,31 @@ export default {
                 if (this.hovered === null) {
                     // header and footer uses headerHovered && footerHovered. If header or footer
                     // was selected then fire event otherwise just return so a value isn't selected
-                    this.checkIfHeaderOrFooterSelected(event, false, closeDropdown)
+                    this.checkIfHeaderOrFooterSelected(event, null, closeDropdown)
                     return
                 }
                 this.setSelected(this.hovered, closeDropdown, event)
             }
         },
 
+        selectHeaderOrFoterByClick(event, origin) {
+            this.checkIfHeaderOrFooterSelected(event, {origin: origin})
+        },
+
         /**
          * Check if header or footer was selected.
          */
-        checkIfHeaderOrFooterSelected(event, triggeredByclick, closeDropdown = true) {
-            if (this.selectableHeader && (this.headerHovered || triggeredByclick)) {
+        checkIfHeaderOrFooterSelected(event, triggerClick, closeDropdown = true) {
+            if (this.selectableHeader && (this.headerHovered || (triggerClick && triggerClick.origin === 'header'))) {
                 this.$emit('select-header', event)
                 this.headerHovered = false
-                if (triggeredByclick) this.setHovered(null)
+                if (triggerClick) this.setHovered(null)
                 if (closeDropdown) this.isActive = false
             }
-            if (this.selectableFooter && (this.footerHovered || triggeredByclick)) {
+            if (this.selectableFooter && (this.footerHovered || (triggerClick && triggerClick.origin === 'footer'))) {
                 this.$emit('select-footer', event)
                 this.footerHovered = false
-                if (triggeredByclick) this.setHovered(null)
+                if (triggerClick) this.setHovered(null)
                 if (closeDropdown) this.isActive = false
             }
         },


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #3533

Use the trigger as an object that identifies whether the click was in the header or footer. Another proposed change for this PR is in the docs. Selectable header and footer documents use an `<a>` with `@click` event, but `@select-header` and `@select-footer` are sufficient.

## Proposed Changes

- Check origin of click to trigger correctly for header or footer
- Improve docs for Autocomplete Header and Footer
