### PR TITLE
chore(docs): update table column docs for default slot

### DIFF
--- a/docs/pages/components/table/api/table.js
+++ b/docs/pages/components/table/api/table.js
@@ -818,7 +818,7 @@ export default [
             {
                 name: 'default',
                 description: '<strong>Required</strong>, table column body',
-                props: '<code>row: Object</code>, <code>column: Vue Object</code>, <code>index: Number</code>, <code>colindex: Number</code>'
+                props: '<code>row: Object</code>, <code>column: Vue Object</code>, <code>index: Number</code>, <code>colindex: Number</code>, <code>toggleDetails: Function</code>, <code>isActiveDetailRow: Boolean</code>'
             },
             {
                 name: '<code>header</code>',

--- a/docs/pages/components/table/api/table.js
+++ b/docs/pages/components/table/api/table.js
@@ -818,7 +818,7 @@ export default [
             {
                 name: 'default',
                 description: '<strong>Required</strong>, table column body',
-                props: '<code>row: Object</code>, <code>column: Vue Object</code>, <code>index: Number</code>, <code>colindex: Number</code>, <code>toggleDetails: Function</code>, <code>isActiveDetailRow: Boolean</code>'
+                props: '<code>row: Object</code>, <code>column: Vue Object</code>, <code>index: Number</code>, <code>colindex: Number</code>, <code>toggleDetails: Function</code>, <code>isActiveDetailRow: Function</code>'
             },
             {
                 name: '<code>header</code>',


### PR DESCRIPTION
Corresponding to the comment:
- https://github.com/buefy/buefy/pull/3862#pullrequestreview-1820605175

## Proposed Changes

- Add `toggleDetails` and `isActiveDetailRow` to the docs of the default scoped slot of `TableColumn`