### PR TITLE
Fix: Change Broken Link at `/expo`

### DIFF
--- a/docs/pages/Expo.vue
+++ b/docs/pages/Expo.vue
@@ -12,7 +12,7 @@
                     </button>
                     <a
                         class="button is-vuetelemetry"
-                        href="https://vuetelemetry.com/explore?ui.slug=buefy&_sort=lastDetectedAt%3Adesc"
+                        href="https://www.vuetelescope.com/explore?ui.slug=buefy&_sort=lastDetectedAt:desc"
                         target="_blank">
                         <b-icon icon="nuxt"/>
                         <span>Explore VueTelemetry</span>


### PR DESCRIPTION
Fixes #
- #3898 

## Proposed Changes
- Change broken link located at `/expo` from `https://vuetelemetry.com/explore?ui.slug=buefy&_sort=lastDetectedAt%3Adesc` to `https://www.vuetelescope.com/explore?ui.slug=buefy&_sort=lastDetectedAt:desc`

https://github.com/buefy/buefy/blob/8f3d72b310dc5c142f46f4e26e3ab7e22f0cceec/docs/pages/Expo.vue#L15