### PR TITLE
Disable infinite scroll output

### DIFF
--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -520,7 +520,6 @@ export default {
         checkIfReachedTheEndOfScroll() {
             const list = this.$refs.dropdown.querySelector('.dropdown-content')
             const footerHeight = this.hasFooterSlot ? list.querySelectorAll('div.dropdown-footer')[0].clientHeight : 0
-
             if (list.clientHeight !== list.scrollHeight &&
                 list.scrollTop + list.parentElement.clientHeight + footerHeight >= list.scrollHeight
             ) {
@@ -705,7 +704,6 @@ export default {
             this.$refs.dropdown && this.$refs.dropdown.querySelector('.dropdown-content')
         ) {
             const list = this.$refs.dropdown.querySelector('.dropdown-content')
-
             list.addEventListener('scroll', this.checkIfReachedTheEndOfScroll)
         }
         if (this.appendToBody) {

--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -317,6 +317,7 @@ export default {
                 }
             }
         },
+
         /**
          * When checkInfiniteScroll property changes scroll event should be removed or added
          */

--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -322,15 +322,17 @@ export default {
          * When checkInfiniteScroll property changes scroll event should be removed or added
          */
         checkInfiniteScroll(checkInfiniteScroll) {
-            const list = this.$refs.dropdown.querySelector('.dropdown-content');
+            if ((this.$refs.dropdown && this.$refs.dropdown.querySelector('.dropdown-content')) === false) return
 
-            if(checkInfiniteScroll === true) {
+            const list = this.$refs.dropdown.querySelector('.dropdown-content')
+
+            if (checkInfiniteScroll === true) {
                 list.addEventListener('scroll', this.checkIfReachedTheEndOfScroll)
 
-                return;
+                return
             }
 
-            list.removeEventListener('scroll', this.checkIfReachedTheEndOfScroll);
+            list.removeEventListener('scroll', this.checkIfReachedTheEndOfScroll)
         },
 
         /**

--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -517,8 +517,10 @@ export default {
          * Check if the scroll list inside the dropdown
          * reached it's end.
          */
-        checkIfReachedTheEndOfScroll(list) {
+        checkIfReachedTheEndOfScroll() {
+            const list = this.$refs.dropdown.querySelector('.dropdown-content')
             const footerHeight = this.hasFooterSlot ? list.querySelectorAll('div.dropdown-footer')[0].clientHeight : 0
+
             if (list.clientHeight !== list.scrollHeight &&
                 list.scrollTop + list.parentElement.clientHeight + footerHeight >= list.scrollHeight
             ) {
@@ -703,7 +705,8 @@ export default {
             this.$refs.dropdown && this.$refs.dropdown.querySelector('.dropdown-content')
         ) {
             const list = this.$refs.dropdown.querySelector('.dropdown-content')
-            list.addEventListener('scroll', () => this.checkIfReachedTheEndOfScroll(list))
+
+            list.addEventListener('scroll', this.checkIfReachedTheEndOfScroll)
         }
         if (this.appendToBody) {
             this.$data._bodyEl = createAbsoluteElement(this.$refs.dropdown)

--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -501,6 +501,8 @@ export default {
          * reached it's end.
          */
         checkIfReachedTheEndOfScroll(list) {
+            if(this.checkInfiniteScroll === false) return;
+
             const footerHeight = this.hasFooterSlot ? list.querySelectorAll('div.dropdown-footer')[0].clientHeight : 0
             if (list.clientHeight !== list.scrollHeight &&
                 list.scrollTop + list.parentElement.clientHeight + footerHeight >= list.scrollHeight

--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -317,6 +317,20 @@ export default {
                 }
             }
         },
+        /**
+         * When checkInfiniteScroll property changes scroll event should be removed or added
+         */
+        checkInfiniteScroll(checkInfiniteScroll) {
+            const list = this.$refs.dropdown.querySelector('.dropdown-content');
+
+            if(checkInfiniteScroll === true) {
+                list.addEventListener('scroll', this.checkIfReachedTheEndOfScroll)
+
+                return;
+            }
+
+            list.removeEventListener('scroll', this.checkIfReachedTheEndOfScroll);
+        },
 
         /**
          * When updating input's value
@@ -501,8 +515,6 @@ export default {
          * reached it's end.
          */
         checkIfReachedTheEndOfScroll(list) {
-            if(this.checkInfiniteScroll === false) return;
-
             const footerHeight = this.hasFooterSlot ? list.querySelectorAll('div.dropdown-footer')[0].clientHeight : 0
             if (list.clientHeight !== list.scrollHeight &&
                 list.scrollTop + list.parentElement.clientHeight + footerHeight >= list.scrollHeight


### PR DESCRIPTION
The autocomplete component has a property that checks if it should emit infinite scroll events. This property only gets checked during mounted and destroyed. If you update the property to false the component should not emit the infinite-scroll event anymore.
