### PR TITLE
Fix for #3652

### DIFF
--- a/src/components/clockpicker/Clockpicker.vue
+++ b/src/components/clockpicker/Clockpicker.vue
@@ -26,7 +26,7 @@
                         :rounded="rounded"
                         v-bind="$attrs"
                         :use-html5-validation="useHtml5Validation"
-                        @click.native.stop="toggle(true)"
+                        @click.native="onInputClick"
                         @keyup.native.enter="toggle(true)"
                         @change.native="onChange($event.target.value)"
                         @focus="handleOnFocus"
@@ -252,6 +252,14 @@ export default {
             if (this.meridienSelected !== value) {
                 this.meridienSelected = value
                 this.onMeridienChange(value)
+            }
+        },
+        /*
+         * Avoid dropdown toggle when is already visible
+         */
+        onInputClick(event) {
+            if (this.$refs.dropdown.isActive) {
+                event.stopPropagation()
             }
         }
     }


### PR DESCRIPTION
Fixes #3652

## Proposed Changes

Field click event in Clockpicker does not close dropdown Datepicker.

These changes are made analogous to the DatePicker.vue.
Do not toggle dropdown here. Instead stop event propagation if the dropdown is already active, else let the dropdown-trigger handle the click event and activate the dropdown.
This way the click event is not blocked to also execute the clickedOutside logic of the dropdown component.