### PR TITLE
Fix publish GitHub Actions workflow

### DIFF
--- a/.github/workflows/npm_deploy.yml
+++ b/.github/workflows/npm_deploy.yml
@@ -10,11 +10,11 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Setup .npmrc file to publish to GitHub Packages
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
+          node-version: '18.x'
           registry-url: 'https://registry.npmjs.org/'
           scope: 'buefy'
       - run: npm ci

--- a/.github/workflows/npm_deploy.yml
+++ b/.github/workflows/npm_deploy.yml
@@ -18,6 +18,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org/'
           scope: 'buefy'
       - run: npm ci
+      - run: npm run build:lib
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Proposed Changes

- Run `npm run build:lib` before `npm publish`
- Bump the dependencies of `npm_deploy` workflow