### PR TITLE
Fix input with emoji do not show the right length

### DIFF
--- a/src/components/input/Input.spec.js
+++ b/src/components/input/Input.spec.js
@@ -54,6 +54,17 @@ describe('BInput', () => {
         expect(counter.text()).toBe('4 / 100')
     })
 
+    it('display correct input value length when value contains some emoji', () => {
+        wrapper.setProps({
+            value: '😀2',
+            maxlength: 5
+        })
+        const counter = wrapper.find('small.counter')
+
+        expect(counter.exists()).toBeTruthy()
+        expect(counter.text()).toBe('2 / 5')
+    })
+
     it('no display counter when hasCounter property set for false', () => {
         wrapper.setProps({ maxlength: 100 })
         expect(wrapper.find('small.counter').exists()).toBeTruthy()

--- a/src/components/input/Input.vue
+++ b/src/components/input/Input.vue
@@ -203,7 +203,7 @@ export default {
         */
         valueLength() {
             if (typeof this.computedValue === 'string') {
-                return this.computedValue.length
+                return Array.from(this.computedValue).length
             } else if (typeof this.computedValue === 'number') {
                 return this.computedValue.toString().length
             }


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes https://github.com/buefy/buefy/issues/3731

## Proposed Changes

I am using `Array.from` to count the string input value length. With this is possible to count emojis as a unique char.

```js
Array.from(this.computedValue).length
```