### PR TITLE
Fix: display zero in numberinput (#3614)

### DIFF
--- a/src/components/numberinput/Numberinput.vue
+++ b/src/components/numberinput/Numberinput.vue
@@ -160,7 +160,7 @@ export default {
                 return this.newValue
             },
             set(value) {
-                let newValue = Number(value) || null
+                let newValue = Number(value) || 0
                 if (value === '' || value === undefined || value === null) {
                     if (this.minNumber !== undefined) {
                         newValue = this.minNumber


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #3614
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- "Number(0) || null" will return null, and the actual value is 0. So what I propose is that all the invalid values and 0 are set to 0
