### PR TITLE
Fix: Tooltip - AbortController is not defined in SSR mode (Nuxt) (#4017)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Buefy Changelog
 
+## 0.9.29 Unreleased
+
+### Fixes
+
+* Fix [#4017](https://github.com/buefy/buefy/issues/4017) `Tooltip` - AbortController is not defined in SSR mode (Nuxt)
+
 ## 0.9.28
 
 ### New features

--- a/src/components/tooltip/Tooltip.vue
+++ b/src/components/tooltip/Tooltip.vue
@@ -285,8 +285,8 @@ export default {
         }
     },
     mounted() {
-        this.controller = new window.AbortController()
         if (this.appendToBody && typeof window !== 'undefined') {
+            this.controller = new window.AbortController()
             this.$data._bodyEl = createAbsoluteElement(this.$refs.content)
             this.updateAppendToBody()
             // updates the tooltip position if the tooltip is inside
@@ -331,7 +331,9 @@ export default {
         if (this.appendToBody) {
             removeElement(this.$data._bodyEl)
         }
-        this.controller.abort()
+        if (this.controller != null) {
+            this.controller.abort()
+        }
         clearTimeout(this.timer)
         clearTimeout(this.timeOutID)
     }


### PR DESCRIPTION
Fixes
- fixes #4017 

## Proposed Changes

- In `Tooltip`, move `window.AbortController` access inside the `window` availability check
- Prepare for `controller` possibly `null`