### PR TITLE
Fix: b-button nativeType for tag 'input'

### DIFF
--- a/src/components/button/Button.spec.js
+++ b/src/components/button/Button.spec.js
@@ -104,4 +104,12 @@ describe('BButton', () => {
         })
         expect(wrapper.element.type).toBeFalsy()
     })
+
+    it('should set type attribute if the tag is input', () => {
+        wrapper.setProps({
+            tag: 'input',
+            nativeType: 'submit'
+        })
+        expect(wrapper.element.type).toBe('submit')
+    })
 })

--- a/src/components/button/Button.vue
+++ b/src/components/button/Button.vue
@@ -3,7 +3,7 @@
         :is="computedTag"
         class="button"
         v-bind="$attrs"
-        :type="computedTag === 'button' ? nativeType : undefined"
+        :type="['button', 'input'].includes(computedTag) ? nativeType : undefined"
         :class="[size, type, {
             'is-rounded': rounded,
             'is-loading': loading,


### PR DESCRIPTION
We cannot use nativeType for b-button with tag 'input' and type 'submit' after pull request with disabling nativeType for tag 'a' (https://github.com/buefy/buefy/pull/3733).
In this pull request I fixed it.