### PR TITLE
Added mobileModal to Clockpicker Component

### DIFF
--- a/docs/pages/components/clockpicker/api/clockpicker.js
+++ b/docs/pages/components/clockpicker/api/clockpicker.js
@@ -124,6 +124,13 @@ export default [
                 default: '<code>true</code>'
             },
             {
+                name: '<code>mobile-modal</code>',
+                description: 'Clockpicker is shown into a modal on mobile',
+                type: 'Boolean',
+                values: '<code>true</code>, <code>false</code>',
+                default: '<code>true</code>'
+            },
+            {
                 name: '<code>position</code>',
                 description: 'Optional, position of the timepicker relative to the input',
                 type: 'String',

--- a/docs/pages/components/datepicker/api/datepicker.js
+++ b/docs/pages/components/datepicker/api/datepicker.js
@@ -192,6 +192,13 @@ export default [
                 default: '<code>true</code>'
             },
             {
+                name: '<code>mobile-modal</code>',
+                description: 'Datepicker is shown into a modal on mobile',
+                type: 'Boolean',
+                values: '<code>true</code>, <code>false</code>',
+                default: '<code>true</code>'
+            },
+            {
                 name: '<code>position</code>',
                 description: 'Optional, position of the datepicker relative to the input',
                 type: 'String',

--- a/docs/pages/components/timepicker/api/timepicker.js
+++ b/docs/pages/components/timepicker/api/timepicker.js
@@ -114,6 +114,13 @@ export default [
                 default: '<code>true</code>'
             },
             {
+                name: '<code>mobile-modal</code>',
+                description: 'Timepicker is shown into a modal on mobile',
+                type: 'Boolean',
+                values: '<code>true</code>, <code>false</code>',
+                default: '<code>true</code>'
+            },
+            {
                 name: '<code>position</code>',
                 description: 'Optional, position of the timepicker relative to the input',
                 type: 'String',

--- a/src/components/clockpicker/Clockpicker.vue
+++ b/src/components/clockpicker/Clockpicker.vue
@@ -6,6 +6,7 @@
             :position="position"
             :disabled="disabled"
             :inline="inline"
+            :mobile-modal="mobileModal"
             :append-to-body="appendToBody"
             append-to-body-copy-parent
             @active-change="onActiveChange">

--- a/src/components/timepicker/Timepicker.vue
+++ b/src/components/timepicker/Timepicker.vue
@@ -6,6 +6,7 @@
             :position="position"
             :disabled="disabled"
             :inline="inline"
+            :mobile-modal="mobileModal"
             :append-to-body="appendToBody"
             append-to-body-copy-parent
             @active-change="onActiveChange">

--- a/src/utils/TimepickerMixin.js
+++ b/src/utils/TimepickerMixin.js
@@ -145,6 +145,10 @@ export default {
             type: Boolean,
             default: () => config.defaultTimepickerMobileNative
         },
+        mobileModal: {
+            type: Boolean,
+            default: () => config.defaultTimepickerMobileModal
+        },
         timeCreator: {
             type: Function,
             default: () => {

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -32,6 +32,7 @@ let config = {
     defaultModalScroll: null,
     defaultDatepickerMobileNative: true,
     defaultTimepickerMobileNative: true,
+    defaultTimepickerMobileModal: true,
     defaultNoticeQueue: true,
     defaultInputHasCounter: true,
     defaultTaginputHasCounter: true,


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
No Issue found. Direct PR
## Proposed Changes

- This PR added the feature to directly set the prop mobile-modal on the Clockpicker and Timepicker Component. It's created parallel to the datepicker mobile-modal logic.
- updated docs clockpicker, datepicker and timepicker.
