### PR TITLE
Add autocomplete missing property in documentation

### DIFF
--- a/docs/pages/components/autocomplete/api/autocomplete.js
+++ b/docs/pages/components/autocomplete/api/autocomplete.js
@@ -177,6 +177,13 @@ export default [
                 default: '<code>false</code>'
             },
             {
+                name: '<code>keep-open</code>',
+                description: 'Keeps the list of options open after a selection',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>true</code>'
+            },
+            {
                 name: 'Any native attribute',
                 description: '—',
                 type: '—',


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #
Add `keep-open` property to autocomplete documentation

