### PR TITLE
Emit an 'active-change' event from the navbar dropdown

### DIFF
--- a/docs/pages/components/navbar/api/navbar.js
+++ b/docs/pages/components/navbar/api/navbar.js
@@ -189,6 +189,13 @@ export default [
             description: 'Dropdown menu custom label',
             props: '-'
         }
+    ],
+    events: [
+        {
+            name: '<code>active-change</code>',
+            description: 'Triggers when dropdown is activated or deactivated (visibility of list)',
+            parameters: '<code>active: Boolean</code>'
+        }
     ]
   }
 ]

--- a/src/components/navbar/NavbarDropdown.vue
+++ b/src/components/navbar/NavbarDropdown.vue
@@ -74,6 +74,10 @@ export default {
     watch: {
         active(value) {
             this.newActive = value
+        },
+
+        newActive(value) {
+            this.$emit('active-change', value)
         }
     },
     methods: {


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Thanks for Buefy!

<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Emit an `active-change` event from the navbar dropdown when it is shown or hidden

This change brings the navbar dropdown into closer API symmetry with the dropdown component.  My use case is I have dynamic content inside the dropdown that I wish to reset when the dropdown is hidden.  By listening for the event, I can handle it in my enclosing component.