### PR TITLE
Remove duplicate property description

### DIFF
--- a/docs/pages/components/table/api/table.js
+++ b/docs/pages/components/table/api/table.js
@@ -775,10 +775,10 @@ export default [
             },
             {
                 name: '<code>header-selectable</code>',
-                description: 'Prevent text selection of header when setting this to <code>false</code>.',
+                description: 'Whether the header text is selectable, works when column is <code>sortable</code>.',
                 type: 'Boolean',
                 values: '—',
-                default: '<code>true</code>'
+                default: '<code>false</code>'
             },
             {
                 name: '<code>header-class</code>',
@@ -793,13 +793,6 @@ export default [
                 type: 'String',
                 values: '—',
                 default: '-'
-            },
-            {
-                name: '<code>header-selectable</code>',
-                description: 'Whether the header text is selectable, works when column is <code>sortable</code>',
-                type: 'Boolean',
-                values: '—',
-                default: '<code>false</code>'
             },
             {
                 name: '<code>th-attrs</code>',


### PR DESCRIPTION
Fix #3724

I checked in the component if it was missing a description, it does not missing. My choice of description is based on line `28` and `85` of the file `src\components\table\TableColumn.vue`.

## Proposed Changes
- Remove property description
