### PR TITLE
Fix: solve two bugs in multiple sorting table

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -880,7 +880,12 @@ export default {
                 let formattedSortingPriority = this.sortMultipleDataLocal.map((i) => {
                     return (i.order && i.order === 'desc' ? '-' : '') + i.field
                 })
-                this.newData = multiColumnSort(this.newData, formattedSortingPriority)
+
+                if (formattedSortingPriority.length === 0) {
+                    this.resetMultiSorting()
+                } else {
+                    this.newData = multiColumnSort(this.newData, formattedSortingPriority)
+                }
             }
         },
         resetMultiSorting() {

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -988,8 +988,8 @@ export default {
                 }
                 if (!this.backendSorting) {
                     this.doSortSingleColumn(column)
+                    this.currentSortColumn = column
                 }
-                this.currentSortColumn = column
             }
         },
 


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #3638
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

### First Problem (Issue #3638)

When multiple sorting and backend sorting are enabled, even if all sorts are removed, the arrow icon persists.

https://user-images.githubusercontent.com/78249749/150859704-0866ed07-7e20-48d3-adb7-d63bcf3e2aff.mov

I fix this issue in 27246c1ed192044877e3d8ce4e17cee36221a5c7.

### Second Problem

In multiple sorting, the table should be reset when all sorts are removed:

https://user-images.githubusercontent.com/78249749/150859656-2dd676de-003d-4c99-9d6c-51d15e7033b6.mov

I fix this issue in 27246c1ed192044877e3d8ce4e17cee36221a5c7 by adding a simple condition in `removeSortingPriority` method and call `resetMultiSorting` method if the length of `formattedSortingPriority` is equal to zero.
