### PR TITLE
Allow navbar burger and dropdowns to be focusable and keyboard-selectable

### DIFF
--- a/src/components/navbar/Navbar.vue
+++ b/src/components/navbar/Navbar.vue
@@ -176,7 +176,11 @@ export default {
                         isOpened: this.isOpened
                     },
                     on: {
-                        click: this.toggleActive
+                        click: this.toggleActive,
+                        keyup: (event) => {
+                            if (event.keyCode !== 13) return
+                            this.toggleActive()
+                        }
                     }
                 })
 

--- a/src/components/navbar/NavbarBurger.vue
+++ b/src/components/navbar/NavbarBurger.vue
@@ -6,6 +6,7 @@
         aria-label="menu"
         :aria-expanded="isOpened"
         v-on="$listeners"
+        tabindex="0"
     >
         <span aria-hidden="true"/>
         <span aria-hidden="true"/>

--- a/src/components/navbar/NavbarDropdown.vue
+++ b/src/components/navbar/NavbarDropdown.vue
@@ -19,7 +19,10 @@
             v-on="$listeners"
             role="menuitem"
             aria-haspopup="true"
-            @click.prevent="newActive = !newActive">
+            @click.prevent="toggleMenu"
+            @keyup.enter="toggleMenu"
+            tabindex="0"
+        >
             <template v-if="label">{{ label }}</template>
             <slot v-else name="label" />
         </component>
@@ -75,6 +78,9 @@ export default {
         }
     },
     methods: {
+        toggleMenu() {
+            this.newActive = !this.newActive
+        },
         showMenu() {
             this.newActive = true
         },

--- a/src/components/navbar/__snapshots__/NavBar.spec.js.snap
+++ b/src/components/navbar/__snapshots__/NavBar.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BNavbar render correctly 1`] = `
 <nav role="navigation" aria-label="main navigation" class="navbar">
-    <div class="navbar-brand"><a role="button" aria-label="menu" class="navbar-burger burger"><span aria-hidden="true"></span> <span aria-hidden="true"></span> <span aria-hidden="true"></span></a></div>
+    <div class="navbar-brand"><a role="button" aria-label="menu" tabindex="0" class="navbar-burger burger"><span aria-hidden="true"></span> <span aria-hidden="true"></span> <span aria-hidden="true"></span></a></div>
     <div class="navbar-menu">
         <div class="navbar-start"></div>
         <div class="navbar-end"></div>

--- a/src/components/navbar/__snapshots__/NavBarBurger.spec.js.snap
+++ b/src/components/navbar/__snapshots__/NavBarBurger.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BNavbarBurger render correctly 1`] = `<a role="button" aria-label="menu" class="navbar-burger burger"><span aria-hidden="true"></span> <span aria-hidden="true"></span> <span aria-hidden="true"></span></a>`;
+exports[`BNavbarBurger render correctly 1`] = `<a role="button" aria-label="menu" tabindex="0" class="navbar-burger burger"><span aria-hidden="true"></span> <span aria-hidden="true"></span> <span aria-hidden="true"></span></a>`;

--- a/src/components/navbar/__snapshots__/NavbarDropdown.spec.js.snap
+++ b/src/components/navbar/__snapshots__/NavbarDropdown.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BNavbarDropdown render correctly 1`] = `
-<div class="navbar-item has-dropdown"><a role="menuitem" aria-haspopup="true" class="navbar-link"></a>
+<div class="navbar-item has-dropdown"><a role="menuitem" aria-haspopup="true" tabindex="0" class="navbar-link"></a>
     <div class="navbar-dropdown"></div>
 </div>
 `;


### PR DESCRIPTION
Fixes #3395

## Proposed Changes

- Add `tabindex="0"` for navbar-burger and navbar-dropdowns to be focusable
- Add handler to toggle the status of these elements through the enter key
