### PR TITLE
Changes aria-expanded attr from collapse content to trigger button.

### DIFF
--- a/docs/pages/components/collapse/examples/ExAccordion.vue
+++ b/docs/pages/components/collapse/examples/ExAccordion.vue
@@ -7,11 +7,14 @@
             v-for="(collapse, index) of collapses"
             :key="index"
             :open="isOpen == index"
-            @open="isOpen = index">
+            @open="isOpen = index"
+            :aria-id="'contentIdForA11y5-' + index">
             <template #trigger="props">
                 <div
                     class="card-header"
                     role="button"
+                    :aria-controls="'contentIdForA11y5-' + index"
+                    :aria-expanded="props.open"
                 >
                     <p class="card-header-title">
                         {{ collapse.title }}

--- a/docs/pages/components/collapse/examples/ExCardTemplate.vue
+++ b/docs/pages/components/collapse/examples/ExCardTemplate.vue
@@ -9,7 +9,8 @@
                 <div
                     class="card-header"
                     role="button"
-                    aria-controls="contentIdForA11y3">
+                    aria-controls="contentIdForA11y3"
+                    :aria-expanded="props.open">
                     <p class="card-header-title">
                         Component
                     </p>

--- a/docs/pages/components/collapse/examples/ExPanelTemplate.vue
+++ b/docs/pages/components/collapse/examples/ExPanelTemplate.vue
@@ -7,6 +7,7 @@
                 type="is-primary"
                 size="is-medium"
                 @click="isOpen = !isOpen"
+                :aria-expanded="isOpen"
                 aria-controls="contentIdForA11y2" />
         </div>
 
@@ -19,7 +20,8 @@
                 <div
                     class="panel-heading"
                     role="button"
-                    aria-controls="contentIdForA11y2">
+                    aria-controls="contentIdForA11y2"
+                    :aria-expanded="isOpen">
                     <strong>Title</strong>
                 </div>
             </template>

--- a/docs/pages/components/collapse/examples/ExPosition.vue
+++ b/docs/pages/components/collapse/examples/ExPosition.vue
@@ -13,9 +13,11 @@
         <b-collapse 
             :open="false" 
             position="is-bottom" 
-            aria-id="contentIdForA11y1">
+            aria-id="contentIdForA11y4">
             <template #trigger="props">
-                <a aria-controls="contentIdForA11y1">
+                <a
+                    aria-controls="contentIdForA11y4"
+                    :aria-expanded="props.open">
                     <b-icon :icon="!props.open ? 'menu-down' : 'menu-up'"></b-icon>
                     {{ !props.open ? 'All options' : 'Fewer options' }}
                 </a>

--- a/docs/pages/components/collapse/examples/ExSimple.vue
+++ b/docs/pages/components/collapse/examples/ExSimple.vue
@@ -2,11 +2,12 @@
     <section>
 
         <b-collapse :open="false" aria-id="contentIdForA11y1">
-            <template #trigger>
+            <template #trigger="props">
                 <b-button
                     label="Click me!"
                     type="is-primary"
-                    aria-controls="contentIdForA11y1" />
+                    aria-controls="contentIdForA11y1"
+                    :aria-expanded="props.open" />
             </template>
             <div class="notification">
                 <div class="content">

--- a/src/components/collapse/Collapse.vue
+++ b/src/components/collapse/Collapse.vue
@@ -60,7 +60,7 @@ export default {
         const content = createElement('transition', { props: { name: this.animation } }, [
             createElement('div', {
                 staticClass: 'collapse-content',
-                attrs: { 'id': this.ariaId, 'aria-expanded': this.isOpen },
+                attrs: { 'id': this.ariaId },
                 directives: [{
                     name: 'show',
                     value: this.isOpen

--- a/src/components/collapse/__snapshots__/Collapse.spec.js.snap
+++ b/src/components/collapse/__snapshots__/Collapse.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BCollapse default render correctly 1`] = `
 <div class="collapse">
-    <div class="collapse-trigger"></div>
-    <div id="" aria-expanded="true" class="collapse-content"></div>
+    <div aria-expanded="true"></div>
+    <div id="" class="collapse-content"></div>
 </div>
 `;


### PR DESCRIPTION
Fixes #3680

## Proposed Changes

- Removes `aria-expanded="true"` from `.collapse-content`
- Passes it in the documentation to the trigger content, most of the cases a button
- Adds proper aria-ids to the examples, to prevent ID collapses in the documentation page
