### PR TITLE
Make a dedicated prop for keepOpen

### DIFF
--- a/src/components/taginput/Taginput.vue
+++ b/src/components/taginput/Taginput.vue
@@ -43,7 +43,7 @@
                 :loading="loading"
                 :autocomplete="nativeAutocomplete"
                 :open-on-focus="openOnFocus"
-                :keep-open="openOnFocus"
+                :keep-open="keepOpen"
                 :keep-first="keepFirst"
                 :group-field="groupField"
                 :group-options="groupOptions"
@@ -147,6 +147,10 @@ export default {
         groupOptions: String,
         nativeAutocomplete: String,
         openOnFocus: Boolean,
+        keepOpen: {
+            type: Boolean,
+            default: true
+        }
         keepFirst: Boolean,
         disabled: Boolean,
         ellipsis: Boolean,


### PR DESCRIPTION
Allow taginput to be closed after selecting an item. Default prop to 'true' to maintain existing functionality.