### PR TITLE
Moves usage of aria-modal to inside dropdown component

### DIFF
--- a/src/components/colorpicker/Colorpicker.vue
+++ b/src/components/colorpicker/Colorpicker.vue
@@ -13,7 +13,6 @@
             :mobile-modal="mobileModal"
             :trap-focus="trapFocus"
             :aria-role="ariaRole"
-            :aria-modal="!inline"
             :append-to-body="appendToBody"
             append-to-body-copy-parent
             @active-change="onActiveChange"

--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -12,7 +12,6 @@
             :mobile-modal="mobileModal"
             :trap-focus="trapFocus"
             :aria-role="ariaRole"
-            :aria-modal="!inline"
             :append-to-body="appendToBody"
             append-to-body-copy-parent
             @active-change="onActiveChange">

--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -37,6 +37,7 @@
                 <div
                     class="dropdown-content"
                     :role="ariaRole"
+                    :aria-modal="!inline"
                     :style="contentStyle">
                     <slot/>
                 </div>


### PR DESCRIPTION
Fixes #3680

## Proposed Changes

- Removes `aria-modal` from `.collapse-content` from Datepicker and Colorpicker child Dropdown component
- Passes the `aria-modal` to inside the `.dropdown-menu` of the Dropdown
