### PR TITLE
[Fixing typo] docs (fields)

### DIFF
--- a/docs/pages/components/field/examples/ExLabelPosition.vue
+++ b/docs/pages/components/field/examples/ExLabelPosition.vue
@@ -85,7 +85,7 @@
         </b-field>
 
         <b-field label="Number!" :label-position="labelPosition">
-            <b-numberinput laceholder="99" :min="95"></b-numberinput>
+            <b-numberinput placeholder="99" :min="95"></b-numberinput>
         </b-field>
 
         <b-field label="Add some tags" :label-position="labelPosition">


### PR DESCRIPTION
fixed typo for "placeholder"


