### PR TITLE
FIX b-table overflow when last column is numeric

### DIFF
--- a/src/scss/components/_table.scss
+++ b/src/scss/components/_table.scss
@@ -123,6 +123,7 @@ $table-sticky-header-height: 300px !default;
                 &.is-numeric {
                     flex-direction: row-reverse;
                     text-align: right;
+                    width: 95%;
                     .icon {
                         margin-left: 0;
                         margin-right: 0.5rem;


### PR DESCRIPTION
When a b-table last column has the `numeric` attribute ( or  `is-numeric` class), the sort icon in the header cell is pushed outside the table layout which create an overflow on the x axis.

Related issue:
https://github.com/buefy/buefy/issues/3484

Fixes #3484

## Proposed Changes

- limit the header cell width when the class `is-numeric` is applied
