### PR TITLE
Add prop to disable Numberinput long press behavior

### DIFF
--- a/docs/pages/components/numberinput/api/numberinput.js
+++ b/docs/pages/components/numberinput/api/numberinput.js
@@ -131,6 +131,13 @@ export default [
                 default: '—'
             },
             {
+                name: '<code>disable-long-press</code>',
+                description: 'Long press on the plus or minus button will not increment/decrement the input value.',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>true</code>'
+            },
+            {
                 name: 'Any native attribute',
                 description: '—',
                 type: '—',

--- a/src/components/numberinput/Numberinput.spec.js
+++ b/src/components/numberinput/Numberinput.spec.js
@@ -92,6 +92,37 @@ describe('BNumberinput', () => {
             expect(wrapper.vm.computedValue).toBe(val)
         })
 
+        it('does not increment/decrement on long pressing when feature is disabled', async () => {
+            wrapper.setProps({
+                disableLongPress: true
+            })
+            jest.useFakeTimers()
+            wrapper.vm.computedValue = 0
+
+            // Increment
+            wrapper.find('.control.plus button').trigger('mousedown')
+
+            // await wait(2000)
+            jest.runOnlyPendingTimers()
+            jest.runOnlyPendingTimers()
+            jest.runOnlyPendingTimers()
+
+            wrapper.find('.control.plus').trigger('mouseup')
+            expect(wrapper.vm.computedValue).toBe(0)
+
+            // Decrement
+            wrapper.find('.control.minus button').trigger('mousedown')
+
+            jest.runOnlyPendingTimers()
+            jest.runOnlyPendingTimers()
+
+            wrapper.find('.control.minus button').trigger('mouseup')
+            // Trigger it another time to check for unexpected browser behavior
+            wrapper.find('.control.minus button').trigger('mouseup')
+
+            expect(wrapper.vm.computedValue).toBe(0)
+        })
+
         it('increments/decrements after manually set value on input', async () => {
             wrapper.setProps({exponential: true, value: 1, step: 1})
             const BASE_VALUE = Math.floor(Math.random() * 10 + 1)

--- a/src/components/numberinput/Numberinput.vue
+++ b/src/components/numberinput/Numberinput.vue
@@ -143,7 +143,11 @@ export default {
         controlsPosition: String,
         placeholder: [Number, String],
         ariaMinusLabel: String,
-        ariaPlusLabel: String
+        ariaPlusLabel: String,
+        disableLongPress: {
+            type: Boolean,
+            default: false
+        }
     },
     data() {
         return {
@@ -301,6 +305,7 @@ export default {
             }, this.exponential ? (250 / (this.exponential * this.timesPressed++)) : 250)
         },
         onStartLongPress(event, inc) {
+            if (this.disableLongPress) return
             if (event.button !== 0 && event.type !== 'touchstart') return
             clearTimeout(this._$intervalRef)
             this.longPressTick(inc)


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

## Proposed Changes
Our needs: In my company, we have some cases where we don't want the long press button behavior and we had no clean way to disable it.

- New property `disableLongPress` added to disable the long press logic
- Unit tests updated
- New property added to the API doc

I'd be happy to know if something's missing. :-)
