### PR TITLE
Fix: SVG icons too large in Safari (#3872)

### DIFF
--- a/src/scss/components/_icon.scss
+++ b/src/scss/components/_icon.scss
@@ -1,5 +1,5 @@
-$icon-svg-width: auto !default;
-$icon-svg-height: auto !default;
+$icon-svg-width: 100% !default;
+$icon-svg-height: 100% !default;
 
 .icon {
     @include unselectable;


### PR DESCRIPTION
Fixes #
- fixes #3872

## Proposed Changes

- Change the default SVG icon size → 100% (thanks to @rubenvannieuwpoort)

I have checked the behavior on Safari and Chrome on macOS.