### PR TITLE
Change timepicker Intl.DateTimeFormat option to use hourCycle option

### DIFF
--- a/docs/pages/components/timepicker/examples/ExEditable.vue
+++ b/docs/pages/components/timepicker/examples/ExEditable.vue
@@ -60,7 +60,8 @@ export default {
                 hour: 'numeric',
                 minute: 'numeric',
                 second: this.enableSeconds ? 'numeric' : undefined,
-                hour12: this.hourFormat ? this.hourFormat === '12' : undefined
+                // Fixes 12 hour display github.com/buefy/buefy/issues/3418
+                hourCycle: this.hourFormat === '12' ? 'h12' : 'h23'
             })
             return dtf.format(new Date(2000, 12, 12, 22, 23, 24))
         }

--- a/src/components/datetimepicker/Datetimepicker.vue
+++ b/src/components/datetimepicker/Datetimepicker.vue
@@ -217,7 +217,8 @@ export default {
                 hour: this.localeOptions.hour || 'numeric',
                 minute: this.localeOptions.minute || 'numeric',
                 second: this.enableSeconds() ? this.localeOptions.second || 'numeric' : undefined,
-                hour12: !this.isHourFormat24()
+                // Fixes 12 hour display github.com/buefy/buefy/issues/3418
+                hourCycle: !this.isHourFormat24 ? 'h12' : 'h23'
             })
         },
         isMobileNative() {

--- a/src/utils/TimepickerMixin.js
+++ b/src/utils/TimepickerMixin.js
@@ -211,7 +211,8 @@ export default {
                 hour: this.localeOptions.hour || 'numeric',
                 minute: this.localeOptions.minute || 'numeric',
                 second: this.enableSeconds ? this.localeOptions.second || 'numeric' : undefined,
-                hour12: !this.isHourFormat24
+                // Fixes 12 hour display github.com/buefy/buefy/issues/3418
+                hourCycle: !this.isHourFormat24 ? 'h12' : 'h23'
             })
         },
         newHourFormat() {


### PR DESCRIPTION
Fixes issue #3418 @jtommy 

<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

Change default format function Intl.DateTimeFormat to use different option for 12 hour format so that 12pm isnt displayed as 0pm
