### PR TITLE
Removes redundacy of role=button on Dropdown trigger.

### DIFF
--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -6,7 +6,6 @@
     >
         <div
             v-if="!inline"
-            role="button"
             :tabindex="disabled ? false : 0"
             ref="trigger"
             class="dropdown-trigger"


### PR DESCRIPTION
Fixes #3687

## Proposed Changes
- Removes the `role="button"` from the trigger wrapper, as this should be in the trigger element itself.