### PR TITLE
Feat(docs): add how to install @ntohq/buefy-next

### DIFF
--- a/docs/assets/scss/_home.scss
+++ b/docs/assets/scss/_home.scss
@@ -36,6 +36,7 @@
         font-size: 1.1em;
         color: lighten($primary, 20%);
         background: darken($primary, 20%);
+        max-width: 100%;
     }
     iframe {
         height: 30px;

--- a/docs/pages/Home.vue
+++ b/docs/pages/Home.vue
@@ -20,7 +20,7 @@
                             <strong>Vue 3</strong>
                             (<a href="https://github.com/ntohq/buefy-next" target="_blank">
                                 <b-icon icon="progress-wrench" size="is-small" />
-                                work in progress
+                                official fork in development
                                 <b-icon icon="github-circle" size="is-small" />
                             </a>)
                         </p>

--- a/docs/pages/Home.vue
+++ b/docs/pages/Home.vue
@@ -16,7 +16,14 @@
                         <pre class="npm home-hero"><code><span class="is-unselectable">$ </span>npm install buefy</code></pre>
                     </div>
                     <div>
-                        <p><strong>Vue 3</strong> (<b-icon icon="progress-wrench" size="is-small" /> work in progress)</p>
+                        <p>
+                            <strong>Vue 3</strong>
+                            (<a href="https://github.com/ntohq/buefy-next" target="_blank">
+                                <b-icon icon="progress-wrench" size="is-small" />
+                                work in progress
+                                <b-icon icon="github-circle" size="is-small" />
+                            </a>)
+                        </p>
                         <pre class="npm home-hero"><code><span class="is-unselectable">$ </span>npm install @ntohq/buefy-next</code></pre>
                     </div>
 

--- a/docs/pages/Home.vue
+++ b/docs/pages/Home.vue
@@ -11,7 +11,14 @@
                         <strong>Lightweight</strong> UI components for <strong><a href="https://vuejs.org/" target="_blank">Vue.js</a></strong>
                         based on <strong><a href="http://bulma.io/" target="_blank">Bulma</a></strong>
                     </h2>
-                    <pre class="npm home-hero"><code><span class="is-unselectable">$ </span>npm install buefy</code></pre>
+                    <div>
+                        <p><strong>Vue 2</strong></p>
+                        <pre class="npm home-hero"><code><span class="is-unselectable">$ </span>npm install buefy</code></pre>
+                    </div>
+                    <div>
+                        <p><strong>Vue 3</strong> (<b-icon icon="progress-wrench" size="is-small" /> work in progress)</p>
+                        <pre class="npm home-hero"><code><span class="is-unselectable">$ </span>npm install @ntohq/buefy-next</code></pre>
+                    </div>
 
                     <div class="github-button home-hero">
                         <iframe

--- a/docs/pages/Home.vue
+++ b/docs/pages/Home.vue
@@ -2,7 +2,7 @@
     <section class="home">
         <TheNavbar light/>
         <div class="hero is-fullheight is-primary">
-            <div class="hero-body">
+            <div class="hero-body is-block">
                 <div class="container has-text-centered">
                     <div class="logo-rounded home-hero">
                         <img src="../assets/buefy.png" alt="Buefy">
@@ -11,11 +11,11 @@
                         <strong>Lightweight</strong> UI components for <strong><a href="https://vuejs.org/" target="_blank">Vue.js</a></strong>
                         based on <strong><a href="http://bulma.io/" target="_blank">Bulma</a></strong>
                     </h2>
-                    <div>
+                    <div class="home-hero">
                         <p><strong>Vue 2</strong></p>
-                        <pre class="npm home-hero"><code><span class="is-unselectable">$ </span>npm install buefy</code></pre>
+                        <pre class="npm"><code><span class="is-unselectable">$ </span>npm install buefy</code></pre>
                     </div>
-                    <div>
+                    <div class="home-hero">
                         <p>
                             <strong>Vue 3</strong>
                             (<a href="https://github.com/ntohq/buefy-next" target="_blank">
@@ -24,7 +24,7 @@
                                 <b-icon icon="github-circle" size="is-small" />
                             </a>)
                         </p>
-                        <pre class="npm home-hero"><code><span class="is-unselectable">$ </span>npm install @ntohq/buefy-next</code></pre>
+                        <pre class="npm"><code><span class="is-unselectable">$ </span>npm install @ntohq/buefy-next</code></pre>
                     </div>
 
                     <div class="github-button home-hero">

--- a/docs/pages/installation/Start.vue
+++ b/docs/pages/installation/Start.vue
@@ -23,7 +23,7 @@
         <b-message type="is-warning" size="is-medium">
             For any installation and usage method, you need
             <strong><a href="https://vuejs.org" target="_blank">Vue.js</a> version 2.6+</strong>.
-            <strong><a href="https://github.com/buefy/buefy/issues/2505" target="_blank">Vue.js version 3+ is not supported at this time.</a></strong>
+            <strong><a href="https://github.com/ntohq/buefy-next/" target="_blank">Vue.js version 3+ is supported here (official fork in development).</a></strong>
         </b-message>
 
         <div class="media">


### PR DESCRIPTION
Fixes #
- fixes #3967

## Proposed Changes

- Show how to install `@ntohq/buefy-next` for people who need Vue 3 support on `Home`
- Add the link to `ntohq/buefy-next` repo to `Home` and `Start`