### PR TITLE
Fix: CDN link not working after update (#3890)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:8.9-browsers
+      - image: cimg/node:18.18.0-browsers
 
     working_directory: ~/repo
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "build:docs": "node build/build.js && copyfiles --flat netlify.toml dist-docs",
     "build": "npm run build:lib && npm run build:docs",
     "cov": "./node_modules/codcov/bin/codcov",
-    "vetur": "node -r esm build/vetur.js"
+    "vetur": "node -r esm build/vetur.js",
+    "prepare": "npm run build:lib"
   },
   "keywords": [
     "bulma",

--- a/src/components/checkbox/__snapshots__/Checkbox.spec.js.snap
+++ b/src/components/checkbox/__snapshots__/Checkbox.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BCheckbox render correctly 1`] = `<label class="b-checkbox checkbox"><input type="checkbox" autocomplete="on" true-value="true" value="false"> <span class="check"></span> <span class="control-label"></span></label>`;
+exports[`BCheckbox render correctly 1`] = `<label class="b-checkbox checkbox"><input id="" type="checkbox" autocomplete="on" true-value="true" value="false"> <span class="check"></span> <span class="control-label"></span></label>`;

--- a/src/components/clockpicker/__snapshots__/Clockpicker.spec.js.snap
+++ b/src/components/clockpicker/__snapshots__/Clockpicker.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BClockpicker render correctly 1`] = `
 <div class="b-clockpicker control is-primary">
-    <b-dropdown-stub maxheight="200" triggers="click" mobilemodal="true" animation="fade" trapfocus="true" closeonclick="true" canclose="true" appendtobodycopyparent="true">
+    <b-dropdown-stub maxheight="200" triggers="click" mobilemodal="true" animation="fade" trapfocus="true" closeonclick="true" canclose="true" appendtobodycopyparent="true" triggertabindex="0">
         <div custom="" class="card">
             <!---->
             <div class="card-content">

--- a/src/components/colorpicker/__snapshots__/Colorpicker.spec.js.snap
+++ b/src/components/colorpicker/__snapshots__/Colorpicker.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BColorpicker render correctly 1`] = `
 <div class="colorpicker control">
-    <b-dropdown-stub maxheight="200" triggers="click" mobilemodal="true" ariarole="dialog" animation="fade" trapfocus="true" closeonclick="true" canclose="true" appendtobodycopyparent="true" aria-modal="true">
+    <b-dropdown-stub maxheight="200" triggers="click" mobilemodal="true" ariarole="dialog" animation="fade" trapfocus="true" closeonclick="true" canclose="true" appendtobodycopyparent="true" triggertabindex="0">
         <b-dropdown-item-stub custom="true" focusable="true" ariarole="" class="">
             <div>
                 <header class="colorpicker-header">

--- a/src/components/datepicker/Datepicker.spec.js
+++ b/src/components/datepicker/Datepicker.spec.js
@@ -264,10 +264,17 @@ describe('BDatepicker', () => {
     })
 
     describe('#dateFormatter', () => {
+        beforeEach(() => {
+            // uses en-US locale to make outputs predictable
+            wrapper.setProps({
+                locale: 'en-US'
+            })
+        })
+
         it('should add one to month since month in dates starts from 0', () => {
             const dateToFormat = new Date(2019, 3, 1)
             const formattedDate = wrapper.vm.dateFormatter(dateToFormat, wrapper.vm)
-            expect(formattedDate).toEqual('2019-4-1')
+            expect(formattedDate).toEqual('4/1/2019')
         })
 
         it('should format based on 2-digit numeric locale date with type === month', () => {
@@ -276,7 +283,7 @@ describe('BDatepicker', () => {
             })
             const dateToFormat = new Date(2019, 3, 1)
             const formattedDate = wrapper.vm.dateFormatter(dateToFormat, wrapper.vm)
-            expect(formattedDate).toEqual('2019-04')
+            expect(formattedDate).toEqual('4/2019')
         })
 
         it('should format a range of dates passed via array', () => {
@@ -285,7 +292,7 @@ describe('BDatepicker', () => {
                 new Date(2019, 3, 3)
             ]
             const formattedDate = wrapper.vm.dateFormatter(dateToFormat, wrapper.vm)
-            expect(formattedDate).toEqual('2019-4-1 - 2019-4-3')
+            expect(formattedDate).toEqual('4/1/2019 - 4/3/2019')
         })
 
         describe('multiple', () => {
@@ -305,7 +312,7 @@ describe('BDatepicker', () => {
                     new Date(2019, 3, 3)
                 ]
                 const formattedDate = wrapper.vm.dateFormatter(dateToFormat, wrapper.vm)
-                expect(formattedDate).toEqual('2019-4-1, 2019-4-13, 2019-4-3')
+                expect(formattedDate).toEqual('4/1/2019, 4/13/2019, 4/3/2019')
             })
 
             it('react accordingly when setting computedValue', () => {

--- a/src/components/datepicker/DatepickerMonth.spec.js
+++ b/src/components/datepicker/DatepickerMonth.spec.js
@@ -5,12 +5,10 @@ import config, {setOptions} from '@utils/config'
 
 let wrapper
 
+// it used to create a Date in UTC but should use the local timezone,
+// because DatepickerMonth deals with the local timezone
 const newDate = (y, m, d) => {
-    const date = new Date(Date.UTC(y, m, d))
-    date.getDate = jest.fn(() => date.getUTCDate())
-    date.getMonth = jest.fn(() => date.getUTCMonth())
-    date.getFullYear = jest.fn(() => date.getUTCFullYear())
-    return date
+    return new Date(y, m, d)
 }
 
 const thisMonth = newDate(2020, 4, 15).getUTCMonth()

--- a/src/components/datepicker/__snapshots__/Datepicker.spec.js.snap
+++ b/src/components/datepicker/__snapshots__/Datepicker.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`BDatepicker render correctly 1`] = `
 <div class="datepicker control">
-    <b-dropdown-stub maxheight="200" triggers="click" mobilemodal="true" ariarole="dialog" animation="fade" trapfocus="true" closeonclick="true" canclose="true" appendtobodycopyparent="true" aria-modal="true">
+    <b-dropdown-stub maxheight="200" triggers="click" mobilemodal="true" ariarole="dialog" animation="fade" trapfocus="true" closeonclick="true" canclose="true" appendtobodycopyparent="true" triggertabindex="-1">
         <b-dropdown-item-stub custom="true" focusable="true" ariarole="" class="">
             <div>
                 <header class="datepicker-header">

--- a/src/components/datetimepicker/Datetimepicker.spec.js
+++ b/src/components/datetimepicker/Datetimepicker.spec.js
@@ -69,6 +69,7 @@ describe('Datetimepicker', () => {
         const datetimeToFormat = new Date(2019, 9, 1, 8, 30, 0, 0)
         wrapper = mount(Datetimepicker, {
             propsData: {
+                locale: 'en-US', // makes outputs predictable
                 value: datetimeToFormat
             },
             stubs: {
@@ -77,7 +78,7 @@ describe('Datetimepicker', () => {
         })
         const datepicker = wrapper.find({ ref: 'datepicker' })
 
-        expect(datepicker.vm.formattedValue).toEqual('2019-10-1 08:30')
+        expect(datepicker.vm.formattedValue).toEqual('10/1/2019, 8:30 AM')
 
         wrapper.setProps({
             datetimeFormatter: (date) => `${date.getFullYear()}`
@@ -88,6 +89,7 @@ describe('Datetimepicker', () => {
     it('should format date time with seconds', () => {
         wrapper = mount(Datetimepicker, {
             propsData: {
+                locale: 'en-US', // makes outputs predictable
                 timepicker: {
                     enableSeconds: true
                 }
@@ -98,13 +100,14 @@ describe('Datetimepicker', () => {
         })
         const datetimeToFormat = new Date(2019, 9, 1, 8, 30, 0, 0)
         const formattedDatetime = wrapper.vm.defaultDatetimeFormatter(datetimeToFormat)
-        expect(formattedDatetime).toEqual('2019-10-1 08:30:00')
+        expect(formattedDatetime).toEqual('10/1/2019, 8:30:00 AM')
     })
 
     it('should format date time according init value', async () => {
         const date = new Date(2019, 9, 1, 8, 30, 0, 0)
         wrapper = mount(Datetimepicker, {
             propsData: {
+                locale: 'en-US', // makes outputs predictable
                 value: date
             },
             stubs: {
@@ -113,11 +116,14 @@ describe('Datetimepicker', () => {
             sync: false
         })
         await wrapper.vm.$nextTick()
-        expect(wrapper.find('input').element.value).toEqual('2019-10-1 08:30')
+        expect(wrapper.find('input').element.value).toEqual('10/1/2019, 8:30 AM')
     })
 
     it('should parse date time', async () => {
         wrapper = mount(Datetimepicker, {
+            propsData: {
+                locale: 'en-US' // makes outputs predictable
+            },
             stubs: {
                 transition: false
             }

--- a/src/components/dropdown/__snapshots__/Dropdown.spec.js.snap
+++ b/src/components/dropdown/__snapshots__/Dropdown.spec.js.snap
@@ -2,10 +2,10 @@
 
 exports[`BDropdown render correctly 1`] = `
 <div class="dropdown dropdown-menu-animation is-mobile-modal">
-    <div role="button" tabindex="0" aria-haspopup="true" class="dropdown-trigger"><button class="trigger">trigger</button></div>
+    <div tabindex="0" aria-haspopup="true" class="dropdown-trigger"><button class="trigger">trigger</button></div>
     <div aria-hidden="true" class="background" style="display: none;" name="fade"></div>
     <div aria-hidden="true" class="dropdown-menu" style="display: none;" name="fade">
-        <div class="dropdown-content"></div>
+        <div aria-modal="true" class="dropdown-content"></div>
     </div>
 </div>
 `;

--- a/src/components/navbar/__snapshots__/NavbarDropdown.spec.js.snap
+++ b/src/components/navbar/__snapshots__/NavbarDropdown.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`BNavbarDropdown render correctly 1`] = `
 <div class="navbar-item has-dropdown"><a aria-haspopup="true" tabindex="0" class="navbar-link"></a>
-    <div class="navbar-dropdown"></div>
+    <div class="navbar-dropdown is-hidden-touch"></div>
+    <div class="navbar-dropdown is-hidden-desktop"></div>
 </div>
 `;

--- a/src/components/numberinput/Numberinput.spec.js
+++ b/src/components/numberinput/Numberinput.spec.js
@@ -170,7 +170,18 @@ describe('BNumberinput', () => {
 
     describe('Rendered (shallow)', () => {
         beforeEach(() => {
-            wrapper = shallowMount(BNumberinput)
+            wrapper = shallowMount(BNumberinput, {
+                stubs: {
+                    // to suppress error messages printed when BNumberinput
+                    // tries to call checkHtml5Validity of the input
+                    'b-input': {
+                        template: '<div></div>',
+                        methods: {
+                            checkHtml5Validity: () => true
+                        }
+                    }
+                }
+            })
         })
 
         it('manage prop types (number / string)', () => {

--- a/src/components/numberinput/Numberinput.spec.js
+++ b/src/components/numberinput/Numberinput.spec.js
@@ -3,10 +3,6 @@ import BNumberinput from '@components/numberinput/Numberinput'
 
 let wrapper
 
-const wait = (time) => {
-    return new Promise((resolve) => setTimeout(resolve, time))
-}
-
 describe('BNumberinput', () => {
     describe('Rendered', () => {
         beforeEach(() => {
@@ -35,28 +31,46 @@ describe('BNumberinput', () => {
         })
 
         it('increments/decrements on long pressing exponentially', async () => {
+            // we should not depend on a real timer
+            // otherwise the results will depend on the machine
+            jest.useFakeTimers()
+
             wrapper.setProps({exponential: true, value: 1, step: 1})
 
             wrapper.find('.control.plus button').trigger('mousedown')
+            expect(wrapper.vm.computedValue).toBe(2)
 
-            await wait(1500)
+            for (let n = 1; n <= 10; ++n) {
+                // while Jest's fake setTimeout truncates the delay to an exact
+                // ms when it schedules the callback,
+                // jest.advanceTimersByTime floors the value and
+                // accumulates the remainder.
+                // so should be floored to prevent the accumulated remainder
+                // from triggering an extra callback
+                jest.advanceTimersByTime(Math.floor(250 / n))
+                expect(wrapper.vm.computedValue).toBe(n + 2)
+            }
 
             wrapper.find('.control.plus').trigger('mouseup')
+            jest.runAllTimers()
             await wrapper.vm.$nextTick()
-
-            expect(wrapper.vm.computedValue).toBeGreaterThan(1)
-            expect(wrapper.vm.computedValue).toBeLessThan(150)
+            expect(wrapper.vm.computedValue).toBe(12)
 
             wrapper.setProps({exponential: 3, value: 0, step: 1})
 
             wrapper.find('.control.plus button').trigger('mousedown')
+            expect(wrapper.vm.computedValue).toBe(1)
 
-            await wait(1000)
+            for (let n = 1; n <= 20; ++n) {
+                // see above for `floor`ing
+                jest.advanceTimersByTime(Math.floor(250 / (n * 3)))
+                expect(wrapper.vm.computedValue).toBe(n + 1)
+            }
 
             wrapper.find('.control.plus').trigger('mouseup')
-
-            expect(wrapper.vm.computedValue).toBeGreaterThan(0)
-            expect(wrapper.vm.computedValue).toBeLessThan(600)
+            jest.runAllTimers()
+            await wrapper.vm.$nextTick()
+            expect(wrapper.vm.computedValue).toBe(21)
         })
 
         it('increments/decrements on long pressing', async () => {

--- a/src/components/pagination/__snapshots__/Pagination.spec.js.snap
+++ b/src/components/pagination/__snapshots__/Pagination.spec.js.snap
@@ -8,6 +8,9 @@ exports[`BPagination render correctly 1`] = `
     <bpaginationbutton-stub page="[object Object]" tag="a" disabled="true" class="pagination-next">
         <b-icon-stub icon="chevron-right" both="true" aria-hidden="true"></b-icon-stub>
     </bpaginationbutton-stub>
+    <div class="control pagination-input">
+        <!---->
+    </div>
     <ul class="pagination-list">
         <!---->
         <!---->

--- a/src/components/sidebar/__snapshots__/Sidebar.spec.js.snap
+++ b/src/components/sidebar/__snapshots__/Sidebar.spec.js.snap
@@ -4,6 +4,7 @@ exports[`BSidebar open render correctly 1`] = `
 <div class="b-sidebar">
     <!---->
     <div class="sidebar-content is-fixed" style="" name="slide-next">
+        <!---->
         <div class="content"></div>
     </div>
 </div>
@@ -13,6 +14,7 @@ exports[`BSidebar render correctly 1`] = `
 <div class="b-sidebar">
     <!---->
     <div class="sidebar-content is-fixed" style="display: none;" name="slide-prev">
+        <!---->
         <div class="content"></div>
     </div>
 </div>

--- a/src/components/steps/__snapshots__/StepItem.spec.js.snap
+++ b/src/components/steps/__snapshots__/StepItem.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BStepItem render correctly 1`] = `<div class="step-item" id="16-content" tabindex="-1" style="display: none;"></div>`;
+exports[`BStepItem render correctly 1`] = `<div id="16-content" tabindex="-1" class="step-item" style="display: none;"></div>`;

--- a/src/components/steps/__snapshots__/Steps.spec.js.snap
+++ b/src/components/steps/__snapshots__/Steps.spec.js.snap
@@ -25,9 +25,9 @@ exports[`BSteps render correctly 1`] = `
         </ul>
     </nav>
     <section class="step-content">
-        <div class="step-item" id="14-content" tabindex="-1" style="display: none;"></div>
-        <div class="step-item" id="16-content" tabindex="0" style="display: none;"></div>
-        <div class="step-item" id="18-content" tabindex="-1" style="display: none;"></div>
+        <div id="14-content" tabindex="-1" class="step-item" style="display: none;"></div>
+        <div id="16-content" tabindex="0" class="step-item" style="display: none;"></div>
+        <div id="18-content" tabindex="-1" class="step-item" style="display: none;"></div>
     </section>
     <nav class="step-navigation"><a role="button" class="pagination-previous"><span class="icon" aria-hidden="true"><i class="mdi mdi-chevron-left mdi-24px"></i></span></a> <a role="button" class="pagination-next"><span class="icon" aria-hidden="true"><i class="mdi mdi-chevron-right mdi-24px"></i></span></a></nav>
 </div>

--- a/src/components/tabs/__snapshots__/TabItem.spec.js.snap
+++ b/src/components/tabs/__snapshots__/TabItem.spec.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BTabItem render correctly 1`] = `<div class="tab-item" role="tabpanel" id="tab2-content" aria-labelledby="tab2-label" tabindex="-1" style="display: none;"></div>`;
+exports[`BTabItem render correctly 1`] = `<div role="tabpanel" id="tab2-content" aria-labelledby="tab2-label" tabindex="-1" class="tab-item" style="display: none;"></div>`;

--- a/src/components/tabs/__snapshots__/Tabs.spec.js.snap
+++ b/src/components/tabs/__snapshots__/Tabs.spec.js.snap
@@ -2,25 +2,25 @@
 
 exports[`BTabs render correctly 1`] = `
 <div class="b-tabs">
-    <nav role="tablist" aria-orientation="horizontal" class="tabs">
-        <ul>
-            <li role="presentation" class="is-active"><a role="tab" id="tab1-tab" aria-controls="tab1-content" aria-selected="true" tabindex="0">
+    <nav class="tabs">
+        <ul aria-orientation="horizontal" role="tablist">
+            <li role="tab" aria-controls="tab1-content" aria-selected="true" class="is-active"><a id="tab1-label" tabindex="0">
                     <!----> <span></span></a></li>
-            <li role="presentation" class="" style="display: none;"><a role="tab" id="tab2-tab" aria-controls="tab2-content" aria-selected="false" tabindex="-1">
+            <li role="tab" aria-controls="tab2-content" aria-selected="false" class="" style="display: none;"><a id="tab2-label" tabindex="-1">
                     <!----> <span></span></a></li>
         </ul>
     </nav>
     <section class="tab-content">
-        <div class="tab-item" role="tabpanel" id="tab1-content" aria-labelledby="tab1-label" tabindex="0"></div>
-        <div class="tab-item" role="tabpanel" id="tab2-content" aria-labelledby="tab2-label" tabindex="-1" style="display: none;"></div>
+        <div role="tabpanel" id="tab1-content" aria-labelledby="tab1-label" tabindex="0" class="tab-item"></div>
+        <div role="tabpanel" id="tab2-content" aria-labelledby="tab2-label" tabindex="-1" class="tab-item" style="display: none;"></div>
     </section>
 </div>
 `;
 
 exports[`BTabs still renders if there is no item 1`] = `
 <div class="b-tabs">
-    <nav role="tablist" aria-orientation="horizontal" class="tabs">
-        <ul></ul>
+    <nav class="tabs">
+        <ul aria-orientation="horizontal" role="tablist"></ul>
     </nav>
     <section class="tab-content"></section>
 </div>

--- a/src/components/taginput/__snapshots__/Taginput.spec.js.snap
+++ b/src/components/taginput/__snapshots__/Taginput.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`BTaginput render correctly 1`] = `
 <div class="taginput control">
     <div class="taginput-container is-focusable">
-        <b-autocomplete-stub usehtml5validation="true" statusicon="true" value="" data="" field="value" dropdownposition="auto" type="text" confirmkeys=",,Tab,Enter"></b-autocomplete-stub>
+        <b-autocomplete-stub usehtml5validation="true" statusicon="true" value="" data="" field="value" keepopen="true" dropdownposition="auto" type="text" confirmkeys=",,Tab,Enter"></b-autocomplete-stub>
     </div>
     <!---->
 </div>

--- a/src/components/timepicker/Timepicker.spec.js
+++ b/src/components/timepicker/Timepicker.spec.js
@@ -5,7 +5,13 @@ let wrapper
 
 describe('BTimepicker', () => {
     beforeEach(() => {
-        wrapper = shallowMount(BTimepicker)
+        wrapper = shallowMount(BTimepicker, {
+            propsData: {
+                // fixes the locale, and hour format to make outputs predictable
+                locale: 'en-US',
+                hourFormat: '24'
+            }
+        })
     })
 
     it('is called', () => {

--- a/src/components/timepicker/__snapshots__/Timepicker.spec.js.snap
+++ b/src/components/timepicker/__snapshots__/Timepicker.spec.js.snap
@@ -2,36 +2,39 @@
 
 exports[`BTimepicker render correctly 1`] = `
 <div class="timepicker control">
-    <b-dropdown-stub maxheight="200" triggers="click" mobilemodal="true" animation="fade" trapfocus="true" closeonclick="true" canclose="true" appendtobodycopyparent="true">
+    <b-dropdown-stub maxheight="200" triggers="click" mobilemodal="true" animation="fade" trapfocus="true" closeonclick="true" canclose="true" appendtobodycopyparent="true" triggertabindex="0">
         <b-dropdown-item-stub custom="true" focusable="true" ariarole="">
             <b-field-stub grouped="true" position="is-centered" addons="true">
                 <b-select-stub usehtml5validation="true" statusicon="true" placeholder="00">
+                    <option value="0">
+                        00
+                    </option>
                     <option value="1">
-                        1
+                        01
                     </option>
                     <option value="2">
-                        2
+                        02
                     </option>
                     <option value="3">
-                        3
+                        03
                     </option>
                     <option value="4">
-                        4
+                        04
                     </option>
                     <option value="5">
-                        5
+                        05
                     </option>
                     <option value="6">
-                        6
+                        06
                     </option>
                     <option value="7">
-                        7
+                        07
                     </option>
                     <option value="8">
-                        8
+                        08
                     </option>
                     <option value="9">
-                        9
+                        09
                     </option>
                     <option value="10">
                         10
@@ -39,8 +42,41 @@ exports[`BTimepicker render correctly 1`] = `
                     <option value="11">
                         11
                     </option>
-                    <option value="0">
+                    <option value="12">
                         12
+                    </option>
+                    <option value="13">
+                        13
+                    </option>
+                    <option value="14">
+                        14
+                    </option>
+                    <option value="15">
+                        15
+                    </option>
+                    <option value="16">
+                        16
+                    </option>
+                    <option value="17">
+                        17
+                    </option>
+                    <option value="18">
+                        18
+                    </option>
+                    <option value="19">
+                        19
+                    </option>
+                    <option value="20">
+                        20
+                    </option>
+                    <option value="21">
+                        21
+                    </option>
+                    <option value="22">
+                        22
+                    </option>
+                    <option value="23">
+                        23
                     </option>
                 </b-select-stub> <span class="control is-colon">:</span>
                 <b-select-stub usehtml5validation="true" statusicon="true" placeholder="00">
@@ -226,14 +262,7 @@ exports[`BTimepicker render correctly 1`] = `
                     </option>
                 </b-select-stub>
                 <!---->
-                <b-select-stub usehtml5validation="true" statusicon="true" value="AM">
-                    <option value="AM">
-                        AM
-                    </option>
-                    <option value="PM">
-                        PM
-                    </option>
-                </b-select-stub>
+                <!---->
             </b-field-stub>
             <!---->
         </b-dropdown-item-stub>

--- a/src/components/tooltip/__snapshots__/Tooltip.spec.js.snap
+++ b/src/components/tooltip/__snapshots__/Tooltip.spec.js.snap
@@ -1,3 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BTooltip render correctly 1`] = `<span class="b-tooltip is-primary is-top is-medium"><div class="tooltip-content" style="display: none;" name="fade"><!----></div> <div class="tooltip-trigger"></div></span>`;
+exports[`BTooltip render correctly 1`] = `
+<div class="b-tooltip is-primary is-top is-medium">
+    <div class="tooltip-content" style="display: none;" name="fade">
+        <!---->
+    </div>
+    <div class="tooltip-trigger"></div>
+</div>
+`;


### PR DESCRIPTION
Fixes
- fixes #3890

## Proposed Changes

- Add [`prepare` script](https://docs.npmjs.com/cli/v10/using-npm/scripts#prepare-and-prepublish) to `package.json` to make sure `build:lib` is run before publishing.
    - The problem was no `dist` folder was built before publishing a package. One could insert `npm run build:lib` before `npm publish` in `npm_deploy.yml` file, but `prepare` script has a few more benefits that other publishing methods, e.g., npm install via GitHub, [yalc](https://github.com/wclr/yalc), will become available.