### PR TITLE
Replaced unpkg by jsdelivr in start page

### DIFF
--- a/docs/pages/installation/Start.vue
+++ b/docs/pages/installation/Start.vue
@@ -74,8 +74,8 @@
                 <div class="content">
                     <p>Just download or use these as CDN:</p>
                     <ul>
-                        <li>Script: <a href="https://unpkg.com/buefy/dist/buefy.min.js" target="_blank">https://unpkg.com/buefy/dist/buefy.min.js</a></li>
-                        <li>Style: <a href="https://unpkg.com/buefy/dist/buefy.min.css" target="_blank">https://unpkg.com/buefy/dist/buefy.min.css</a></li>
+                        <li>Script: <a href="https://cdn.jsdelivr.net/npm/buefy/dist/buefy.min.js" target="_blank">https://cdn.jsdelivr.net/npm/buefy/dist/buefy.min.js</a></li>
+                        <li>Style: <a href="https://cdn.jsdelivr.net/npm/buefy/dist/buefy.min.css" target="_blank">https://cdn.jsdelivr.net/npm/buefy/dist/buefy.min.css</a></li>
                     </ul>
                 </div>
 
@@ -159,7 +159,7 @@
                 <head>
                     <meta charset="utf-8">
                     <meta name="viewport" content="width=device-width, initial-scale=1">
-                    <link rel="stylesheet" href="https://unpkg.com/buefy/dist/buefy.min.css">
+                    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/buefy/dist/buefy.min.css">
                 </head>
 
                 <body>
@@ -167,9 +167,9 @@
                         <!-- Buefy components goes here -->
                     </div>
 
-                    <script src="https://unpkg.com/vue@2"></\script>
+                    <script src="https://cdn.jsdelivr.net/npm/vue@2"></\script>
                     <!-- Full bundle -->
-                    <script src="https://unpkg.com/buefy/dist/buefy.min.js"></\script>
+                    <script src="https://cdn.jsdelivr.net/npm/buefy/dist/buefy.min.js"></\script>
 
                     <!-- Individual components -->
                     <script src="https://unpkg.com/buefy/dist/components/table"></\script>


### PR DESCRIPTION
Unpkg is not reliable for a production project. This change ensures newcomers opting for standalone will start on a more reliable base. See discussion https://github.com/buefy/buefy/discussions/4033

<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Only documentation changes, standalone sample
- replaced the vuejs source
- replaced the buefy sources (js and css)
- the individual components sources were left unchanged, I couldn't find them on jsdelivr.net
