### PR TITLE
Document v-model for Notification

### DIFF
--- a/docs/pages/components/notification/api/notification.js
+++ b/docs/pages/components/notification/api/notification.js
@@ -2,6 +2,13 @@ export default [
     {
         props: [
             {
+                name: '<code>v-model</code>',
+                description: 'Active state - set on `true` to reopen after close',
+                type: 'Boolean',
+                values: '—',
+                default: 'true'
+            },
+            {
                 name: '<code>type</code>',
                 description: 'Type (color) of the notification, optional',
                 type: 'String',


### PR DESCRIPTION
## Proposed Changes

- Missing docs for https://buefy.org/documentation/notification. Note: the v-model is visible in the examples.  

