### PR TITLE
Fix: unnecessary component duplication in navbar-item (#3939)

### DIFF
--- a/src/components/navbar/NavbarDropdown.vue
+++ b/src/components/navbar/NavbarDropdown.vue
@@ -26,20 +26,11 @@
             <slot v-else name="label" />
         </component>
         <div
-            class="navbar-dropdown is-hidden-touch"
+            class="navbar-dropdown"
             :class="{
                 'is-right': right,
                 'is-boxed': boxed,
-            }"
-        >
-            <slot />
-        </div>
-        <div
-            v-show="!collapsible || (collapsible && newActive)"
-            class="navbar-dropdown is-hidden-desktop"
-            :class="{
-                'is-right': right,
-                'is-boxed': boxed,
+                'is-hidden-touch': collapsible && !newActive
             }"
         >
             <slot />

--- a/src/components/navbar/__snapshots__/NavbarDropdown.spec.js.snap
+++ b/src/components/navbar/__snapshots__/NavbarDropdown.spec.js.snap
@@ -2,7 +2,6 @@
 
 exports[`BNavbarDropdown render correctly 1`] = `
 <div class="navbar-item has-dropdown"><a aria-haspopup="true" tabindex="0" class="navbar-link"></a>
-  <div class="navbar-dropdown is-hidden-touch"></div>
-  <div class="navbar-dropdown is-hidden-desktop"></div>
+  <div class="navbar-dropdown"></div>
 </div>
 `;


### PR DESCRIPTION
Fixes
- fixes #3939

## Proposed Changes

- Merge two `<div>`s representing the same dropdown items in `BNavbarDropdown`: one `<div>` for desktop, and the other `<div>` for touch devices
- Refresh the snapshot of `BNavbarDropdown` spec