### PR TITLE
chore(docs): alias @ntohq/buefy-next → buefy

### DIFF
--- a/docs/pages/Home.vue
+++ b/docs/pages/Home.vue
@@ -24,7 +24,7 @@
                                 <b-icon icon="github-circle" size="is-small" />
                             </a>)
                         </p>
-                        <pre class="npm"><code><span class="is-unselectable">$ </span>npm install @ntohq/buefy-next</code></pre>
+                        <pre class="npm"><code><span class="is-unselectable">$ </span>npm install buefy@npm:@ntohq/buefy-next</code></pre>
                     </div>
 
                     <div class="github-button home-hero">


### PR DESCRIPTION
## Proposed Changes

- The installation instruction for Buefy for Vue 3 (buefy-next) on the documentation aliases `@ntohq/buefy-next` → `buefy`. Inspired by the reddit post: <https://www.reddit.com/r/vuejs/comments/wg1b0u/comment/kttd5sa/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button>