### PR TITLE
Expose isActiveDetailRow method in table component column slot props

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -290,7 +290,10 @@
                                         :class="column.getRootClasses(row)"
                                         :style="column.getRootStyle(row)"
                                         :data-label="column.label"
-                                        :props="{ row, column, index, colindex, toggleDetails }"
+                                        :props="{
+                                            row, column, index, colindex,
+                                            toggleDetails, isActiveDetailRow
+                                        }"
                                         @click.native="$emit('cellclick',row,column,index,colindex)"
                                     />
                                 </template>

--- a/src/components/table/TableColumn.spec.js
+++ b/src/components/table/TableColumn.spec.js
@@ -32,7 +32,7 @@ describe('BTableColumn', () => {
                 <BTable :data="tableData" detail-key="id" detailed>
                     <BTableColumn :td-attrs="(td) => ({ id: \`td-\${td.id}\` })" v-slot="props">
                         <div>
-                            {{ props.row.name }} - {{ props.isActiveDetailRow(props.row) ? 'Openned' : 'Closed' }}
+                            {{ props.row.name }} - {{ props.isActiveDetailRow(props.row) ? 'Opened' : 'Closed' }}
                         </div>
                         <BButton @click="props.toggleDetails(props.row)">Toggle details</BButton>
                     </BTableColumn>
@@ -57,22 +57,22 @@ describe('BTableColumn', () => {
         await wrapper.vm.$nextTick()
         // Toggle first row details
         expect(wrapper.find('#td-1').text()).toContain('Closed')
-        expect(wrapper.find('#td-1').text()).not.toContain('Openned')
+        expect(wrapper.find('#td-1').text()).not.toContain('Opened')
         wrapper.find('#td-1 button').trigger('click')
         await wrapper.vm.$nextTick()
         expect(wrapper.find('#td-1').text()).not.toContain('Closed')
-        expect(wrapper.find('#td-1').text()).toContain('Openned')
+        expect(wrapper.find('#td-1').text()).toContain('Opened')
         wrapper.find('#td-1 button').trigger('click')
         await wrapper.vm.$nextTick()
         expect(wrapper.find('#td-1').text()).toContain('Closed')
-        expect(wrapper.find('#td-1').text()).not.toContain('Openned')
+        expect(wrapper.find('#td-1').text()).not.toContain('Opened')
 
         // Toggle second row details
         expect(wrapper.find('#td-2').text()).toContain('Closed')
-        expect(wrapper.find('#td-2').text()).not.toContain('Openned')
+        expect(wrapper.find('#td-2').text()).not.toContain('Opened')
         wrapper.find('#td-2 button').trigger('click')
         await wrapper.vm.$nextTick()
         expect(wrapper.find('#td-2').text()).not.toContain('Closed')
-        expect(wrapper.find('#td-2').text()).toContain('Openned')
+        expect(wrapper.find('#td-2').text()).toContain('Opened')
     })
 })

--- a/src/components/table/TableColumn.spec.js
+++ b/src/components/table/TableColumn.spec.js
@@ -1,6 +1,7 @@
 import { mount } from '@vue/test-utils'
 import BTable from '@components/table/Table'
 import BTableColumn from '@components/table/TableColumn'
+import BButton from '@components/button/Button'
 
 let wrapper
 const WrapperComp = {
@@ -23,5 +24,55 @@ describe('BTableColumn', () => {
     it('is called', () => {
         expect(wrapper.name()).toBe('BTableColumn')
         expect(wrapper.isVueInstance()).toBeTruthy()
+    })
+
+    it('expose isActiveDetailRow method', async () => {
+        const DetailedTable = {
+            template: `
+                <BTable :data="tableData" detail-key="id" detailed>
+                    <BTableColumn :td-attrs="(td) => ({ id: \`td-\${td.id}\` })" v-slot="props">
+                        <div>
+                            {{ props.row.name }} - {{ props.isActiveDetailRow(props.row) ? 'Openned' : 'Closed' }}
+                        </div>
+                        <BButton @click="props.toggleDetails(props.row)">Toggle details</BButton>
+                    </BTableColumn>
+                </BTable>`,
+            components: { BTable, BTableColumn, BButton }
+        }
+
+        const tableData = [
+            { id: 1, name: 'Jesse' },
+            { id: 2, name: 'John' },
+            { id: 3, name: 'Tina' },
+            { id: 4, name: 'Anne' },
+            { id: 5, name: 'Clarence' }
+        ]
+
+        const wrapper = mount(DetailedTable, {
+            sync: false,
+            data: () => ({ detailKey: 'id', detailed: true, tableData })
+        })
+
+        // Wait for component to properly mount
+        await wrapper.vm.$nextTick()
+        // Toggle first row details
+        expect(wrapper.find('#td-1').text()).toContain('Closed')
+        expect(wrapper.find('#td-1').text()).not.toContain('Openned')
+        wrapper.find('#td-1 button').trigger('click')
+        await wrapper.vm.$nextTick()
+        expect(wrapper.find('#td-1').text()).not.toContain('Closed')
+        expect(wrapper.find('#td-1').text()).toContain('Openned')
+        wrapper.find('#td-1 button').trigger('click')
+        await wrapper.vm.$nextTick()
+        expect(wrapper.find('#td-1').text()).toContain('Closed')
+        expect(wrapper.find('#td-1').text()).not.toContain('Openned')
+
+        // Toggle second row details
+        expect(wrapper.find('#td-2').text()).toContain('Closed')
+        expect(wrapper.find('#td-2').text()).not.toContain('Openned')
+        wrapper.find('#td-2 button').trigger('click')
+        await wrapper.vm.$nextTick()
+        expect(wrapper.find('#td-2').text()).not.toContain('Closed')
+        expect(wrapper.find('#td-2').text()).toContain('Openned')
     })
 })


### PR DESCRIPTION
Hi, 

I didn't seem to find any way to know if a detailed table row was opened or closed, other than keeping track of it outside of the component. Looking through the `Table` component I found `isActiveDetailRow` method, can it be exposed through the `b-table-column` props ?
Sorry if I missed something !

## Proposed Changes
Allow to expose the `isActiveDetailRow` method in `b-table-column` props to expose the opened / closed state of the detailed row to elements inside `b-table-column` slot.
