### PR TITLE
extend the firstDayOfWeek prop to Datetimepicker

### DIFF
--- a/docs/pages/components/datetimepicker/api/datetimepicker.js
+++ b/docs/pages/components/datetimepicker/api/datetimepicker.js
@@ -37,6 +37,13 @@ export default [
                 default: '—'
             },
             {
+                name: '<code>first-day-of-week</code>',
+                description: 'First day of week to display in table header',
+                type: 'Number',
+                values: '<code>0 - 6 (Sunday is 0, Monday is 1, and so on)</code>',
+                default: '<code>0</code>'
+            },
+            {
                 name: '<code>size</code>',
                 description: 'Vertical size of input and picker, optional',
                 type: 'String',

--- a/docs/pages/components/datetimepicker/examples/ExSimple.vue
+++ b/docs/pages/components/datetimepicker/examples/ExSimple.vue
@@ -25,6 +25,18 @@
                     <option value="zn-CN">zn-CN</option>
                 </b-select>
             </b-field>
+            <b-field label="First day of week">
+                <b-select v-model="firstDayOfWeek">
+                    <option :value="undefined"></option>
+                    <option :value="0">Sunday</option>
+                    <option :value="1">Monday</option>
+                    <option :value="2">Tuesday</option>
+                    <option :value="3">Wednesday</option>
+                    <option :value="4">Thursday</option>
+                    <option :value="5">Friday</option>
+                    <option :value="6">Saturday</option>
+                </b-select>
+            </b-field>
             <b-field label="Hour format">
                 <b-select v-model="hourFormat">
                     <option :value="undefined"></option>
@@ -43,6 +55,7 @@
                 icon-right-clickable
                 @icon-right-click="clearDateTime"
                 :locale="locale"
+                :first-day-of-week="firstDayOfWeek"
                 :datepicker="{ showWeekNumber }"
                 :timepicker="{ enableSeconds, hourFormat }"
                 horizontal-time-picker>
@@ -59,7 +72,8 @@ export default {
             showWeekNumber: false,
             enableSeconds: false,
             hourFormat: undefined, // Browser locale
-            locale: undefined // Browser locale
+            locale: undefined, // Browser locale
+            firstDayOfWeek: undefined // 0 - Sunday
         }
     },
     methods: {

--- a/src/components/datetimepicker/Datetimepicker.vue
+++ b/src/components/datetimepicker/Datetimepicker.vue
@@ -12,6 +12,8 @@
         :editable="editable"
         :expanded="expanded"
         :close-on-click="false"
+        :first-day-of-week="firstDayOfWeek"
+        :rules-for-first-week="rulesForFirstWeek"
         :date-formatter="defaultDatetimeFormatter"
         :date-parser="defaultDatetimeParser"
         :min-date="minDate"
@@ -116,6 +118,20 @@ export default {
         placeholder: String,
         horizontalTimePicker: Boolean,
         disabled: Boolean,
+        firstDayOfWeek: {
+            type: Number,
+            default: () => {
+                if (typeof config.defaultFirstDayOfWeek === 'number') {
+                    return config.defaultFirstDayOfWeek
+                } else {
+                    return 0
+                }
+            }
+        },
+        rulesForFirstWeek: {
+            type: Number,
+            default: () => 4
+        },
         icon: String,
         iconRight: String,
         iconRightClickable: Boolean,

--- a/types/components.d.ts
+++ b/types/components.d.ts
@@ -1,5 +1,5 @@
 import _Vue from "vue";
-import {ColorModifiers, GlobalPositions, SizesModifiers} from "./helpers";
+import {ColorModifiers, DaysOfWeek, GlobalPositions, SizesModifiers} from "./helpers";
 
 // Component base definition
 export class BComponent extends _Vue {
@@ -32,7 +32,7 @@ export declare type BuefyConfig = {
     defaultDateCreator?: Function;
     defaultDayNames?: string[];
     defaultMonthNames?: string[];
-    defaultFirstDayOfWeek?: number;
+    defaultFirstDayOfWeek?: DaysOfWeek;
     defaultUnselectableDaysOfWeek?: number[];
     defaultTimeFormatter?: Function;
     defaultTimeParser?: Function;

--- a/types/helpers.d.ts
+++ b/types/helpers.d.ts
@@ -2,3 +2,4 @@ export type ColorModifiers = 'is-white' | 'is-black' | 'is-light' | 'is-dark' | 
 export type GlobalPositions = 'is-top-right' | 'is-top' | 'is-top-left' | 'is-bottom-right' | 'is-bottom' | 'is-bottom-left';
 export type SizesModifiers = 'is-small' | 'is-medium' | 'is-large';
 export type IconPacks = 'mdi' | 'fa' | 'fas' | 'far' | 'fab' | 'fad' | 'fal';
+export type DaysOfWeek = 0 | 1 | 2 | 3 | 4 | 5 | 6;


### PR DESCRIPTION
I don't know if I misread the documentation, but I didn't see the way to choose the first day of the week on `Datetimepicker` when the prop is available on the `Datepicker` 🤔

## Proposed Change
- add prop `firstDayOfWeek` on `Datetimepicker`
