### PR TITLE
Confusing instructions

### DIFF
--- a/docs/pages/installation/ConstructorOptions.vue
+++ b/docs/pages/installation/ConstructorOptions.vue
@@ -22,7 +22,6 @@
                 usageBundle: `
                 Vue.use(Buefy, {
                     defaultIconPack: 'fas',
-                    defaultContainerElement: '#content',
                     // ...
                 })`,
                 usageComponents: `
@@ -32,7 +31,6 @@
                 Vue.use(Input)
                 ConfigProgrammatic.setOptions({
                     defaultIconPack: 'fas',
-                    defaultContainerElement: '#content',
                     // ...
                 })`
             }


### PR DESCRIPTION
Those instructions may lead to future mistakes. Since people visit this page probably when they aren't familiarized with Buefy, they might just copy and paste this code. I suggest the removal of it or maybe adding additional instructions in parentheses such as "defaultContainerElement: '#content', (read documentation, might create overlapping snackbars/toasts)"

<!-- Thank you for helping Buefy! -->

## Proposed Changes

- Remove content from constructor page