### PR TITLE
fix: GitHub action build publish error and publish Buefy `v0.9.27`

### DIFF
--- a/.github/workflows/npm_deploy.yml
+++ b/.github/workflows/npm_deploy.yml
@@ -10,14 +10,15 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Setup .npmrc file to publish to GitHub Packages
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
+          node-version: '18.x'
           registry-url: 'https://registry.npmjs.org/'
           scope: 'buefy'
       - run: npm ci
+      - run: npm run build:lib
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "buefy",
-  "version": "0.9.26",
+  "version": "0.9.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "buefy",
-      "version": "0.9.26",
+      "version": "0.9.27",
       "license": "MIT",
       "dependencies": {
         "bulma": "0.9.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buefy",
-  "version": "0.9.26",
+  "version": "0.9.27",
   "homepage": "https://buefy.org",
   "description": "Lightweight UI components for Vue.js based on Bulma",
   "author": "Rafael Beraldo <rafael.pimpa@gmail.com>",


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #3957 


## Proposed Changes
- Bump version to `0.9.26`.
- Update the publish Github action packages that publish `Buefy`.
- Add build step to the publish Github action.
