### PR TITLE
Fix Tooltip.vue

### DIFF
--- a/src/components/tooltip/Tooltip.vue
+++ b/src/components/tooltip/Tooltip.vue
@@ -1,5 +1,5 @@
 <template>
-    <div ref="tooltip" :class="[...rootClasses, 'is-inline']">
+    <div ref="tooltip" :class="rootClasses">
         <transition :name="newAnimation">
             <div
                 v-show="active && (isActive || always)"

--- a/src/components/tooltip/Tooltip.vue
+++ b/src/components/tooltip/Tooltip.vue
@@ -1,5 +1,5 @@
 <template>
-    <span ref="tooltip" :class="rootClasses">
+    <div ref="tooltip" :class="[...rootClasses, 'is-inline']">
         <transition :name="newAnimation">
             <div
                 v-show="active && (isActive || always)"
@@ -23,7 +23,7 @@
             @mouseleave="close">
             <slot ref="slot" />
         </div>
-    </span>
+    </div>
 </template>
 
 <script>


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #

Fix Tooltip.vue because div inside span tag gives validation error - validator.w3.org

<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Change span to div tag in Tooltip.vue and add ```is-inline``` class to this
