### PR TITLE
TOAST: change type declaration and update doc

### DIFF
--- a/docs/pages/components/toast/Toast.vue
+++ b/docs/pages/components/toast/Toast.vue
@@ -33,7 +33,7 @@
                 ExSimpleCode,
                 outsideVueInstance: `
                 import { ToastProgrammatic as Toast } from 'buefy'
-                Toast.open('Toasty!')`
+                new Toast().open('Toasty!')`
             }
         }
     }

--- a/types/components.d.ts
+++ b/types/components.d.ts
@@ -387,8 +387,8 @@ export declare const SnackbarProgrammatic: {
 }
 
 
-export declare const ToastProgrammatic: {
-    open: (params: BNoticeConfig | string) => BNoticeComponent;
+export declare class ToastProgrammatic {
+    open: (params: BNoticeConfig | string) => BNoticeComponent
 }
 
 export declare type BNotificationConfig = BNoticeConfig & {


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Working with Toast component and using it outside the component noticed that trying to invoke it as stated in docs results in a `TypeError: Toast.open is not a function`

Reproduction: https://codesandbox.io/p/live/1d49f415-fba6-4a78-93da-316fc1c22f49

## Proposed Changes

- change type declaration of toast to class
- change information in documentation
