### PR TITLE
Fix: Table: customSort does not work when sortMultiple is enabled (#2681)

### DIFF
--- a/src/components/table/Table.spec.js
+++ b/src/components/table/Table.spec.js
@@ -237,4 +237,183 @@ describe('BTable', () => {
             expect(bodyRows).toHaveLength(2) // Filtering after debounce
         })
     })
+
+    describe('Sortable', () => {
+        let wrapper
+        const data = [
+            { id: 1, name: 'Jesse' },
+            { id: 2, name: 'João' },
+            { id: 3, name: 'Tina' },
+            { id: 4, name: 'Anne' },
+            { id: 5, name: 'Clarence' }
+        ]
+        const columns = [
+            {
+                field: 'id',
+                label: 'ID',
+                numeric: true,
+                sortable: true
+            },
+            {
+                field: 'name',
+                label: 'Name',
+                sortable: true
+            }
+        ]
+
+        beforeEach(() => {
+            wrapper = shallowMount(BTable, {
+                propsData: {
+                    columns,
+                    data
+                }
+            })
+        })
+
+        it('should be able to sort by ID', () => {
+            const sorted = [...data]
+            wrapper.vm.sort(columns[0])
+            expect(wrapper.vm.currentSortColumn).toBe(columns[0])
+            expect(wrapper.vm.isAsc).toBe(true)
+            expect(wrapper.vm.visibleData).toEqual(sorted)
+            // toggles
+            wrapper.vm.sort(columns[0])
+            expect(wrapper.vm.isAsc).toBe(false)
+            expect(wrapper.vm.visibleData).toEqual(sorted.reverse())
+        })
+
+        it('should be able to sort by Name', () => {
+            const sorted = [
+                data[3], data[4], data[0], data[1], data[2]
+            ]
+            wrapper.vm.sort(columns[1])
+            expect(wrapper.vm.currentSortColumn).toBe(columns[1])
+            expect(wrapper.vm.isAsc).toBe(true)
+            expect(wrapper.vm.visibleData).toEqual(sorted)
+            // toggles
+            wrapper.vm.sort(columns[1])
+            expect(wrapper.vm.isAsc).toBe(false)
+            expect(wrapper.vm.visibleData).toEqual(sorted.reverse())
+        })
+    })
+
+    describe('Multi-sortable', () => {
+        let wrapper
+        const data = [
+            { id: 1, name: 'Jesse', age: 23 },
+            { id: 2, name: 'João', age: 22 },
+            { id: 3, name: 'Tina', age: 22 },
+            { id: 4, name: 'Anne', age: 23 },
+            { id: 5, name: 'Clarence', age: 22 }
+        ]
+        const columns = [
+            {
+                field: 'id',
+                label: 'ID'
+            },
+            {
+                field: 'name',
+                label: 'Name',
+                sortable: true
+            },
+            {
+                field: 'age',
+                label: 'Age',
+                numeric: true,
+                sortable: true
+            }
+        ]
+
+        beforeEach(() => {
+            wrapper = shallowMount(BTable, {
+                propsData: {
+                    columns,
+                    data,
+                    sortMultiple: true
+                }
+            })
+        })
+
+        it('should be able to sort by Age then Name', () => {
+            wrapper.vm.sort(columns[2])
+            wrapper.vm.sort(columns[1])
+            expect(wrapper.vm.sortMultipleDataLocal).toEqual([
+                { field: 'age', order: undefined },
+                { field: 'name', order: undefined }
+            ])
+            expect(wrapper.vm.visibleData).toEqual([
+                data[4], data[1], data[2], data[3], data[0]
+            ])
+            // toggles age
+            wrapper.vm.sort(columns[2])
+            expect(wrapper.vm.sortMultipleDataLocal).toEqual([
+                { field: 'age', order: 'desc' },
+                { field: 'name', order: undefined }
+            ])
+            expect(wrapper.vm.visibleData).toEqual([
+                data[3], data[0], data[4], data[1], data[2]
+            ])
+            // toggles name
+            wrapper.vm.sort(columns[1])
+            expect(wrapper.vm.sortMultipleDataLocal).toEqual([
+                { field: 'age', order: 'desc' },
+                { field: 'name', order: 'desc' }
+            ])
+            expect(wrapper.vm.visibleData).toEqual([
+                data[0], data[3], data[2], data[1], data[4]
+            ])
+        })
+    })
+
+    describe('Sortable with custom sort', () => {
+        let wrapper
+        const weekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+        const data = weekdays.map((day, i) => ({
+            id: i + 1,
+            day
+        }))
+        const customSort = jest.fn((a, b, isAsc) => {
+            const ord = weekdays.indexOf(a.day) - weekdays.indexOf(b.day)
+            return isAsc ? ord : -ord
+        })
+        const columns = [
+            {
+                field: 'id',
+                label: 'ID',
+                numeric: true
+            },
+            {
+                field: 'day',
+                label: 'Day',
+                sortable: true,
+                customSort
+            }
+        ]
+
+        beforeEach(() => {
+            wrapper = shallowMount(BTable, {
+                propsData: {
+                    columns,
+                    data
+                }
+            })
+        })
+
+        afterEach(() => {
+            customSort.mockClear()
+        })
+
+        it('should be able to sort by Day with custom sort', () => {
+            const sorted = [...data]
+            wrapper.vm.sort(columns[1])
+            expect(wrapper.vm.currentSortColumn).toBe(columns[1])
+            expect(wrapper.vm.isAsc).toBe(true)
+            expect(wrapper.vm.visibleData).toEqual(sorted)
+            expect(customSort).toHaveBeenCalled()
+            // toggles
+            wrapper.vm.sort(columns[1])
+            expect(wrapper.vm.isAsc).toBe(false)
+            expect(wrapper.vm.visibleData).toEqual(sorted.reverse())
+        })
+    })
 })

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -943,14 +943,10 @@ export default {
                 this.sortMultipleDataLocal = this.sortMultipleDataLocal.filter(
                     (priority) => priority.field !== column.field)
 
-                let formattedSortingPriority = this.sortMultipleDataLocal.map((i) => {
-                    return (i.order && i.order === 'desc' ? '-' : '') + i.field
-                })
-
-                if (formattedSortingPriority.length === 0) {
+                if (this.sortMultipleDataLocal.length === 0) {
                     this.resetMultiSorting()
                 } else {
-                    this.newData = multiColumnSort(this.newData, formattedSortingPriority)
+                    this.newData = multiColumnSort(this.newData, this.sortMultipleDataLocal)
                 }
             }
         },
@@ -1009,19 +1005,18 @@ export default {
                 if (existingPriority) {
                     existingPriority.order = existingPriority.order === 'desc' ? 'asc' : 'desc'
                 } else {
-                    this.sortMultipleDataLocal.push(
-                        {field: column.field, order: column.isAsc}
-                    )
+                    this.sortMultipleDataLocal.push({
+                        field: column.field,
+                        order: column.isAsc,
+                        customSort: column.customSort
+                    })
                 }
                 this.doSortMultiColumn()
             }
         },
 
         doSortMultiColumn() {
-            let formattedSortingPriority = this.sortMultipleDataLocal.map((i) => {
-                return (i.order && i.order === 'desc' ? '-' : '') + i.field
-            })
-            this.newData = multiColumnSort(this.newData, formattedSortingPriority)
+            this.newData = multiColumnSort(this.newData, this.sortMultipleDataLocal)
         },
 
         /**

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -185,14 +185,19 @@ export function removeDiacriticsFromString(value) {
 }
 
 export function multiColumnSort(inputArray, sortingPriority) {
+    // NOTE: this function is intended to be used by BTable
     // clone it to prevent the any watchers from triggering every sorting iteration
     let array = JSON.parse(JSON.stringify(inputArray))
     const fieldSorter = (fields) => (a, b) => fields.map((o) => {
-        let dir = 1
-        if (o[0] === '-') { dir = -1; o = o.substring(1) }
-        const aValue = getValueByPath(a, o)
-        const bValue = getValueByPath(b, o)
-        return aValue > bValue ? dir : aValue < bValue ? -(dir) : 0
+        const { field, order, customSort } = o
+        if (typeof customSort === 'function') {
+            return customSort(a, b, order !== 'desc')
+        } else {
+            const aValue = getValueByPath(a, field)
+            const bValue = getValueByPath(b, field)
+            const ord = aValue > bValue ? 1 : aValue < bValue ? -1 : 0
+            return order === 'desc' ? -ord : ord
+        }
     }).reduce((p, n) => p || n, 0)
 
     return array.sort(fieldSorter(sortingPriority))


### PR DESCRIPTION
Fixes
- fixes #2681

## Proposed Changes

- Make `BTable` use `customSort` of each column if exists when it sorts multiple columns
- Change the format of the second parameter `sortingPriority` of `multiColumnSort` function defined in `src/utils/helpers.js`
- Add test cases around sorting by `BTable`