### PR TITLE
[Feature Request]: Stop progress of remaining time when pause on hover in Programmatic notification

### DIFF
--- a/docs/pages/components/notification/examples/ExProgrammatically.vue
+++ b/docs/pages/components/notification/examples/ExProgrammatically.vue
@@ -66,6 +66,7 @@
                     duration: 5000,
                     progressBar: true,
                     type: 'is-primary',
+                    pauseOnHover: true
                 })
             },
         }

--- a/src/utils/MessageMixin.js
+++ b/src/utils/MessageMixin.js
@@ -113,7 +113,7 @@ export default {
                  * Runs every one second to set the duration passed before
                  * the alert will auto close to show it in the progress bar (Remaining Time)
                  */
-                this.progress = setInterval(() => {
+                window.durationProgress = setInterval(() => {
                     if (this.remainingTime !== 0) {
                         this.remainingTime -= 1
                     } else {
@@ -128,7 +128,7 @@ export default {
              **/
             window.setTimeout(() => {
                 this.remainingTime = this.duration / 1000
-                clearInterval(this.progress)
+                clearInterval(window.durationProgress)
             }, 100)
         }
     },

--- a/src/utils/NoticeMixin.js
+++ b/src/utils/NoticeMixin.js
@@ -83,6 +83,7 @@ export default {
         pause() {
             if (this.pauseOnHover && !this.indefinite) {
                 this.isPaused = true
+                clearInterval(window.durationProgress)
             }
         },
         removePause() {


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #3545
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes
- made the **ID** of remaining time interval **global** (`window`) for accessibility in `NoticeMixin.vue` to clear it when hover.
- add `clearInterval` in pause event.

[Click Here](https://firebasestorage.googleapis.com/v0/b/webcheck-fd169.appspot.com/o/Recording%20%235.mp4?alt=media&token=55e20994-c7dc-4134-9fab-f212b4db5f9b) to see a video showing that feature.

### Notice: All of the my Latest PRs are related to the same main feature (remaining time in progress) because it gonna struggle the author by review, not want to make a big PR that is Hard to review then merge, 
### This is gonna be the last PR Related to this Feature.

