### PR TITLE
Use v-show instead of v-if in Loading component

### DIFF
--- a/src/components/loading/Loading.vue
+++ b/src/components/loading/Loading.vue
@@ -3,7 +3,7 @@
         <div
             class="loading-overlay is-active"
             :class="{ 'is-full-page': displayInFullPage }"
-            v-if="isActive">
+            v-show="isActive">
             <div class="loading-background" @click="cancel"/>
             <slot>
                 <div class="loading-icon" />

--- a/src/components/loading/__snapshots__/Loading.spec.js.snap
+++ b/src/components/loading/__snapshots__/Loading.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BLoading active render correctly 1`] = `
 <transition-stub name="fade">
-    <div class="loading-overlay is-active is-full-page">
+    <div class="loading-overlay is-active is-full-page" style="">
         <div class="loading-background"></div>
         <div class="loading-icon"></div>
     </div>


### PR DESCRIPTION
## Proposed Changes

- Use `v-show` instead of `v-if` in Loading.vue

## Proposed Reasons

- I think v-show is better for performance reasons because the rendering cost of this component is small and the state changes frequently.
- For example, if someone using nuxt/firebase authenticates with CSR and changes the state of this component according to the result, v-if will create different virtual DOMs for SSR and CSR. To avoid this problem and make it easier to use, I believe v-show is the way to go.