### PR TITLE
Fix: sort icons on Table overlapped next columns

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -93,7 +93,7 @@
                             @dragover="handleColumnDragOver($event, column, index)"
                             @dragleave="handleColumnDragLeave($event, column, index)">
                             <div
-                                class="th-wrap"
+                                class="th-wrap is-relative"
                                 :class="{
                                     'is-numeric': column.numeric,
                                     'is-centered': column.centered
@@ -110,14 +110,14 @@
                                     />
                                 </template>
                                 <template v-else>
-                                    <span class="is-relative">
-                                        {{ column.label }}
-                                        <template
-                                            v-if="sortMultiple &&
-                                                sortMultipleDataComputed &&
-                                                sortMultipleDataComputed.length > 0 &&
-                                                sortMultipleDataComputed.filter(i =>
-                                            i.field === column.field).length > 0">
+                                    {{ column.label }}
+                                    <template
+                                        v-if="sortMultiple &&
+                                            sortMultipleDataComputed &&
+                                            sortMultipleDataComputed.length > 0 &&
+                                            sortMultipleDataComputed.filter(i =>
+                                        i.field === column.field).length > 0">
+                                        <span class="multi-sort-icons">
                                             <b-icon
                                                 :icon="sortIcon"
                                                 :pack="iconPack"
@@ -132,21 +132,21 @@
                                                 class="delete is-small multi-sort-cancel-icon"
                                                 type="button"
                                                 @click.stop="removeSortingPriority(column)"/>
-                                        </template>
+                                        </span>
+                                    </template>
 
-                                        <b-icon
-                                            v-else
-                                            :icon="sortIcon"
-                                            :pack="iconPack"
-                                            both
-                                            :size="sortIconSize"
-                                            class="sort-icon"
-                                            :class="{
-                                                'is-desc': !isAsc,
-                                                'is-invisible': currentSortColumn !== column
-                                            }"
-                                        />
-                                    </span>
+                                    <b-icon
+                                        v-else
+                                        :icon="sortIcon"
+                                        :pack="iconPack"
+                                        both
+                                        :size="sortIconSize"
+                                        class="sort-icon"
+                                        :class="{
+                                            'is-desc': !isAsc,
+                                            'is-invisible': currentSortColumn !== column
+                                        }"
+                                    />
                                 </template>
                             </div>
                         </th>

--- a/src/scss/components/_table.scss
+++ b/src/scss/components/_table.scss
@@ -114,6 +114,8 @@ $table-sticky-header-height: 300px !default;
             font-weight: $weight-semibold;
             .th-wrap {
                 display: flex;
+                flex-wrap: wrap;
+                justify-content: space-between;
                 align-items: center;
                 .icon {
                     margin-left: 0.5rem;
@@ -124,9 +126,11 @@ $table-sticky-header-height: 300px !default;
                     flex-direction: row-reverse;
                     text-align: right;
                     width: 95%;
-                    .icon {
+                    .sort-icon {
                         margin-left: 0;
                         margin-right: 0.5rem;
+                        left: 0;
+                        right: auto;
                     }
                 }
                 &.is-centered {
@@ -149,14 +153,18 @@ $table-sticky-header-height: 300px !default;
                     position: absolute;
                 }
             }
-            .sort-icon, .multi-sort-cancel-icon {
+            .sort-icon {
                 position: absolute;
                 bottom: 50%;
-                left: 100%;
+                right: 0;
                 transform: translateY(50%);
             }
-            .multi-sort-cancel-icon {
-                margin-left: 10px;
+            .multi-sort-icons {
+                display: flex;
+                align-items: center;
+                .multi-sort-cancel-icon {
+                    margin-left: 10px;
+                }
             }
             &.is-sticky {
                 position: -webkit-sticky;


### PR DESCRIPTION
Fixes
- fixes #2886
- fixes #3034

## Proposed Changes

- Place the sort icons inside the columns instead of at the right side of the column label texts
    - The sort icons are placed on the left if `is-numeric` is `true`, otherwise on the right.
- In the `sort-multiple` mode, group the sort icon, number, and delete button as `multi-sort-icons` so that they won't split
    - The delete buttons used to be placed at the right side of the column label texts, but they are placed in the same flow with the column label texts now
    - The `multi-sort-icons` groups are placed on the left if `is-numeric` is `true`, otherwise on the right.