### PR TITLE
Proper usage of role tablist and tabs on Tabs component #3685

### DIFF
--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -3,19 +3,22 @@
         <nav
             class="tabs"
             :class="navClasses"
-            role="tablist"
-            :aria-orientation="vertical ? 'vertical' : 'horizontal'"
             @keydown="manageTablistKeydown"
         >
             <slot name="start" />
-            <ul>
+            <ul
+                :aria-orientation="vertical ? 'vertical' : 'horizontal'"
+                role="tablist"
+            >
                 <li
                     v-for="(childItem, childIdx) in items"
                     :key="childItem.value"
                     v-show="childItem.visible"
                     :class="[ childItem.headerClass, { 'is-active': childItem.isActive,
                                                        'is-disabled': childItem.disabled }]"
-                    role="presentation"
+                    role="tab"
+                    :aria-controls="`${childItem.value}-content`"
+                    :aria-selected="`${childItem.isActive}`"
                 >
                     <b-slot-component
                         ref="tabLink"
@@ -23,10 +26,7 @@
                         :component="childItem"
                         name="header"
                         tag="a"
-                        role="tab"
                         :id="`${childItem.value}-label`"
-                        :aria-controls="`${childItem.value}-content`"
-                        :aria-selected="`${childItem.isActive}`"
                         :tabindex="childItem.isActive ? 0 : -1"
                         @focus.native="currentFocus = childIdx"
                         @click.native="childClick(childItem)"
@@ -35,10 +35,7 @@
                     <a
                         ref="tabLink"
                         v-else
-                        role="tab"
-                        :id="`${childItem.value}-tab`"
-                        :aria-controls="`${childItem.value}-content`"
-                        :aria-selected="`${childItem.isActive}`"
+                        :id="`${childItem.value}-label`"
                         :tabindex="childItem.isActive ? 0 : -1"
                         @focus="currentFocus = childIdx"
                         @click="childClick(childItem)"


### PR DESCRIPTION
Fixes #3685

## Proposed Changes

- Moves the `role="tablist"` from `<nav>` to `<ul>` element, and `role="tab"` from `<a>` to `<li>` so that their parent-child relation is correct.
- Removes the `role="presentation"` due to the change aforementioned.
- Moves the `:aria-orientation="vertical ? 'vertical' : 'horizontal'"` to the `<ul>`
- Moves both the `aria-controls` and `aria-selected` to the `<li>`
- Lastly, @service-paradis I know you did some of the logic for the tab navigation here, I did a small change to the ID, which was `:id="`${childItem.value}-tab`"` instead of `:id="`${childItem.value}-label`"` on the `<a>`. Not 100% sure why it was this way, but was causing the IDs to be invalid as the `TabbedChildMixin` only sets the `aria-labelledby` as `-label`.
