### PR TITLE
Fix: Browser tab freezes, unresponsive, plus possible memory leak with form in modal (#4018)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 * Fix [#4017](https://github.com/buefy/buefy/issues/4017) `Tooltip` - AbortController is not defined in SSR mode (Nuxt)
+* Fix [#4018](https://github.com/buefy/buefy/issues/4018) Browser tab froze when `Field` with both `grouped` and `horizontal` props `true` got a validation error. `grouped` and `horizontal` should not be mixed, anyway.
 
 ## 0.9.28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 * Fix [#4017](https://github.com/buefy/buefy/issues/4017) `Tooltip` - AbortController is not defined in SSR mode (Nuxt)
-* Fix [#4018](https://github.com/buefy/buefy/issues/4018) Browser tab froze when `Field` with both `grouped` and `horizontal` props `true` got a validation error. `grouped` and `horizontal` should not be mixed, anyway.
+* Fix [#4018](https://github.com/buefy/buefy/issues/4018) Browser tab froze when `Field` with both `grouped` and `horizontal` props `true` got a validation error. However, there is another issue that validation errors cannot be reset once they are set if `grouped` and `horizontal` are combined.
 
 ## 0.9.28
 

--- a/docs/pages/components/field/api/field.js
+++ b/docs/pages/components/field/api/field.js
@@ -41,7 +41,7 @@ export default [
             },
             {
                 name: '<code>grouped</code>',
-                description: 'Direct child components/elements of Field will be grouped horizontally (see which ones at the top of the page)',
+                description: 'Direct child components/elements of Field will be grouped horizontally (see which ones at the top of the page). Do not mix with <code>horizontal</code>.',
                 type: 'Boolean',
                 values: '—',
                 default: '<code>false</code>'
@@ -69,7 +69,7 @@ export default [
             },
             {
                 name: '<code>horizontal</code>',
-                description: 'Group label and control on the same line for horizontal forms',
+                description: 'Group label and control on the same line for horizontal forms. Do not mix with <code>grouped</code>.',
                 type: 'Boolean',
                 values: '—',
                 default: '<code>false</code>'

--- a/docs/pages/components/field/api/field.js
+++ b/docs/pages/components/field/api/field.js
@@ -41,7 +41,7 @@ export default [
             },
             {
                 name: '<code>grouped</code>',
-                description: 'Direct child components/elements of Field will be grouped horizontally (see which ones at the top of the page). Do not mix with <code>horizontal</code>.',
+                description: 'Direct child components/elements of Field will be grouped horizontally (see which ones at the top of the page). Do not mix with <code>horizontal</code> because there is an issue that the validation error cannot be reset once it is set if combined with <code>horizontal</code>.',
                 type: 'Boolean',
                 values: '—',
                 default: '<code>false</code>'
@@ -69,7 +69,7 @@ export default [
             },
             {
                 name: '<code>horizontal</code>',
-                description: 'Group label and control on the same line for horizontal forms. Do not mix with <code>grouped</code>.',
+                description: 'Group label and control on the same line for horizontal forms. Do not mix with <code>grouped</code> because there is an issue that the validation error cannot be reset once it is set if combined with <code>grouped</code>.',
                 type: 'Boolean',
                 values: '—',
                 default: '<code>false</code>'

--- a/src/components/field/Field.spec.js
+++ b/src/components/field/Field.spec.js
@@ -247,4 +247,53 @@ describe('BField', () => {
             expect(helpWrapper.text()).toEqual(message)
         })
     })
+
+    describe('with grouped and horizontal true', () => {
+        let wrapper
+
+        beforeEach(() => {
+            wrapper = mount(BField, {
+                localVue,
+                propsData: {
+                    grouped: true,
+                    horizontal: true
+                },
+                slots: {
+                    default: [BInput, BInput]
+                }
+            })
+        })
+
+        it('should wrap each child in a field under a field-body', () => {
+            const body = wrapper.find(BFieldBody)
+            expect(body.exists()).toBe(true)
+            const childFields = body.findAll(BField)
+            expect(childFields.length).toBe(2)
+            expect(childFields.at(0).find(BInput).exists()).toBe(true)
+            expect(childFields.at(1).find(BInput).exists()).toBe(true)
+        })
+
+        describe('when validation fails', () => {
+            let childFields
+
+            beforeEach(async () => {
+                await wrapper.setData({
+                    newType: 'is-danger',
+                    newMessage: 'error message'
+                })
+                const body = wrapper.find(BFieldBody)
+                childFields = body.findAll(BField)
+            })
+
+            it('should set message only to the first child field', () => {
+                expect(childFields.at(0).props('message')).toEqual(['error message'])
+                expect(childFields.at(1).props('message')).toBeUndefined()
+            })
+
+            it('should set type to all the child fields', () => {
+                expect(childFields.at(0).props('type')).toBe('is-danger')
+                expect(childFields.at(1).props('type')).toBe('is-danger')
+            })
+        })
+    })
 })

--- a/src/components/field/Field.vue
+++ b/src/components/field/Field.vue
@@ -222,7 +222,14 @@ export default {
         * Set internal message when prop change.
         */
         message(value) {
-            this.newMessage = value
+            // we deep comparison here becase an innner Field of another Field
+            // receives the message as a brand new array every time, so simple
+            // identity check won't work and will end up with infinite
+            // recursions
+            // https://github.com/buefy/buefy/issues/4018#issuecomment-1985026234
+            if (JSON.stringify(value) !== JSON.stringify(this.newMessage)) {
+                this.newMessage = value
+            }
         },
 
         /**


### PR DESCRIPTION
Fixes #
- fixes #4018

## Proposed Changes

- `Field` makes sure that the contents of a new value for `newMessage` are different from the current `newMessage` before updating it to avoid infinite recursions that made a browser tab freeze
- Add warnings of not mixing `grouped` and `horizontal` props of `Field` to the documentation

## Remarks

Since `Field` was not designed to turn on `grouped` and `horizontal` props simultaneously, another issue will emerge after merging this PR, where once a validation error state is set, the error state won't be reset even after correcting the input. A workaround for now is not to mix `grouped` and `horizontal`. This PR will mitigate the worst scenario anyway.