### PR TITLE
Horizontal scrollable table ignores column width (#3726)

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -97,7 +97,9 @@
                                 :class="{
                                     'is-numeric': column.numeric,
                                     'is-centered': column.centered
-                            }">
+                                }"
+                                :style="column.thWrapStyle"
+                            >
                                 <template v-if="column.$scopedSlots && column.$scopedSlots.header">
                                     <b-slot-component
                                         :component="column"
@@ -179,7 +181,9 @@
                                 :class="{
                                     'is-numeric': column.numeric,
                                     'is-centered': column.centered
-                            }">
+                                }"
+                                :style="column.thWrapStyle"
+                            >
                                 <template
                                     v-if="column.$scopedSlots && column.$scopedSlots.subheading"
                                 >
@@ -205,7 +209,7 @@
                             v-bind="column.thAttrs(column)"
                             :style="column.thStyle"
                             :class="{'is-sticky': column.sticky}">
-                            <div class="th-wrap">
+                            <div class="th-wrap" :style="column.thWrapStyle">
                                 <template v-if="column.searchable">
                                     <template
                                         v-if="column.$scopedSlots

--- a/src/components/table/TableColumn.vue
+++ b/src/components/table/TableColumn.vue
@@ -63,6 +63,9 @@ export default {
             }
             return style
         },
+        thWrapStyle() {
+            return this.style
+        },
         rootClasses() {
             return [this.cellClass, {
                 'has-text-right': this.numeric && !this.centered,


### PR DESCRIPTION
Fixes
- fixes #3726

## Proposed Changes

- Apply `width` style to `<div class="th-wrap">` in `<th>`.
- Introduce a new computed property `thWrapStyle` to `BTableColumn`