### PR TITLE
Fix notice queue

### DIFF
--- a/src/utils/NoticeMixin.js
+++ b/src/utils/NoticeMixin.js
@@ -125,6 +125,7 @@ export default {
         },
 
         showNotice() {
+            if (this._isDestroyed) return
             if (this.shouldQueue()) {
                 // Call recursively if should queue
                 setTimeout(() => this.showNotice(), 250)

--- a/src/utils/NoticeMixin.spec.js
+++ b/src/utils/NoticeMixin.spec.js
@@ -48,4 +48,28 @@ describe('NoticeMixin', () => {
         wrapper.vm.close()
         expect(wrapper.vm.isActive).toBeFalsy()
     })
+
+    it('should not insert element when component is destroyed', () => {
+        jest.useFakeTimers()
+        HTMLElement.prototype.insertAdjacentElement = jest.fn()
+        let queueCounter = 0
+
+        const component = {
+            template: '<div class="b-component"></div>'
+        }
+        const wrapper = shallowMount(component, {
+            attachToDocument: true,
+            mixins: [NoticeMixin],
+            methods: {
+                shouldQueue() {
+                    if (queueCounter++ >= 5) wrapper.destroy()
+                    return true
+                }
+            }
+        })
+
+        jest.advanceTimersByTime(1500)
+
+        expect(HTMLElement.prototype.insertAdjacentElement).toHaveBeenCalledTimes(0)
+    })
 })


### PR DESCRIPTION
Fixes #3424

Following steps to reproduce it is possible to see that no other Toast can be opened, but the real and big problem was happening in recursion. Since the toast is closed (with` .close() `call) before added to DOM the component is destroyed, but nothing happens with the element that will added to DOM. It will be added to DOM anyway,  it is not visible, but is in the DOM.

In this scenario the `shouldQueue()` always return `true` because of the following condition.

```js
return (
    this.parentTop.childElementCount > 0 ||
    this.parentBottom.childElementCount > 0
)
```

In `showNotice()` this ends the execution and call `showNotice()` again, and it will **`happen FOREVER`**.

## Proposed Changes

- Check if component is destroyed
