### PR TITLE
Corrected a misplaced letter

### DIFF
--- a/docs/pages/components/breadcrumb/api/breadcrumb.js
+++ b/docs/pages/components/breadcrumb/api/breadcrumb.js
@@ -11,7 +11,7 @@ export default [
             },
             {
                 name: '<code>separator</code>',
-                description: 'Symbole that separates the bradcrumb items.',
+                description: 'Symbol that separates the breadcrumb items.',
                 type: 'String',
                 values: '<code>has-arrow-separator</code>, <code>has-bullet-separator</code>, <code>has-dot-separator</code>, <code>has-succeeds-separator</code>',
                 default: '—'


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes
"Symbole that separates the bradcrumb items." should read as: "Symbol that separates the breadcrumb items."

-
-
-
