### PR TITLE
Fix: Dropdown with "hover" trigger incorrectly rendered on mobile devices (#3961)

### DIFF
--- a/docs/pages/components/dropdown/Dropdown.vue
+++ b/docs/pages/components/dropdown/Dropdown.vue
@@ -2,8 +2,8 @@
     <div>
         <Example :component="ExSimple" :code="ExSimpleCode">
             <p>
-                It appears as a modal for tablets and smartphones, more precisely, when the screen is narrower than <code>$dropdown-mobile-breakpoint</code>.
-                However, Dropdowns with <code>"hover"</code> trigger won't change it's behavior to avoid any mulfunction with hover.
+                It appears as a modal for tablets and smartphones, more precisely when the screen is narrower than <code>$dropdown-mobile-breakpoint</code>.
+                However, dropdowns with <code>"hover"</code> trigger won't change its behavior to avoid any malfunction with hover.
                 <code>"hover"</code> trigger works like <code>"click"</code> trigger on touch devices where hover events do not make sense.
                 <code>"hover"</code> trigger precedes <code>"click"</code> trigger.
             </p>

--- a/docs/pages/components/dropdown/Dropdown.vue
+++ b/docs/pages/components/dropdown/Dropdown.vue
@@ -5,6 +5,10 @@
                 While it appear as a modal for tablet and smartphones,
                 Dropdowns with <code>hoverable</code> prop won't change it's behavior to avoid any malfunction with hover.
             </p>
+            <b-message type="is-info">
+                Hover is suppressed on a mobile screen that is narrower than <code>$dropdown-mobile-breakpoint</code>.
+                You can disable this behavior by setting <code>mobile-modal</code> to <code>false</code>.
+            </b-message>
         </Example>
 
         <Example :component="ExContentPosition" :code="ExContentPositionCode" title="Content and position" paddingless>

--- a/docs/pages/components/dropdown/Dropdown.vue
+++ b/docs/pages/components/dropdown/Dropdown.vue
@@ -2,13 +2,11 @@
     <div>
         <Example :component="ExSimple" :code="ExSimpleCode">
             <p>
-                While it appear as a modal for tablet and smartphones,
-                Dropdowns with <code>hoverable</code> prop won't change it's behavior to avoid any malfunction with hover.
+                It appears as a modal for tablets and smartphones, more precisely, when the screen is narrower than <code>$dropdown-mobile-breakpoint</code>.
+                However, Dropdowns with <code>"hover"</code> trigger won't change it's behavior to avoid any mulfunction with hover.
+                <code>"hover"</code> trigger works like <code>"click"</code> trigger on touch devices where hover events do not make sense.
+                <code>"hover"</code> trigger precedes <code>"click"</code> trigger.
             </p>
-            <b-message type="is-info">
-                Hover is suppressed on a mobile screen that is narrower than <code>$dropdown-mobile-breakpoint</code>.
-                You can disable this behavior by setting <code>mobile-modal</code> to <code>false</code>.
-            </b-message>
         </Example>
 
         <Example :component="ExContentPosition" :code="ExContentPositionCode" title="Content and position" paddingless>

--- a/docs/pages/components/dropdown/examples/ExSimple.vue
+++ b/docs/pages/components/dropdown/examples/ExSimple.vue
@@ -15,12 +15,12 @@
             <b-dropdown-item aria-role="listitem">Something else</b-dropdown-item>
         </b-dropdown>
 
-        <b-dropdown :triggers="['click', 'hover']" aria-role="list">
+        <b-dropdown :triggers="['hover']" aria-role="list">
             <template #trigger="{ active }">
                 <b-button
                     label="Hover me!"
                     type="is-info"
-                    :icon-right="active ? 'menu-up' : 'menu-down'" />
+                    icon-right="menu-down" />
             </template>
 
 

--- a/docs/pages/components/dropdown/examples/ExSimple.vue
+++ b/docs/pages/components/dropdown/examples/ExSimple.vue
@@ -15,12 +15,12 @@
             <b-dropdown-item aria-role="listitem">Something else</b-dropdown-item>
         </b-dropdown>
 
-        <b-dropdown :triggers="['hover']" aria-role="list">
-            <template #trigger>
+        <b-dropdown :triggers="['click', 'hover']" aria-role="list">
+            <template #trigger="{ active }">
                 <b-button
                     label="Hover me!"
                     type="is-info"
-                    icon-right="menu-down" />
+                    :icon-right="active ? 'menu-up' : 'menu-down'" />
             </template>
 
 

--- a/docs/pages/components/dropdown/examples/ExSimple.vue
+++ b/docs/pages/components/dropdown/examples/ExSimple.vue
@@ -16,7 +16,7 @@
         </b-dropdown>
 
         <b-dropdown :triggers="['hover']" aria-role="list">
-            <template #trigger="{ active }">
+            <template #trigger>
                 <b-button
                     label="Hover me!"
                     type="is-info"

--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -187,11 +187,22 @@ export default {
 
         /**
         * Emit event when isActive value is changed.
+        *
+        * Also resets `isTouchEnabled` when it turns inactive.
         */
         isActive(value) {
             this.$emit('active-change', value)
             if (!value) {
-                this.isTouchEnabled = false
+                // delays to reset the touch enabled flag until the dropdown
+                // menu disappears to avoid glitches
+                // also takes care of chattering, e.g., repeated quick taps,
+                // otherwise the flag may become inconsistent with the actual
+                // state of the dropdown menu
+                setTimeout(() => {
+                    if (!this.isActive) {
+                        this.isTouchEnabled = false
+                    }
+                }, 250)
             }
             this.handleScroll()
             if (this.appendToBody) {

--- a/src/scss/components/_dropdown.scss
+++ b/src/scss/components/_dropdown.scss
@@ -42,12 +42,10 @@ $dropdown-disabled-opacity: 0.5 !default;
             display: none;
         }
     }
-    @media (hover: hover) {
-        &.is-hoverable {
-            &:hover {
-                .dropdown-menu {
-                    display: inherit;
-                }
+    &.is-hoverable:not(.is-touch-enabled) {
+        &:hover {
+            .dropdown-menu {
+                display: inherit;
             }
         }
     }

--- a/src/scss/components/_dropdown.scss
+++ b/src/scss/components/_dropdown.scss
@@ -42,10 +42,12 @@ $dropdown-disabled-opacity: 0.5 !default;
             display: none;
         }
     }
-    &.is-hoverable {
-        &:hover {
-            .dropdown-menu {
-                display: inherit;
+    @media (hover: hover) {
+        &.is-hoverable {
+            &:hover {
+                .dropdown-menu {
+                    display: inherit;
+                }
             }
         }
     }
@@ -110,7 +112,9 @@ $dropdown-disabled-opacity: 0.5 !default;
         }
     }
     @media screen and (max-width: $dropdown-mobile-breakpoint - 1px) {
-        &.is-mobile-modal {
+        /* prevents modal on hover unless it is on touch devices */
+        &.is-mobile-modal:not(.is-hoverable),
+        &.is-mobile-modal.is-touch-enabled {
             > .dropdown-menu {
                 position: fixed !important;
                 width: calc(100vw - 40px);
@@ -127,19 +131,6 @@ $dropdown-disabled-opacity: 0.5 !default;
                 > .dropdown-content {
                     > .dropdown-item, > .has-link a {
                         padding: 1rem 1.5rem;
-                    }
-                }
-            }
-            /* cancels hoverable */
-            &.is-hoverable {
-                &:hover {
-                    .dropdown-menu {
-                        display: none;
-                    }
-                }
-                &.is-active {
-                    .dropdown-menu {
-                        display: block;
                     }
                 }
             }

--- a/src/scss/components/_dropdown.scss
+++ b/src/scss/components/_dropdown.scss
@@ -130,6 +130,19 @@ $dropdown-disabled-opacity: 0.5 !default;
                     }
                 }
             }
+            /* cancels hoverable */
+            &.is-hoverable {
+                &:hover {
+                    .dropdown-menu {
+                        display: none;
+                    }
+                }
+                &.is-active {
+                    .dropdown-menu {
+                        display: block;
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes
- fixes #3961

## Proposed Changes

- Change the behavior of "hover" trigger on touch devices. It works like "click" trigger when the screen is narrow on touch devices. "hover" trigger won't change the behavior on non-touch devices, e.g., PC, even if the screen is narrow.
- The documentation page of `BDropdown` explains the new behavior of "hover" trigger.