### PR TITLE
Add open and close events to Tooltip

### DIFF
--- a/docs/pages/components/tooltip/api/tooltip.js
+++ b/docs/pages/components/tooltip/api/tooltip.js
@@ -102,6 +102,18 @@ export default [
                 values: '—',
                 default: '<code>false</code>'
             }
+        ],
+        events: [
+            {
+                name: '<code>open</code>',
+                description: 'Triggers when the tooltip is opened',
+                parameters: '—'
+            },
+            {
+                name: '<code>close</code>',
+                description: 'Triggers when the tooltip is closed',
+                parameters: '—'
+            },
         ]
     }
 ]

--- a/src/components/tooltip/Tooltip.vue
+++ b/src/components/tooltip/Tooltip.vue
@@ -107,7 +107,8 @@ export default {
         }
     },
     watch: {
-        isActive(value) {
+        isActive() {
+            this.$emit(this.isActive ? 'open' : 'close')
             if (this.appendToBody) {
                 this.updateAppendToBody()
             }


### PR DESCRIPTION
## Proposed Changes

 - Add `open` and `close` events to Tooltip

As Tooltip content is `v-show`ed (already in DOM and `mounted` already called), it's not possible trigger an action when the user open the Tooltip. Other components have these kind of events (Tag, Collapse ...).