### PR TITLE
Drag-n-drop on touch screens (#3916)

### DIFF
--- a/docs/pages/components/table/Table.vue
+++ b/docs/pages/components/table/Table.vue
@@ -129,6 +129,9 @@
                 Use <code>draggable</code>/<code>draggable-column</code> prop to allow rows and columns to be draggable. Manage dragging using <code>dragstart</code>/<code>columndragstart</code>,
                 <code>dragover</code>/<code>columndragover</code> and <code>drop</code>/<code>columndrop</code> events
             </p>
+            <b-message type="is-info">
+                You have to <strong>double-tap and hold</strong> a row to start dragging the row on touch devices.
+            </b-message>
         </Example>
 
         <ApiView :data="api"/>

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -1468,7 +1468,6 @@ export default {
             // drag won't start unless the row has been clicked (tapped)
             // I think trapping touch-scrolling is annoying
             if (this._selectedRow !== row) return
-            this.isDraggingRow = true
             event.preventDefault()
             event.target.dispatchEvent(translateTouchAsDragEvent(event, {
                 type: 'dragstart'
@@ -1527,7 +1526,6 @@ export default {
             event.target.dispatchEvent(translateTouchAsDragEvent(event, {
                 type: 'dragend'
             }))
-            this.isDraggingRow = false
             this._selectedRow = null
         },
 
@@ -1537,8 +1535,7 @@ export default {
         handleColumnTouchStart(event, column, index) {
             if (!this.canDragColumn) return
             if (this.isDraggingRow) return
-            this.isDraggingColumn = true
-            event.preventDefault()
+            event.preventDefault() // otherwise triggers touch-scrolling
             event.target.dispatchEvent(translateTouchAsDragEvent(event, {
                 type: 'dragstart'
             }))
@@ -1596,7 +1593,6 @@ export default {
             event.target.dispatchEvent(translateTouchAsDragEvent(event, {
                 type: 'dragend'
             }))
-            this.isDraggingColumn = false
         },
 
         refreshSlots() {

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -408,6 +408,7 @@
             v-show="mayBeTouchDragging && (isDraggingRow || isDraggingColumn)"
             ref="draggedCell"
             class="touch-dragged-cell"
+            :class="touchDraggedCellClasses"
             v-html="draggedCellContent"
         />
 
@@ -680,6 +681,11 @@ export default {
         tableStyle() {
             return {
                 height: toCssWidth(this.height)
+            }
+        },
+        touchDraggedCellClasses() {
+            return {
+                'has-mobile-cards': this.mobileCards
             }
         },
 
@@ -1494,6 +1500,9 @@ export default {
                 this.draggedCellContent = tr
                     ? `<table class="table"><tr>${tr.innerHTML}</tr></table>`
                     : event.target.innerHTML
+                this.$refs.draggedCell.style.width = tr
+                    ? `${tr.offsetWidth}px`
+                    : `${event.target.offsetWidth}px`
                 event.target.dispatchEvent(translateTouchAsDragEvent(event, {
                     type: 'dragstart'
                 }))
@@ -1570,6 +1579,7 @@ export default {
             if (!this.mayBeTouchDragging) return
             if (!this.isDraggingColumn) {
                 this.draggedCellContent = event.target.innerHTML
+                this.$refs.draggedCell.style.width = `${event.target.offsetWidth}px`
                 event.target.dispatchEvent(translateTouchAsDragEvent(event, {
                     type: 'dragstart'
                 }))

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -404,7 +404,7 @@
 </template>
 
 <script>
-import { getValueByPath, indexOf, multiColumnSort, escapeRegExpChars, toCssWidth, removeDiacriticsFromString, isNil } from '../../utils/helpers'
+import { getValueByPath, indexOf, multiColumnSort, escapeRegExpChars, toCssWidth, removeDiacriticsFromString, isNil, translateTouchAsDragEvent } from '../../utils/helpers'
 import debounce from '../../utils/debounce'
 import { VueInstance } from '../../utils/config'
 import Checkbox from '../checkbox/Checkbox.vue'
@@ -1464,19 +1464,9 @@ export default {
             // I think trapping touch-scrolling is annoying
             if (this._selectedRow !== row) return
             this.isDraggingRow = true
-            const touch = event.touches[0]
             event.preventDefault()
-            event.target.dispatchEvent(new DragEvent('dragstart', {
-                dataTransfer: new DataTransfer(),
-                bubbles: true,
-                screenX: touch.screenX,
-                screenY: touch.screenY,
-                clientX: touch.clientX,
-                clientY: touch.clientY,
-                ctrlKey: event.ctrlKey,
-                shiftKey: event.shiftKey,
-                altKey: event.altKey,
-                metaKey: event.metaKey
+            event.target.dispatchEvent(translateTouchAsDragEvent(event, {
+                type: 'dragstart'
             }))
         },
         /**
@@ -1487,59 +1477,31 @@ export default {
             if (!this.isDraggingRow) return
             const touch = event.touches[0]
             const target = document.elementFromPoint(touch.clientX, touch.clientY)
-            const draggedRect = event.target.getBoundingClientRect()
             if (target != null) {
                 if (target !== this.touchDragoverTarget) {
                     if (this.touchDragoverTarget != null) {
-                        const targetRect = this.touchDragoverTarget.getBoundingClientRect()
-                        const offsetX = targetRect.left - draggedRect.left
-                        const offsetY = targetRect.top - draggedRect.top
-                        this.touchDragoverTarget.dispatchEvent(new DragEvent('dragleave', {
-                            dataTransfer: new DataTransfer(),
-                            bubbles: true,
-                            screenX: touch.screenX,
-                            screenY: touch.screenY,
-                            clientX: touch.clientX + offsetX,
-                            clientY: touch.clientY + offsetY,
-                            ctrlKey: event.ctrlKey,
-                            shiftKey: event.shiftKey,
-                            altKey: event.altKey,
-                            metaKey: event.metaKey
-                        }))
+                        this.touchDragoverTarget.dispatchEvent(
+                            translateTouchAsDragEvent(event, {
+                                type: 'dragleave',
+                                target: this.touchDragoverTarget
+                            })
+                        )
                     }
                     this.touchDragoverTarget = target
-                    const targetRect = target.getBoundingClientRect()
-                    const offsetX = targetRect.left - draggedRect.left
-                    const offsetY = targetRect.top - draggedRect.top
-                    target.dispatchEvent(new DragEvent('dragover', {
-                        dataTransfer: new DataTransfer(),
-                        bubbles: true,
-                        screenX: touch.screenX,
-                        screenY: touch.screenY,
-                        clientX: touch.clientX + offsetX,
-                        clientY: touch.clientY + offsetY,
-                        ctrlKey: event.ctrlKey,
-                        shiftKey: event.shiftKey,
-                        altKey: event.altKey,
-                        metaKey: event.metaKey
-                    }))
+                    target.dispatchEvent(
+                        translateTouchAsDragEvent(event, {
+                            type: 'dragover',
+                            target
+                        })
+                    )
                 }
             } else if (this.touchDragoverTarget != null) {
-                const targetRect = this.touchDragoverTarget.getBoundingClientRect()
-                const offsetX = targetRect.left - draggedRect.left
-                const offsetY = targetRect.top - draggedRect.top
-                this.touchDragoverTarget.dispatchEvent(new DragEvent('dragleave', {
-                    dataTransfer: new DataTransfer(),
-                    bubbles: true,
-                    screenX: touch.screenX,
-                    screenY: touch.screenY,
-                    clientX: touch.clientX + offsetX,
-                    clientY: touch.clientY + offsetY,
-                    ctrlKey: event.ctrlKey,
-                    shiftKey: event.shiftKey,
-                    altKey: event.altKey,
-                    metaKey: event.metaKey
-                }))
+                this.touchDragoverTarget.dispatchEvent(
+                    translateTouchAsDragEvent(event, {
+                        type: 'dragleave',
+                        target: this.touchDragoverTarget
+                    })
+                )
                 this.touchDragoverTarget = null
             }
         },
@@ -1552,34 +1514,13 @@ export default {
             const touch = event.changedTouches[0]
             const target = document.elementFromPoint(touch.clientX, touch.clientY)
             if (target != null) {
-                const draggedRect = event.target.getBoundingClientRect()
-                const targetRect = target.getBoundingClientRect()
-                const offsetX = targetRect.left - draggedRect.left
-                const offsetY = targetRect.top - draggedRect.top
-                target.dispatchEvent(new DragEvent('drop', {
-                    dataTransfer: new DataTransfer(),
-                    bubbles: true,
-                    screenX: touch.screenX,
-                    screenY: touch.screenY,
-                    clientX: touch.clientX + offsetX,
-                    clientY: touch.clientY + offsetY,
-                    ctrlKey: event.ctrlKey,
-                    shiftKey: event.shiftKey,
-                    altKey: event.altKey,
-                    metaKey: event.metaKey
+                target.dispatchEvent(translateTouchAsDragEvent(event, {
+                    type: 'drop',
+                    target
                 }))
             }
-            event.target.dispatchEvent(new DragEvent('dragend', {
-                dataTransfer: new DataTransfer(),
-                bubbles: true,
-                screenX: touch.screenX,
-                screenY: touch.screenY,
-                clientX: touch.clientX,
-                clientY: touch.clientY,
-                ctrlKey: event.ctrlKey,
-                shiftKey: event.shiftKey,
-                altKey: event.altKey,
-                metaKey: event.metaKey
+            event.target.dispatchEvent(translateTouchAsDragEvent(event, {
+                type: 'dragend'
             }))
             this.isDraggingRow = false
             this._selectedRow = null

--- a/src/scss/components/_table.scss
+++ b/src/scss/components/_table.scss
@@ -279,15 +279,36 @@ $table-sticky-header-height: 300px !default;
 }
 
 .touch-dragged-cell {
-  position: absolute;
+    position: absolute;
 }
 .touch-dragged-cell,
 .touch-dragged-cell .table {
-  pointer-events: none;
-  background-color: color-mix(in srgb, $table-background-color 10%, transparent);
+    pointer-events: none;
+    background-color: color-mix(in srgb, $table-background-color 10%, transparent);
 }
-.touch-dragged-cell .table {
-  tr, td {
-    background-color: transparent;
-  }
+.touch-dragged-cell {
+    .table {
+        width: 100%;
+        tr, td {
+            background-color: transparent;
+        }
+    }
+}
+.touch-dragged-cell.has-mobile-cards .table {
+    @include mobile {
+        tr {
+            display: block;
+            td {
+                display: flex;
+                justify-content: space-between;
+                text-align: right;
+                &:before {
+                    content: attr(data-label);
+                    font-weight: $weight-semibold;
+                    padding-right: 0.5em;
+                    text-align: left;
+                }
+            }
+        }
+    }
 }

--- a/src/scss/components/_table.scss
+++ b/src/scss/components/_table.scss
@@ -277,3 +277,17 @@ $table-sticky-header-height: 300px !default;
         }
     }
 }
+
+.touch-dragged-cell {
+  position: absolute;
+}
+.touch-dragged-cell,
+.touch-dragged-cell .table {
+  pointer-events: none;
+  background-color: color-mix(in srgb, $table-background-color 10%, transparent);
+}
+.touch-dragged-cell .table {
+  tr, td {
+    background-color: transparent;
+  }
+}

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -305,3 +305,45 @@ export const isDefined = (d) => d !== undefined
  * https://github.com/lodash/lodash/blob/master/isNil.js
  */
 export const isNil = (value) => value === null || value === undefined
+
+/**
+ * Translates a touch event as a drag event.
+ *
+ * `event` must be a touch event.
+ *
+ * `options` must be an object with the following properties:
+ * - `type`: new event type (required). must be one of the following:
+ *     - `"dragstart"`
+ *     - `"dragend"`
+ *     - `"drop"`
+ *     - `"dragover"`
+ *     - `"dragleave"`
+ * - `target`: new target element (optional). `clientX` and `clientY` will be
+ *   translated if `target` is different from `event.target`.
+ *
+ * This function only works with single-touch events for now.
+ */
+export const translateTouchAsDragEvent = (event, options) => {
+    const { type, target } = options
+    let translateX = 0
+    let translateY = 0
+    if (target != null && target !== event.target) {
+        const baseRect = event.target.getBoundingClientRect()
+        const targetRect = target.getBoundingClientRect()
+        translateX = targetRect.left - baseRect.left
+        translateY = targetRect.top - baseRect.top
+    }
+    const touch = event.touches[0] || event.changedTouches[0]
+    return new DragEvent(type, {
+        dataTransfer: new DataTransfer(),
+        bubbles: true,
+        screenX: touch.screenX,
+        screenY: touch.screenY,
+        clientX: touch.clientX + translateX,
+        clientY: touch.clientY + translateY,
+        ctrlKey: event.ctrlKey,
+        shiftKey: event.shiftKey,
+        altKey: event.altKey,
+        metaKey: event.metaKey
+    })
+}


### PR DESCRIPTION
Fixes
- fixes #3916

## Proposed Changes

- Let `BTable` emulate drag-n-drop on touch-enabled devices
    - `BTable` captures touch events: `touchstart`, `touchmove`, and `touchend`
    - `BTable` inserts an extra `<div>` element to superimpose the dragged contents on the screen, which turns visible only while table rows or columns are being dragged
- Add how to start dragging rows on touch devices to the documentation page of `BTable`

**Remarks**: users have to **double-tap and hold** on a row to start drag-n-drop of the row on touch-enabled devices. Otherwise users cannot do touch-scrolling on `BTable`.