### PR TITLE
Numberinput: Parse float value before attempting toFixed

### DIFF
--- a/src/components/numberinput/Numberinput.vue
+++ b/src/components/numberinput/Numberinput.vue
@@ -270,7 +270,7 @@ export default {
             }
             if (typeof this.minNumber === 'undefined' || (this.computedValue - this.stepNumber) >= this.minNumber) {
                 const value = this.computedValue - this.stepNumber
-                this.computedValue = parseFloat(value.toFixed(this.stepDecimals))
+                this.computedValue = parseFloat(value).toFixed(this.stepDecimals)
             }
         },
         increment() {
@@ -283,7 +283,7 @@ export default {
             }
             if (typeof this.maxNumber === 'undefined' || (this.computedValue + this.stepNumber) <= this.maxNumber) {
                 const value = this.computedValue + this.stepNumber
-                this.computedValue = parseFloat(value.toFixed(this.stepDecimals))
+                this.computedValue = parseFloat(value).toFixed(this.stepDecimals)
             }
         },
         onControlClick(event, inc) {


### PR DESCRIPTION
This issue is potentially linked to #3260 - however I am unable to say for sure as the returned errors are slightly different. They do appear to be linked to the same increment method though.

I haven't created an issue for this as it's something I came across whilst deep in the zone at work - however when trying to increment a decimal value bound to a b-numberinput component I received the following console error:

```javascript
vue.common.dev.js:1902 TypeError: value.toFixed is not a function
    at VueComponent.increment (numberinput.js:202:1)
    at VueComponent.longPressTick (numberinput.js:213:1)
    at VueComponent.onStartLongPress (numberinput.js:221:1)
    at mousedown (numberinput.js:236:2155)
    at invokeWithErrorHandling (vue.common.dev.js:1868:1)
    at HTMLButtonElement.invoker (vue.common.dev.js:2193:1)
    at HTMLButtonElement.original._wrapper (vue.common.dev.js:7587:1)
```

Decrementing works fine, just incrementing it seems to fail.
I was a few versions behind but after updating the issue seems to persist. 

Below is my component just in case I'm being daft and missing something obvious. If so, then sorry for wasting your time!

```html
<b-numberinput
	:exponential=".5"
	:size="size"
	:controls="controls"
	:controls-alignment="controlsAlignment"
	:controls-position="controlsPosition"
	min="0"
	step=".01"
	@input="emitValue()"
	v-model="amount"
	:expanded="isExpanded">
</b-numberinput>
```

## Proposed Changes

- Attempt `parseFloat` before attempting a `.toFixed(...)`
