### PR TITLE
Fix colorpicker scss build error

### DIFF
--- a/src/scss/components/_colorpicker.scss
+++ b/src/scss/components/_colorpicker.scss
@@ -149,7 +149,7 @@ div.b-colorpicker-square {
         left: 0;
 
         .hue-range-thumb {
-            border-radius: calc($colorpicker-radius / 1.75);
+            border-radius: calc(#{$colorpicker-radius} / 1.75);
             position: absolute;
             aspect-ratio: 1 / 1;
             transform: translate(-50%, -50%);


### PR DESCRIPTION
Fixes following error when running `npm run build` on a project using buefy version 0.9.16
```
Error: CSS minification error: Lexical error on line 1: Unrecognized text.

  Erroneous area:
1: $colorpicker-radius / 1.75
^..^. File: css/app.90f56c4c.css
```