### PR TITLE
Tooltip Glitchy (#3753)

### DIFF
--- a/src/components/tooltip/Tooltip.vue
+++ b/src/components/tooltip/Tooltip.vue
@@ -147,30 +147,37 @@ export default {
 
                 const rect = trigger.getBoundingClientRect()
 
-                let top = rect.top + window.scrollY
-                let left = rect.left + window.scrollX
+                const top = rect.top + window.scrollY
+                const left = rect.left + window.scrollX
 
-                const quaterHeight = trigger.clientHeight / 2 / 2
-
+                // `tooltipEl` will be placed relative to `wrapper`
+                // because `wrapper` should create a stacking context
+                // as its z-index is non-auto
+                tooltipEl.style.position = 'absolute'
                 switch (this.position) {
                     case 'is-top':
                         tooltipEl.style.width = `${trigger.clientWidth}px`
-                        tooltipEl.style.height = `0px`
-                        top -= trigger.clientHeight - quaterHeight
+                        tooltipEl.style.height = '0px'
+                        tooltipEl.style.top = '0px'
+                        tooltipEl.style.left = '0px'
                         break
                     case 'is-bottom':
                         tooltipEl.style.width = `${trigger.clientWidth}px`
-                        tooltipEl.style.height = `0px`
-                        top += quaterHeight
+                        tooltipEl.style.height = '0px'
+                        tooltipEl.style.top = `${trigger.clientHeight}px`
+                        tooltipEl.style.left = '0px'
                         break
                     case 'is-left':
-                        tooltipEl.style.width = `0px`
+                        tooltipEl.style.width = '0px'
                         tooltipEl.style.height = `${trigger.clientHeight}px`
+                        tooltipEl.style.top = '0px'
+                        tooltipEl.style.left = '0px'
                         break
                     case 'is-right':
-                        tooltipEl.style.width = `0px`
+                        tooltipEl.style.width = '0px'
                         tooltipEl.style.height = `${trigger.clientHeight}px`
-                        left += trigger.clientWidth
+                        tooltipEl.style.top = '0px'
+                        tooltipEl.style.left = `${trigger.clientWidth}px`
                         break
                 }
 
@@ -178,7 +185,7 @@ export default {
                 wrapper.style.position = 'absolute'
                 wrapper.style.top = `${top}px`
                 wrapper.style.left = `${left}px`
-                wrapper.style.width = `0px`
+                wrapper.style.width = '0px'
                 wrapper.style.zIndex = this.isActive || this.always ? '99' : '-1'
                 this.triggerStyle = {
                     zIndex: this.isActive || this.always ? '100' : undefined

--- a/src/components/tooltip/Tooltip.vue
+++ b/src/components/tooltip/Tooltip.vue
@@ -287,6 +287,16 @@ export default {
         if (this.appendToBody && typeof window !== 'undefined') {
             this.$data._bodyEl = createAbsoluteElement(this.$refs.content)
             this.updateAppendToBody()
+            // updates the tooltip position if the tooltip is inside
+            // `.animation-content`
+            const animation = this.$el.closest('.animation-content')
+            if (animation != null) {
+                const listener = () => {
+                    this.updateAppendToBody()
+                    animation.removeEventListener('transitionend', listener)
+                }
+                animation.addEventListener('transitionend', listener)
+            }
             // observes changes in the window size
             this.resizeListener = () => this.updateAppendToBody()
             window.addEventListener('resize', this.resizeListener)

--- a/src/components/tooltip/Tooltip.vue
+++ b/src/components/tooltip/Tooltip.vue
@@ -94,7 +94,9 @@ export default {
             isActive: false,
             triggerStyle: {},
             timer: null,
-            _bodyEl: undefined // Used to append to body
+            _bodyEl: undefined, // Used to append to body
+            resizeObserver: undefined,
+            resizeListener: undefined
         }
     },
     computed: {
@@ -285,6 +287,14 @@ export default {
         if (this.appendToBody && typeof window !== 'undefined') {
             this.$data._bodyEl = createAbsoluteElement(this.$refs.content)
             this.updateAppendToBody()
+            // observes changes in the window size
+            this.resizeListener = () => this.updateAppendToBody()
+            window.addEventListener('resize', this.resizeListener)
+            // observes changes in the size of the immediate parent
+            this.resizeObserver = new ResizeObserver(this.resizeListener)
+            if (this.$el.parentNode != null && this.$el.parentNode.nodeType === Node.ELEMENT_NODE) {
+                this.resizeObserver.observe(this.$el.parentNode)
+            }
         }
     },
     created() {
@@ -297,6 +307,12 @@ export default {
         if (typeof window !== 'undefined') {
             document.removeEventListener('click', this.clickedOutside)
             document.removeEventListener('keyup', this.keyPress)
+        }
+        if (this.resizeListener != null) {
+            window.removeEventListener('resize', this.resizeListener)
+        }
+        if (this.resizeObserver != null) {
+            this.resizeObserver.disconnect()
         }
         if (this.appendToBody) {
             removeElement(this.$data._bodyEl)


### PR DESCRIPTION
Fixes #
- fixes #3753
- fixes #3065

## Proposed Changes

These commits might not be sufficient to fix the problem in #3753, because there was no reproduction code, and I was not able to watch the attached video. However, they fix as many problems as I could find on my machine (macOS/Safari, Chrome).

- Correct the position of `Tooltip`s appended to body by specifying the absolute position of the anchor element (`tooltipEl`) instead of the `wrapper` element
- Update the position of `Tooltip`s in response to resizing window and the parent element
- Adjust the position of `Tooltip`s after the `Modal` CSS transition completes if `Tooltip`s are in a` Modal`
    - The position of `Tooltip`s were slightly dislodged just after the `Modal` was opened