### PR TITLE
Add conditional rendering to Collapse component

### DIFF
--- a/docs/pages/components/collapse/Collapse.vue
+++ b/docs/pages/components/collapse/Collapse.vue
@@ -9,6 +9,8 @@
         <Example :component="ExPosition" :code="ExPositionCode" title="Position" vertical/>
 
         <Example :component="ExAccordion" :code="ExAccordionCode" title="Accordion Effect" vertical/>
+        
+        <Example :component="ExConditionalRendering" :code="ExConditionalRenderingCode" title="Conditional Rendering" vertical/>
 
         <ApiView :data="api"/>
     </div>
@@ -19,6 +21,9 @@
 
     import ExSimple from './examples/ExSimple'
     import ExSimpleCode from '!!raw-loader!./examples/ExSimple'
+
+    import ExConditionalRendering from './examples/ExConditionalRendering'
+    import ExConditionalRenderingCode from '!!raw-loader!./examples/ExConditionalRendering'
 
     import ExPanelTemplate from './examples/ExPanelTemplate'
     import ExPanelTemplateCode from '!!raw-loader!./examples/ExPanelTemplate'
@@ -40,6 +45,8 @@
                 ExSimpleCode,
                 ExPanelTemplate,
                 ExPanelTemplateCode,
+                ExConditionalRendering,
+                ExConditionalRenderingCode,
                 ExCardTemplate,
                 ExCardTemplateCode,
                 ExPosition,

--- a/docs/pages/components/collapse/examples/ExConditionalRendering.vue
+++ b/docs/pages/components/collapse/examples/ExConditionalRendering.vue
@@ -1,0 +1,57 @@
+<template>
+    <section>
+
+        <ul>
+            <li v-for="(image, index) in images" :key="index">
+                <b-collapse :open="false" class="card" animation="slide" aria-id="contentIdForA11y3">
+                    <template #trigger="props">
+                        <div
+                            class="card-header"
+                            role="button"
+                            aria-controls="contentIdForA11y3"
+                            :aria-expanded="props.open">
+                            <p class="card-header-title">
+                                Image {{ index + 1 }}
+                            </p>
+                            <a class="card-header-icon">
+                                <b-icon
+                                    :icon="props.open ? 'menu-down' : 'menu-up'">
+                                </b-icon>
+                            </a>
+                        </div>
+                    </template>
+    
+                    <template #content="props">
+                        <div class="card-content">
+                            <div>
+                                <p>This content is always rendered, regardless of the collapse state.</p>
+                            </div>
+                            <div v-if="props.open">
+                                <hr />
+                                <p>This content is only rendered when the collapse is open.</p>
+                                <hr />
+                                <p>A network request to load this image will now only be made after the collapse is opened for the first time.</p>
+                                <img :src="image" />
+                            </div>
+                        </div>
+                    </template>
+                </b-collapse>
+            </li>
+        </ul>
+
+    </section>
+</template>
+
+<script>
+    export default {
+        data: () => ({
+            images: [
+                'https://placehold.co/600x400?text=Image%201',
+                'https://placehold.co/600x400?text=Image%202',
+                'https://placehold.co/600x400?text=Image%203',
+                'https://placehold.co/600x400?text=Image%204',
+                'https://placehold.co/600x400?text=Image%205'
+            ]
+        })
+    }
+</script>

--- a/src/components/collapse/Collapse.spec.js
+++ b/src/components/collapse/Collapse.spec.js
@@ -24,6 +24,22 @@ describe('BCollapse', () => {
             expect(wrapper.html()).toMatchSnapshot()
         })
     })
+    describe('open prop is true', () => {
+        it('should render default slot contents', async () => {
+            const slotDefault = '<div>Content</div>'
+            wrapper = shallowMount(BCollapse, {
+                propsData: {
+                    open: true
+                },
+                slots: {
+                    default: slotDefault
+                }
+            })
+            await wrapper.vm.$nextTick()
+            expect(wrapper.find('.collapse-content div').exists()).toBe(true)
+            expect(wrapper.find('.collapse-content div').html()).toContain(slotDefault)
+        })
+    })
     describe('open prop is false', () => {
         beforeEach(() => {
             wrapper = shallowMount(BCollapse, {
@@ -70,6 +86,21 @@ describe('BCollapse', () => {
             wrapper.setProps({ open: true })
             expect(wrapper.vm.isOpen).toBe(true)
             expect(wrapper.find('.collapse-content').isVisible()).toBe(true)
+        })
+
+        it('should render default slot contents', async () => {
+            const slotDefault = '<div>Content</div>'
+            wrapper = shallowMount(BCollapse, {
+                propsData: {
+                    open: false
+                },
+                slots: {
+                    default: slotDefault
+                }
+            })
+            await wrapper.vm.$nextTick() // Wait for the DOM to update
+            expect(wrapper.find('.collapse-content div').exists()).toBe(true)
+            expect(wrapper.find('.collapse-content div').html()).toContain(slotDefault)
         })
     })
 

--- a/src/components/collapse/Collapse.spec.js
+++ b/src/components/collapse/Collapse.spec.js
@@ -39,6 +39,27 @@ describe('BCollapse', () => {
             expect(wrapper.find('.collapse-content div').exists()).toBe(true)
             expect(wrapper.find('.collapse-content div').html()).toContain(slotDefault)
         })
+
+        it('should render content slot contents', async () => {
+            wrapper = shallowMount(BCollapse, {
+                propsData: {
+                    open: true
+                },
+                scopedSlots: {
+                    content: `
+                        <div>
+                            <img 
+                                v-if="props.open"
+                                src="https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png"
+                            />
+                        </div>
+                    `
+                }
+            })
+            await wrapper.vm.$nextTick()
+            expect(wrapper.find('.collapse-content div').exists()).toBe(true)
+            expect(wrapper.find('.collapse-content div img').exists()).toBe(true)
+        })
     })
     describe('open prop is false', () => {
         beforeEach(() => {
@@ -101,6 +122,27 @@ describe('BCollapse', () => {
             await wrapper.vm.$nextTick() // Wait for the DOM to update
             expect(wrapper.find('.collapse-content div').exists()).toBe(true)
             expect(wrapper.find('.collapse-content div').html()).toContain(slotDefault)
+        })
+
+        it('should not render content slot contents', async () => {
+            wrapper = shallowMount(BCollapse, {
+                propsData: {
+                    open: false
+                },
+                scopedSlots: {
+                    content: `
+                        <div>
+                            <img 
+                                v-if="props.open"
+                                src="https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png"
+                            />
+                        </div>
+                    `
+                }
+            })
+            await wrapper.vm.$nextTick()
+            expect(wrapper.find('.collapse-content div').exists()).toBe(true)
+            expect(wrapper.find('.collapse-content div img').exists()).toBe(false)
         })
     })
 

--- a/src/components/collapse/Collapse.vue
+++ b/src/components/collapse/Collapse.vue
@@ -65,7 +65,10 @@ export default {
                     name: 'show',
                     value: this.isOpen
                 }]
-            }, this.$slots.default)
+            }, this.$scopedSlots.content
+                ? [this.$scopedSlots.content({ open: this.isOpen })]
+                : [this.$slots.default]
+            )
         ])
         return createElement('div', { staticClass: 'collapse' },
             this.position === 'is-top' ? [trigger, content] : [content, trigger])


### PR DESCRIPTION
## Proposed Changes

This pull request adds the ability to use a named `content` slot in the `BCollapse` component. This feature provides developers with the flexibility to delay rendering of the collapsible content until the `BCollapse` is open, which can improve performance when the content is complex or data-heavy (such as loading one or more images in every collapsible component in a list, or a complex iteration template that can cause performance degradation).

## Impact
No breaking changes to existing usage. Developers can opt-in to the feature by using the `content` slot instead of the default slot for deferred content rendering.  

## Testing
- Added unit tests for new slot behavior in `BCollapse.spec.js`.
- Ensured all existing tests pass with no regressions.