### PR TITLE
Fix: Validation error on Field with multiple child components (addons) persists after value is corrected (#3883)

### DIFF
--- a/src/components/field/Field.spec.js
+++ b/src/components/field/Field.spec.js
@@ -180,6 +180,29 @@ describe('BField', () => {
             })
             expect(wrapper.find('.field').find('label').isVisible()).toBe(true)
         })
+
+        it('should reflect validation status of wrapped input unless type is specified', async () => {
+            const wrapper = mount(BField, mountOptions)
+            const input = wrapper.find(BInput)
+
+            input.vm.setInvalid()
+            await wrapper.vm.$nextTick()
+            expect(wrapper.vm.newType).toBe('is-danger')
+
+            input.vm.setValidity(null, null)
+            await wrapper.vm.$nextTick()
+            expect(wrapper.vm.newType).toBeFalsy()
+
+            await wrapper.setProps({ type: 'is-warning' })
+
+            input.vm.setInvalid()
+            await wrapper.vm.$nextTick()
+            expect(wrapper.vm.newType).toBe('is-warning')
+
+            input.vm.setValidity(null, null)
+            await wrapper.vm.$nextTick()
+            expect(wrapper.vm.newType).toBe('is-warning')
+        })
     })
 
     describe('Passing true for horizontal prop', () => {

--- a/src/components/field/Field.vue
+++ b/src/components/field/Field.vue
@@ -32,7 +32,7 @@
         <div v-else-if="hasInnerField" class="field-body">
             <b-field
                 :addons="false"
-                :type="newType"
+                :type="type"
                 :class="innerFieldClasses">
                 <slot/>
             </b-field>


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #3883

## Proposed Changes

- Propagate `type` instead of `newType` to the inner `Field` that is inserted when the default slot has multiple components
    - Binding `type` prop to `newType` prevented the type of the inner `Field` from being updated once `newType` was set due to the following check: https://github.com/buefy/buefy/blob/6f41e91bd24dfef8f680f27313e07b488ddcfc1d/src/utils/FormElementMixin.js#L137