### PR TITLE
Chore: Add information on and the link to ntohq/buefy-next to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 </p>
 
 > Buefy is a lightweight library of responsive UI components for [Vue.js](https://vuejs.org/) based on [Bulma](http://bulma.io/) framework and design.
+> 
+> *Check out the official [`@ntohq/Buefy-next`](https://github.com/ntohq/buefy-next) fork in development for `Vue v3.0.0+` support.*
 
 ## Features
 
@@ -31,7 +33,7 @@ Browse [online documentation here](https://buefy.org/).
 
 ## Quick start
 
-You need [Vue.js](https://vuejs.org/) **version 2.6+**. (Vue 3 is [not supported](https://github.com/buefy/buefy/issues/2505#issuecomment-997000720))
+You need [Vue.js](https://vuejs.org/) **version 2.6+**. (Vue 3 is supported [here](https://github.com/ntohq/buefy-next))
 
 ### 1 Install via npm
 


### PR DESCRIPTION
Fixes #3965

## Proposed Changes
- Add information on and the link to [ntohq/buefy-next](https://github.com/ntohq/buefy-next) to `README.md`.
- Make a note in the `README.md` that Vue3 is supported [ntohq/buefy-next](https://github.com/ntohq/buefy-next).
