### PR TITLE
[docs] Fixed: Closing not working on component modal example

### DIFF
--- a/docs/pages/components/modal/examples/ExComponent.vue
+++ b/docs/pages/components/modal/examples/ExComponent.vue
@@ -7,7 +7,7 @@
             @click="isComponentModalActive = true" />
 
         <b-modal
-            :active="isComponentModalActive"
+            v-model="isComponentModalActive"
             has-modal-card
             trap-focus
             :destroy-on-hide="false"


### PR DESCRIPTION
On the example for modals here: https://buefy.org/documentation/modal/ closing the component modal does not work. This is due to using `:active`. Changing this to v-model like the other examples fixes this.

## Proposed Changes
- Changes `:active` to `v-model` on the modal example page for component modals