### PR TITLE
Allow "any" keyword as step in Numberinput component

### DIFF
--- a/src/components/numberinput/Numberinput.spec.js
+++ b/src/components/numberinput/Numberinput.spec.js
@@ -101,6 +101,26 @@ describe('BNumberinput', () => {
 
             expect(wrapper.vm.computedValue).toEqual(BASE_VALUE)
         })
+
+        it('is invalid when step / minStep decimals and value decimals lengths are different', () => {
+            wrapper.setProps({step: 1, value: 1.15})
+            expect(wrapper.find('input').element.checkValidity()).toEqual(false)
+            wrapper.setProps({step: 1.15, value: 1.154})
+            expect(wrapper.find('input').element.checkValidity()).toEqual(false)
+            wrapper.setProps({step: 1.15, value: 1.11541, minStep: 0.0001})
+            expect(wrapper.find('input').element.checkValidity()).toEqual(false)
+        })
+
+        it('is valid when step is "any"', () => {
+            wrapper.setProps({step: 'any', value: 1.15})
+            expect(wrapper.find('input').element.checkValidity()).toEqual(true)
+            wrapper.setProps({step: 'any', value: 1.054878})
+            expect(wrapper.find('input').element.checkValidity()).toEqual(true)
+            wrapper.setProps({step: 'any', value: 1})
+            expect(wrapper.find('input').element.checkValidity()).toEqual(true)
+            wrapper.setProps({step: 'any', value: ''})
+            expect(wrapper.find('input').element.checkValidity()).toEqual(true)
+        })
     })
 
     describe('Rendered (shallow)', () => {
@@ -221,6 +241,26 @@ describe('BNumberinput', () => {
             expect(wrapper.vm.computedValue).toBe(start - (step * 2))
         })
 
+        it('can increment / decrement with a "any" step', () => {
+            const start = 5
+            const step = 'any'
+            const min = -5
+            wrapper.vm.computedValue = start
+            wrapper.setProps({ step, min })
+            wrapper.vm.decrement()
+            expect(wrapper.vm.computedValue).toBe(start - 1)
+            wrapper.vm.decrement()
+            expect(wrapper.vm.computedValue).toBe(start - (1 * 2))
+
+            const decimalStart = 5.15
+            wrapper.vm.computedValue = decimalStart
+            wrapper.setProps({ step, min })
+            wrapper.vm.decrement()
+            expect(wrapper.vm.computedValue).toBe(start - 1)
+            wrapper.vm.decrement()
+            expect(wrapper.vm.computedValue).toBe(start - (1 * 2))
+        })
+
         it('can increment / decrement with minStep', () => {
             const start = 5.51
             const step = 0.2
@@ -241,6 +281,28 @@ describe('BNumberinput', () => {
             wrapper.setProps({ minStep: newMinStep })
             wrapper.vm.decrement()
             expect(wrapper.vm.computedValue).toBe(5.3)
+        })
+
+        it('can increment / decrement with minStep and "any" as step', () => {
+            const start = 5.51
+            const step = 'any'
+            const minStep = 0.01
+            const min = -5
+            wrapper.vm.computedValue = start
+            wrapper.setProps({ step, min, minStep })
+            wrapper.vm.decrement()
+            expect(wrapper.vm.computedValue).toBe(4.51)
+            wrapper.vm.decrement()
+            expect(wrapper.vm.computedValue).toBe(3.51)
+            wrapper.vm.increment()
+            expect(wrapper.vm.computedValue).toBe(4.51)
+            wrapper.vm.increment()
+            expect(wrapper.vm.computedValue).toBe(5.51)
+
+            const newMinStep = 0.1
+            wrapper.setProps({ minStep: newMinStep })
+            wrapper.vm.decrement()
+            expect(wrapper.vm.computedValue).toBe(4.5)
         })
 
         it('manages empty value', () => {

--- a/src/components/numberinput/Numberinput.vue
+++ b/src/components/numberinput/Numberinput.vue
@@ -210,9 +210,15 @@ export default {
             return typeof this.max === 'string' ? parseFloat(this.max) : this.max
         },
         stepNumber() {
+            if (this.newStep === 'any') {
+                return 1
+            }
             return typeof this.newStep === 'string' ? parseFloat(this.newStep) : this.newStep
         },
         minStepNumber() {
+            if (this.newStep === 'any' && typeof this.newMinStep === 'undefined') {
+                return 'any'
+            }
             const step = typeof this.newMinStep !== 'undefined' ? this.newMinStep : this.newStep
             return typeof step === 'string' ? parseFloat(step) : step
         },


### PR DESCRIPTION
Fixes #3565
This is only a partial fix for #3565, see https://github.com/buefy/buefy/issues/3565#issuecomment-996278575

## Proposed Changes

- Allow the use of ["any"](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/number#step) keyword for step prop

Changes seem to mimic native behavior quite well, I added a few unit tests to that specific behaviour. 
Tell me if that's seems to be ok for you, and if you want me to add a few lines in the documentation if the PR passes
