### PR TITLE
Update Twitter and Sponsor Links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -3,4 +3,3 @@
 custom: 
   - https://ko-fi.com/kemoto
   - https://ko-fi.com/wesdevpro
-  - https://www.paypal.me/wtommasi

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,6 @@
 # These are supported funding model platforms
 
-custom: https://www.paypal.me/wtommasi
+custom: 
+  - https://ko-fi.com/kemoto
+  - https://ko-fi.com/wesdevpro
+  - https://www.paypal.me/wtommasi

--- a/docs/components/TheNavbar.vue
+++ b/docs/components/TheNavbar.vue
@@ -40,7 +40,7 @@
                 <a
                     class="navbar-item"
                     :class="{ 'has-text-twitter': !light }"
-                    href="https://twitter.com/walter_tommasi"
+                    href="https://twitter.com/buefycss"
                     target="_blank"
                     title="Twitter">
                     <b-icon icon="twitter"/>


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->
## Proposed Changes
1. Update the documentation website's twitter link to use the [official twitter](https://twitter.com/buefycss) for `Buefy`.
2. Update the GitHub sponsor links to include the two new maintainers of `Buefy`.