### PR TITLE
Fix typo with isNil helper method

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -372,7 +372,7 @@
 </template>
 
 <script>
-import { getValueByPath, indexOf, multiColumnSort, escapeRegExpChars, toCssWidth, removeDiacriticsFromString } from '../../utils/helpers'
+import { getValueByPath, indexOf, multiColumnSort, escapeRegExpChars, toCssWidth, removeDiacriticsFromString, isNil } from '../../utils/helpers'
 import debounce from '../../utils/debounce'
 import { VueInstance } from '../../utils/config'
 import Checkbox from '../checkbox/Checkbox'
@@ -908,8 +908,10 @@ export default {
                         return isAsc ? newA - newB : newB - newA
                     }
 
-                    if (!newA && newA !== 0) return 1
-                    if (!newB && newB !== 0) return -1
+                    // sort null values to the bottom when in asc order
+                    // and to the top when in desc order
+                    if (!isNil(newB) && isNil(newA)) return isAsc ? 1 : -1
+                    if (!isNil(newA) && isNil(newB)) return isAsc ? -1 : 1
                     if (newA === newB) return 0
 
                     newA = (typeof newA === 'string')

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -298,3 +298,10 @@ export function isCustomElement(vm) {
 }
 
 export const isDefined = (d) => d !== undefined
+
+/**
+ * Checks if a value is null or undefined.
+ * Based on
+ * https://github.com/lodash/lodash/blob/master/isNil.js
+ */
+export const isNil = (value) => value !== null || value !== undefined

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -304,4 +304,4 @@ export const isDefined = (d) => d !== undefined
  * Based on
  * https://github.com/lodash/lodash/blob/master/isNil.js
  */
-export const isNil = (value) => value !== null || value !== undefined
+export const isNil = (value) => value === null || value === undefined


### PR DESCRIPTION
Fixes #3618

## Proposed Changes

- There was a typo when adding the new `isNil` helper method in #3619 to resolve the null value table sorting behavior
- This PR fixes this typo so that this method correctly checks for null or undefined values
