### PR TITLE
Move sort and expand class to cell

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -77,6 +77,9 @@
                             v-bind="column.thAttrs(column)"
                             :class="[column.thClasses, {
                                 'is-current-sort': !sortMultiple && currentSortColumn === column,
+                                'is-desc': sortMultiple && sortMultipleDataComputed.length
+                                    ? (sortMultipleDataComputed.find(i =>
+                                    i.field === column.field) || {}).order === 'desc' : !isAsc
                             }]"
                             :style="column.thStyle"
                             @click.stop="sort(column, null, $event)"
@@ -115,9 +118,7 @@
                                                 :pack="iconPack"
                                                 both
                                                 :size="sortIconSize"
-                                                :class="{
-                                                    'is-desc': sortMultipleDataComputed.filter(i =>
-                                                i.field === column.field)[0].order === 'desc'}"
+                                                class="multi-sort-icon"
                                             />
                                             {{ findIndexOfSortData(column) }}
                                             <button
@@ -134,7 +135,6 @@
                                             :size="sortIconSize"
                                             class="sort-icon"
                                             :class="{
-                                                'is-desc': !isAsc,
                                                 'is-invisible': currentSortColumn !== column
                                             }"
                                         />
@@ -240,6 +240,7 @@
                             <td
                                 v-if="showDetailRowIcon"
                                 class="chevron-cell"
+                                :class="{'is-expanded': isVisibleDetailRow(row)}"
                             >
                                 <a
                                     v-if="hasDetailedVisible(row)"
@@ -248,8 +249,7 @@
                                     <b-icon
                                         :icon="detailIcon"
                                         :pack="iconPack"
-                                        both
-                                        :class="{'is-expanded': isVisibleDetailRow(row)}"/>
+                                        both/>
                                 </a>
                             </td>
 

--- a/src/scss/components/_table.scss
+++ b/src/scss/components/_table.scss
@@ -93,16 +93,6 @@ $table-sticky-header-height: 300px !default;
 
     .icon {
         transition: transform $speed-slow $easing, opacity $speed $easing;
-        &.is-desc {
-            transform: rotate(180deg);
-        }
-        &.is-expanded {
-            transform: rotate(90deg);
-        }
-    }
-
-    .sort-icon.icon.is-desc {
-        transform: rotate(180deg) translateY(-50%) !important;
     }
 
     .table {
@@ -138,16 +128,20 @@ $table-sticky-header-height: 300px !default;
                 border-color: $grey;
                 font-weight: $weight-bold;
             }
+            &.is-desc {
+                .sort-icon {
+                    transform: rotate(180deg) translateY(-50%);
+                }
+                .multi-sort-icon {
+                    transform: rotate(180deg);
+                }
+            }
             &.is-sortable:hover {
                 border-color: $grey;
             }
             &.is-sortable,
             &.is-sortable .th-wrap {
                 cursor: pointer;
-
-                .is-relative {
-                    position: absolute;
-                }
             }
             .sort-icon, .multi-sort-cancel-icon {
                 position: absolute;
@@ -224,6 +218,11 @@ $table-sticky-header-height: 300px !default;
                 left: 0;
                 z-index: 1;
                 background: $table-background-color;
+            }
+            &.is-expanded {
+                .icon {
+                    transform: rotate(90deg);
+                }
             }
         }
 


### PR DESCRIPTION
## What I try to improve

When using `b-table-column` with a custom header users have to manually add sort icon :
```vue
<b-table>
  <b-table-column>
    <template #header>
      // ...
      <b-icon icon="carret-down" class="sort-icon" />
    </template>
  </b-table-column>
</b-table>
```
At least, with this PR, user don't to handle sort direction.

## Proposed Changes

- Move the sort class `is-desc` and the expand class `is-expanded` to the cell. This allow user to rely on it even when using templates.
