### PR TITLE
Fix: Datepicker keyboard navigation causes browser hangup (#3876)

### DIFF
--- a/src/components/datepicker/DatepickerTableRow.vue
+++ b/src/components/datepicker/DatepickerTableRow.vue
@@ -369,7 +369,7 @@ export default {
                 (!this.maxDate || nextDay < this.maxDate) &&
                 !this.selectableDate(nextDay)
             ) {
-                nextDay.setDate(day.getDate() + Math.sign(inc))
+                nextDay.setDate(nextDay.getDate() + Math.sign(inc))
             }
             this.setRangeHoverEndDate(nextDay)
             this.$emit('change-focus', nextDay)


### PR DESCRIPTION
Fixes
- #3876
- #3792

## Proposed Changes

- Replace `day` inside the `changeFocus` loop with `nextDay` 