### PR TITLE
Fix: Tag with close in tag list produces unwanted offset (#3074)

### DIFF
--- a/src/components/tag/Tag.vue
+++ b/src/components/tag/Tag.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="attached && closable" class="tags has-addons">
+    <div v-if="attached && closable" class="tags has-addons inline-tags">
         <span
             class="tag"
             :class="[type, size, { 'is-rounded': rounded }]">

--- a/src/scss/components/_tag.scss
+++ b/src/scss/components/_tag.scss
@@ -25,3 +25,9 @@
         }
     }
 }
+
+.tags {
+    &.inline-tags {
+        margin-bottom: 0px;
+    }
+}

--- a/src/scss/components/_tag.scss
+++ b/src/scss/components/_tag.scss
@@ -29,5 +29,8 @@
 .tags {
     &.inline-tags {
         margin-bottom: 0px;
+        &:not(:last-child) {
+            @include ltr-property("margin", 0.5rem);
+        }
     }
 }


### PR DESCRIPTION
Fixes
- fixes #3074

## Proposed Changes

- Introduce a new class `inline-tags` for `BTag` with the attached close button to cancel the margin imposed on `.tags` by Bulma
- Introduce a margin after `.tags` with `inline-tags` so that a subsequent `BTag` does not stick to it