### PR TITLE
Avoid setting the type html attribute on non-button tags.

### DIFF
--- a/src/components/button/Button.spec.js
+++ b/src/components/button/Button.spec.js
@@ -90,4 +90,18 @@ describe('BButton', () => {
         })
         expect(wrapper.vm.computedTag).toBe('button')
     })
+
+    it('should set type attribute', () => {
+        wrapper.setProps({
+            nativeType: 'submit'
+        })
+        expect(wrapper.element.type).toBe('submit')
+    })
+
+    it("shouldn't set type attribute unless if the tag is button", () => {
+        wrapper.setProps({
+            tag: 'a'
+        })
+        expect(wrapper.element.type).toBeFalsy()
+    })
 })

--- a/src/components/button/Button.vue
+++ b/src/components/button/Button.vue
@@ -3,7 +3,7 @@
         :is="computedTag"
         class="button"
         v-bind="$attrs"
-        :type="nativeType"
+        :type="computedTag === 'button' ? nativeType : undefined"
         :class="[size, type, {
             'is-rounded': rounded,
             'is-loading': loading,


### PR DESCRIPTION
For instance for the `<a>` tag it's something completely different: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-type

The `nativeType` prop also validates only against standard values for `<button>`