### PR TITLE
b-menu-item expanded shouldn't overwrite on click

### DIFF
--- a/src/components/menu/MenuItem.vue
+++ b/src/components/menu/MenuItem.vue
@@ -102,7 +102,7 @@ export default {
             if (this.disabled) return
             const menu = this.getMenu()
             this.reset(this.$parent, menu)
-            this.newExpanded = !this.newExpanded
+            this.newExpanded = this.$props.expanded || !this.newExpanded
             this.$emit('update:expanded', this.newExpanded)
             if (menu && menu.activable) {
                 this.newActive = true


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- if setting `b-menu-item` property `expanded=true`, clicking on the menu item should not close it
