### PR TITLE
Add generic to ColorModifiers type

### DIFF
--- a/types/helpers.d.ts
+++ b/types/helpers.d.ts
@@ -1,4 +1,4 @@
-export type ColorModifiers = 'is-white' | 'is-black' | 'is-light' | 'is-dark' | 'is-primary' | 'is-info' | 'is-success' | 'is-warning' | 'is-danger' | string;
+export type ColorModifiers<T = string> = 'is-white' | 'is-black' | 'is-light' | 'is-dark' | 'is-primary' | 'is-info' | 'is-success' | 'is-warning' | 'is-danger' | T;
 export type GlobalPositions = 'is-top-right' | 'is-top' | 'is-top-left' | 'is-bottom-right' | 'is-bottom' | 'is-bottom-left';
 export type SizesModifiers = 'is-small' | 'is-medium' | 'is-large';
 export type IconPacks = 'mdi' | 'fa' | 'fas' | 'far' | 'fab' | 'fad' | 'fal';


### PR DESCRIPTION
## Proposed Changes

- Add generic to ColorModifiers type

ATM ColorModifiers type will always resolve to `string` because of `| string`. 
This PR will allow to pass custom union to `ColorModifiers` when defining new colors in a project using buefy / bulma, which will make the type more strict and representative of the colors used in your project.
As the default type of the generic is string, it will not break existing configurations.

## Usage
```
type ProjectColors = ColorModifiers<'is-very-danger' | 'is-secondary'>
// Will resolve to 'is-white' | 'is-black' | 'is-light' | 'is-dark' | 'is-primary' | 'is-info' | 'is-success' | 'is-warning' | 'is-danger' | 'is-very-danger' | 'is-secondary'
```

Not sure if it's the right way to go, or is it better to create a `.d.ts` file directly in your project and overwritting this type as needed ? 