### PR TITLE
Fix: Validation error on Input not reset by programmatically correcting the value (#3884)

### DIFF
--- a/src/components/input/Input.spec.js
+++ b/src/components/input/Input.spec.js
@@ -197,4 +197,88 @@ describe('BInput', () => {
             done()
         })
     })
+
+    describe('validation', () => {
+        let spyOnCheckHtml5Validity
+
+        beforeEach(() => {
+            spyOnCheckHtml5Validity = jest
+                .spyOn(BInput.mixins[0].methods, 'checkHtml5Validity')
+                .mockImplementation(function () {
+                    this.isValid = false
+                })
+        })
+
+        afterEach(() => {
+            spyOnCheckHtml5Validity.mockReset()
+        })
+
+        it('should validate value when updated by user interaction', async () => {
+            const wrapper = shallowMount(BInput, {
+                data: () => ({ isValid: false })
+            })
+
+            // simulates "input" event
+            wrapper.vm.onInput({ target: { value: 'foo' } })
+            await wrapper.vm.$nextTick()
+            expect(spyOnCheckHtml5Validity).toHaveBeenCalledTimes(1)
+
+            // simulates "change" event
+            await wrapper.setProps({ lazy: true })
+            wrapper.vm.onChange({ target: { value: 'bar' } })
+            await wrapper.vm.$nextTick()
+            expect(spyOnCheckHtml5Validity).toHaveBeenCalledTimes(2)
+        })
+
+        it('should validate value when programmatically updated', async () => {
+            const wrapper = shallowMount(BInput, {
+                data: () => ({ isValid: false })
+            })
+            await wrapper.setProps({ value: 'foo' })
+            await wrapper.vm.$nextTick()
+            expect(spyOnCheckHtml5Validity).toHaveBeenCalledTimes(1)
+        })
+
+        describe('via v-model', () => {
+            let root
+            let wrapper
+
+            beforeEach(async () => {
+                root = mount({
+                    template: '<b-input v-model="value" :lazy="lazy" />',
+                    components: { 'b-input': BInput },
+                    data: () => ({
+                        value: '',
+                        lazy: false
+                    })
+                })
+                wrapper = root.find(BInput)
+                // triggers validation and invalidates
+                wrapper.vm.onBlur({})
+                await wrapper.vm.$nextTick()
+                spyOnCheckHtml5Validity.mockClear()
+            })
+
+            it('should validate value once when updated by user interaction', async () => {
+                // simulates "input" event
+                wrapper.vm.onInput({ target: { value: 'foo' } })
+                await wrapper.vm.$nextTick()
+                expect(root.vm.value).toBe('foo')
+                expect(spyOnCheckHtml5Validity).toHaveBeenCalledTimes(1)
+
+                // simulates "change" event
+                await root.setData({ lazy: true })
+                wrapper.vm.onChange({ target: { value: 'bar' } })
+                await wrapper.vm.$nextTick()
+                expect(root.vm.value).toBe('bar')
+                expect(spyOnCheckHtml5Validity).toHaveBeenCalledTimes(2)
+            })
+
+            it('should validate value once when programmatically updated', async () => {
+                await root.setData({ value: 'foo' })
+                await wrapper.vm.$nextTick()
+                expect(spyOnCheckHtml5Validity).toHaveBeenCalledTimes(1)
+            })
+        })
+    })
 })

--- a/src/components/input/Input.vue
+++ b/src/components/input/Input.vue
@@ -214,9 +214,18 @@ export default {
         /**
         * When v-model is changed:
         *   1. Set internal value.
+        *   2. Validate it if the value came from outside;
+        *      i.e., not equal to computedValue
         */
         value(value) {
+            const fromOutside = this.computedValue != value // eslint-disable-line eqeqeq
             this.newValue = value
+            if (fromOutside) {
+                // validation must wait for DOM updated
+                this.$nextTick(() => {
+                    !this.isValid && this.checkHtml5Validity()
+                })
+            }
         },
         type(type) {
             this.newType = type


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #3884

## Proposed Changes

- Run validation when `value` prop is changed.
    - Avoid running validation twice on the same value by checking the change is not from user interaction: `computedValue != value`