### PR TITLE
Fix: Modal: Display close button in mobile version (#2621)

### DIFF
--- a/src/scss/components/_modal.scss
+++ b/src/scss/components/_modal.scss
@@ -21,4 +21,17 @@
     .modal-content {
         width: 100%;
     }
+    .modal-close {
+        @include until($modal-breakpoint) {
+            /* keep modal-close visible when the contents fill the screen */
+            background-color: color-mix(in hsl, $modal-background-background-color 10%, transparent);
+            &:hover,
+            :focus {
+                background-color: color-mix(in hsl, $modal-background-background-color 20%, transparent);
+            }
+            &:active {
+                background-color: color-mix(in hsl, $modal-background-background-color 30%, transparent);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fixes
- fixes #2621

## Proposed Changes

- Switch the background color of `.modal-close` from `none` to a translucent dark color when the screen width is within the modal breakpoint