### PR TITLE
Add messages prop to message slot in BField

### DIFF
--- a/docs/pages/components/field/api/field.js
+++ b/docs/pages/components/field/api/field.js
@@ -91,7 +91,7 @@ export default [
             {
                 name: '<code>message</code>',
                 description: 'Custom message',
-                props: '-'
+                props: '<code>messages: [string]</code>'
             }
         ]
     }

--- a/src/components/field/Field.spec.js
+++ b/src/components/field/Field.spec.js
@@ -48,13 +48,14 @@ describe('BField', () => {
     })
 
     describe('Passing a message prop', () => {
-        const generateMountOptions = ({message}) => {
+        const generateMountOptions = ({message, slot}) => {
             return {
                 propsData: {message},
                 localVue,
                 slots: {
                     default: [BInput, '<button class="button">Button</button>']
-                }
+                },
+                scopedSlots: slot ? {message: slot} : {}
             }
         }
 
@@ -113,6 +114,14 @@ describe('BField', () => {
             const mountOptions = generateMountOptions({message})
             const wrapper = shallowMount(BField, mountOptions)
             expect(wrapper.find('p.help').html().split('<br>').length).toEqual(5)
+        })
+
+        it('messages are passed down to the message slot', () => {
+            const message = 'Some string message'
+            const slot = '<template #message="{ messages }">{{ messages }}</template>'
+            const mountOptions = generateMountOptions({message, slot})
+            const wrapper = shallowMount(BField, mountOptions)
+            expect(wrapper.find('p.help').text()).toEqual(message)
         })
     })
 

--- a/src/components/field/Field.vue
+++ b/src/components/field/Field.vue
@@ -45,7 +45,11 @@
             class="help"
             :class="newType"
         >
-            <slot v-if="$slots.message" name="message"/>
+            <slot
+                v-if="$slots.message"
+                name="message"
+                :messages="formattedMessage"
+            />
             <template v-else>
                 <template v-for="(mess, i) in formattedMessage">
                     {{ mess }}


### PR DESCRIPTION

## Proposed Changes

 - In the BField component, the slot `#message` now receive a `:messages` prop with computedMessage
  This allow users to easily wrap help messages.

```vue
<BField>
  <BInput />
  <template #message="{ message }">
    <strong class="custom-wrapper">{{  messages }}</strong>
  </template>
</BField>
```
