### PR TITLE
Changed the checkbox to listen for a change event instead of a just a click event

### DIFF
--- a/src/components/checkbox/Checkbox.vue
+++ b/src/components/checkbox/Checkbox.vue
@@ -5,7 +5,11 @@
         ref="label"
         :disabled="disabled"
         @click="focus"
-        @keydown.prevent.enter="$refs.label.click()">
+        @keydown.prevent.enter="$refs.label.click()"
+        @keydown.prevent.space="$refs.label.click()">
+        <!-- Checkbox needs to listen for a space event instead of a just a
+             click and enter event so that that using the keyboard spacebar will also
+             trigger the checkbox change in the b-table -->
         <input
             v-model="computedValue"
             :indeterminate.prop="indeterminate"

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -258,8 +258,11 @@
                                     autocomplete="off"
                                     :disabled="!isRowCheckable(row)"
                                     :value="isRowChecked(row)"
-                                    @click.native.prevent.stop="checkRow(row, index, $event)"
+                                    @change.native.prevent.stop="checkRow(row, index, $event)"
                                 />
+                                <!-- Checkbox needs to listen for a change event instead of a just a
+                                click event so that that using the keyboard spacebar will also
+                                trigger the checkbox change. -->
                             </td>
 
                             <template v-for="(column, colindex) in visibleColumns">
@@ -289,8 +292,11 @@
                                     autocomplete="off"
                                     :disabled="!isRowCheckable(row)"
                                     :value="isRowChecked(row)"
-                                    @click.native.prevent.stop="checkRow(row, index, $event)"
+                                    @change.native.prevent.stop="checkRow(row, index, $event)"
                                 />
+                                <!-- Checkbox needs to listen for a change event instead of a just a
+                                click event so that that using the keyboard spacebar will also
+                                trigger the checkbox change. -->
                             </td>
                         </tr>
 

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -258,11 +258,8 @@
                                     autocomplete="off"
                                     :disabled="!isRowCheckable(row)"
                                     :value="isRowChecked(row)"
-                                    @change.native.prevent.stop="checkRow(row, index, $event)"
+                                    @click.native.prevent.stop="checkRow(row, index, $event)"
                                 />
-                                <!-- Checkbox needs to listen for a change event instead of a just a
-                                click event so that that using the keyboard spacebar will also
-                                trigger the checkbox change. -->
                             </td>
 
                             <template v-for="(column, colindex) in visibleColumns">
@@ -292,11 +289,8 @@
                                     autocomplete="off"
                                     :disabled="!isRowCheckable(row)"
                                     :value="isRowChecked(row)"
-                                    @change.native.prevent.stop="checkRow(row, index, $event)"
+                                    @click.native.prevent.stop="checkRow(row, index, $event)"
                                 />
-                                <!-- Checkbox needs to listen for a change event instead of a just a
-                                click event so that that using the keyboard spacebar will also
-                                trigger the checkbox change. -->
                             </td>
                         </tr>
 


### PR DESCRIPTION
Changed the checkbox to listen for a change event instead of a just a
click event so that that using the keyboard spacebar will also trigger the checkbox change.


Fixes #3432 

## Proposed Changes
Fix b-table checkbox check event.
-
-
-
