### PR TITLE
Fix: Invalid type error for tags (#3887)

### DIFF
--- a/src/components/tag/Tag.vue
+++ b/src/components/tag/Tag.vue
@@ -69,7 +69,7 @@ export default {
     props: {
         attached: Boolean,
         closable: Boolean,
-        type: String,
+        type: [String, Object],
         size: String,
         rounded: Boolean,
         disabled: Boolean,


### PR DESCRIPTION
Fixes #
- #3887

## Proposed Changes

- Add `Object` to the acceptable types of `Tag.type`