### PR TITLE
Add aria-label on modal close button

### DIFF
--- a/docs/pages/components/modal/api/modal.js
+++ b/docs/pages/components/modal/api/modal.js
@@ -142,6 +142,13 @@ export default [
                 type: 'Boolean',
                 values: '—',
                 default: '<code>false</code>'
+            },
+            {
+                name: '<code>close-button-aria-label</code>',
+                description: `Aria label attribute to be passed to the close button for better accessibility.`,
+                type: 'String',
+                values: '—',
+                default: '—'
             }
         ],
         events: [

--- a/docs/pages/components/modal/examples/ExComponent.vue
+++ b/docs/pages/components/modal/examples/ExComponent.vue
@@ -13,6 +13,7 @@
             :destroy-on-hide="false"
             aria-role="dialog"
             aria-label="Example Modal"
+            close-button-aria-label="Close"
             aria-modal>
             <template #default="props">
                 <modal-form v-bind="formProps" @close="props.close"></modal-form>

--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -40,6 +40,7 @@
                     v-if="showX"
                     v-show="!animating"
                     class="modal-close is-large"
+                    :aria-label="closeButtonAriaLabel"
                     @click="cancel('x')"/>
             </div>
         </div>
@@ -131,6 +132,7 @@ export default {
                 return Boolean(value)
             }
         },
+        closeButtonAriaLabel: String,
         destroyOnHide: {
             type: Boolean,
             default: true


### PR DESCRIPTION
Note: For some reason exiting the component modal in docs is broken on `dev` (and this PR).