### PR TITLE
Clear event listeners and timers before component unmounts

### DIFF
--- a/docs/components/TheNavbar.vue
+++ b/docs/components/TheNavbar.vue
@@ -133,6 +133,10 @@ export default {
     },
     mounted() {
         this.$eventHub.$on('navigate', this.closeMenu)
+    },
+
+    beforeDestroy() {
+        this.$eventHub.$off('navigate', this.closeMenu)
     }
 }
 </script>

--- a/docs/templates/Documentation.vue
+++ b/docs/templates/Documentation.vue
@@ -62,6 +62,10 @@ export default {
         if (this.$route.hash) {
             this.$nextTick(() => this.scrollTo(this.$route.hash))
         }
+    },
+
+    beforeDestroy() {
+        this.$eventHub.$off('navigate', this.setMeta)
     }
 }
 </script>

--- a/src/components/numberinput/Numberinput.vue
+++ b/src/components/numberinput/Numberinput.vue
@@ -312,6 +312,10 @@ export default {
             clearTimeout(this._$intervalRef)
             this._$intervalRef = null
         }
+    },
+
+    beforeDestroy() {
+        clearTimeout(this._$intervalRef)
     }
 }
 </script>

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -295,6 +295,7 @@ export default {
         if (this.isFixed) {
             removeElement(this.$el)
         }
+        clearTimeout(this.timer)
     }
 }
 </script>

--- a/src/components/slider/SliderThumb.vue
+++ b/src/components/slider/SliderThumb.vue
@@ -222,6 +222,14 @@ export default {
                 this.oldValue = value
             }
         }
+    },
+
+    beforeDestroy() {
+        document.removeEventListener('mousemove', this.onDragging)
+        document.removeEventListener('touchmove', this.onDragging)
+        document.removeEventListener('mouseup', this.onDragEnd)
+        document.removeEventListener('touchend', this.onDragEnd)
+        document.removeEventListener('contextmenu', this.onDragEnd)
     }
 }
 </script>


### PR DESCRIPTION
Hi 👋 , thank you for this library!

We found that some components used event listeners and timing events, but did not remove them before unmounting. This means an accumulation of listeners and timers each time a component is mounted, on top of the previous ones, leading to a memory leak. This PR fixes this issue :) 

