### PR TITLE
fix(taginput): fix dropdown position when autocompleted and appended …

### DIFF
--- a/src/components/autocomplete/Autocomplete.vue
+++ b/src/components/autocomplete/Autocomplete.vue
@@ -664,7 +664,7 @@ export default {
         },
         updateAppendToBody() {
             const dropdownMenu = this.$refs.dropdown
-            const trigger = this.$refs.input.$el
+            const trigger = this.$parent.$data._isTaginput ? this.$parent.$el : this.$refs.input.$el
             if (dropdownMenu && trigger) {
                 // update wrapper dropdown
                 const root = this.$data._bodyEl


### PR DESCRIPTION
…to body

When Autocomplete is used as Taginput child, appended to body Dropdown position should be calculated from Taginput element as trigger.

<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

-
-
-
