### PR TITLE
Fix: Reindexing sorted results

### DIFF
--- a/docs/components/SidebarSearch.vue
+++ b/docs/components/SidebarSearch.vue
@@ -28,6 +28,8 @@
                             placeholder="Search docs"
                             type="search"
                             @input="search"
+                            maxlength="32"
+                            :has-counter="false"
                         />
                         <span class="icon is-left">
                             <i class="fas fa-search" aria-hidden="true" />
@@ -308,6 +310,15 @@ export default {
     &-noresult {
         margin: 8px auto 12px;
         padding: 0 8px;
+
+        strong {
+            display: inline-block;
+            max-width: 340px;
+            white-space: pre;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            vertical-align: bottom;
+        }
     }
     &-shortcuts {
         list-style: none;

--- a/docs/components/SidebarSearch.vue
+++ b/docs/components/SidebarSearch.vue
@@ -156,8 +156,7 @@ export default {
                 }
                 resultsByCategory[category].results.push({
                     ...result,
-                    score,
-                    index: index++
+                    score
                 })
             })
 
@@ -166,6 +165,7 @@ export default {
             sorted.forEach((category) => {
                 category.results = category.results
                     .sort((a, b) => String(b.score).localeCompare(a.score))
+                    .map((result) => ({ ...result, index: index++ }))
             })
 
             return sorted

--- a/docs/components/SidebarSearch.vue
+++ b/docs/components/SidebarSearch.vue
@@ -74,6 +74,7 @@
 
                                 <div
                                     v-for="result in section.results"
+                                    :ref="`result_${result.index}`"
                                     :key="result.path"
                                     class="notification"
                                     :class="{
@@ -230,6 +231,15 @@ export default {
                 return regexp.test(route.title) || regexp.test(route.subtitle)
             })
         },
+        scrollToSelection() {
+            if (this.$refs[`result_${this.selectedIndex}`]) {
+                this.$refs[`result_${this.selectedIndex}`][0].scrollIntoView({
+                    behavior: 'auto',
+                    block: 'center',
+                    inline: 'nearest'
+                })
+            }
+        },
         navigateTo() {
             this.$router.push(this.results[this.selectedIndex].path)
             this.close()
@@ -253,6 +263,7 @@ export default {
                             0,
                             this.selectedIndex - 1
                         )
+                        this.scrollToSelection()
                     }
                     break
                 case 'ArrowDown':
@@ -261,6 +272,19 @@ export default {
                             this.results.length - 1,
                             this.selectedIndex + 1
                         )
+                        this.scrollToSelection()
+                    }
+                    break
+                case 'PageUp':
+                    if (this.isActive) {
+                        this.selectedIndex = 0
+                        this.scrollToSelection()
+                    }
+                    break
+                case 'PageDown':
+                    if (this.isActive) {
+                        this.selectedIndex = Math.max(0, this.results.length - 1)
+                        this.scrollToSelection()
                     }
                     break
                 case 'Enter':
@@ -314,6 +338,7 @@ export default {
         flex-direction: column;
         align-items: stretch;
         max-height: 488px;
+        scroll-behavior: smooth;
         scrollbar-width: thin;
         overflow: hidden auto;
 

--- a/docs/components/SidebarSearch.vue
+++ b/docs/components/SidebarSearch.vue
@@ -241,15 +241,16 @@ export default {
             }
         },
         navigateTo() {
-            for (const category of this.sortedResults) {
-                for (const result of category.results) {
+            this.sortedResults.some((category) =>
+                category.results.some((result) => {
                     if (result.index === this.selectedIndex) {
                         this.$router.push(result.path)
                         this.close()
-                        return
+                        return true
                     }
-                }
-            }
+                    return false
+                })
+            )
         },
         shortcutHandler(event) {
             switch (event.key) {

--- a/docs/components/SidebarSearch.vue
+++ b/docs/components/SidebarSearch.vue
@@ -241,8 +241,15 @@ export default {
             }
         },
         navigateTo() {
-            this.$router.push(this.results[this.selectedIndex].path)
-            this.close()
+            for (const category of this.sortedResults) {
+                for (const result of category.results) {
+                    if (result.index === this.selectedIndex) {
+                        this.$router.push(result.path)
+                        this.close()
+                        return
+                    }
+                }
+            }
         },
         shortcutHandler(event) {
             switch (event.key) {


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/18756261/164082680-57230b7c-a8c5-4dcd-affe-ef5d00ecbc65.png)

Sorry. I added the sorting at the last moment and I didn't retest enough, so when you scroll with the arrows keys in the search results the order is anarchic because the index corresponds to the order before the sorting. I took advantage of my mistake to improve some details.

## Proposed Changes
- Index results after sorting
- Improve accessibility
- Improve keyboard experience
