### PR TITLE
Numberinput: fix long-press breaking when disabled

### DIFF
--- a/src/components/numberinput/Numberinput.spec.js
+++ b/src/components/numberinput/Numberinput.spec.js
@@ -108,7 +108,7 @@ describe('BNumberinput', () => {
             jest.runOnlyPendingTimers()
 
             wrapper.find('.control.plus').trigger('mouseup')
-            expect(wrapper.vm.computedValue).toBe(0)
+            expect(wrapper.vm.computedValue).toBe(1)
 
             // Decrement
             wrapper.find('.control.minus button').trigger('mousedown')

--- a/src/components/numberinput/Numberinput.vue
+++ b/src/components/numberinput/Numberinput.vue
@@ -296,12 +296,12 @@ export default {
             if (inc) this.increment()
             else this.decrement()
 
+            if (!this.longPress) return
             this._$intervalRef = setTimeout(() => {
                 this.longPressTick(inc)
             }, this.exponential ? (250 / (this.exponential * this.timesPressed++)) : 250)
         },
         onStartLongPress(event, inc) {
-            if (!this.longPress) return
             if (event.button !== 0 && event.type !== 'touchstart') return
             clearTimeout(this._$intervalRef)
             this.longPressTick(inc)


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

# Fixes
A while ago, I wrote this PR: https://github.com/buefy/buefy/pull/3782.
Basically, the bug happens when `long-press` is disabled: clicking on the + or the - buttons does nothing.
The code I wrote was not working at all and was breaking the base feature of the Numberinput component... 🤦 
Sorry about that.

I made a little video of the bug: https://www.loom.com/share/81e46aab3a8149ceb6da309de9a3c6b9?sid=cf53a12a-713a-4ab6-9f60-8a173ae4c68f.
It can be easily reproduced in production by opening any example of the Numberinput in CodePen and add `:long-press="false"` to one of the component declaration.

Anyway, I fixed the bug and updated the unit test.
