### PR TITLE
Modal render on mounted (#3827)

### DIFF
--- a/docs/pages/components/modal/api/modal.js
+++ b/docs/pages/components/modal/api/modal.js
@@ -149,6 +149,13 @@ export default [
                 type: 'String',
                 values: '—',
                 default: '—'
+            },
+            {
+                name: '<code>render-on-mounted</code>',
+                description: 'Create DOM for the modal content whether modal is active or not',
+                type: 'Boolean',
+                values: '-',
+                default: '<code>false</code>'
             }
         ],
         events: [

--- a/src/components/modal/Modal.spec.js
+++ b/src/components/modal/Modal.spec.js
@@ -105,4 +105,30 @@ describe('BModal', () => {
         wrapper.vm.afterLeave()
         expect(wrapper.emitted()['after-leave']).toBeTruthy()
     })
+
+    it('should not be rendered on mounted if active and renderOnMounted are false', () => {
+        const wrapper = shallowMount(BModal, {
+            propsData: {
+                active: false,
+                renderOnMounted: false
+            },
+            stubs: {
+                transition: false
+            }
+        })
+        expect(wrapper.find('.modal.is-active').exists()).toBeFalsy()
+    })
+
+    it('should be rendered on mounted if active is false but renderOnMounted is true', () => {
+        const wrapper = shallowMount(BModal, {
+            propsData: {
+                active: false,
+                renderOnMounted: true
+            },
+            stubs: {
+                transition: false
+            }
+        })
+        expect(wrapper.find('.modal.is-active').exists()).toBeTruthy()
+    })
 })

--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -137,6 +137,10 @@ export default {
         destroyOnHide: {
             type: Boolean,
             default: true
+        },
+        renderOnMounted: {
+            type: Boolean,
+            default: false
         }
     },
     data() {
@@ -147,7 +151,7 @@ export default {
                 ? this.width + 'px'
                 : this.width,
             animating: !this.active,
-            destroyed: !this.active
+            destroyed: !(this.active || this.renderOnMounted)
         }
     },
     computed: {


### PR DESCRIPTION
Fixes
- #3827

## Proposed Changes

- Introduce `renderOnMounted` prop for `Modal`. If it is `true`, `Modal` creates DOM for its content whether it is active or not.