### PR TITLE
Fix: correct defaultDatepickerYearsRange value in docs

### DIFF
--- a/docs/pages/components/datepicker/api/datepicker.js
+++ b/docs/pages/components/datepicker/api/datepicker.js
@@ -224,7 +224,7 @@ export default [
                 description: 'Years range relative to selected year',
                 type: 'Array',
                 values: '-',
-                default: '<code>[-100, 3]</code>'
+                default: '<code>[-100, 10]</code>'
             },
             {
                 name: '<code>nearby-month-days</code>',

--- a/docs/pages/installation/api/constructor-options.js
+++ b/docs/pages/installation/api/constructor-options.js
@@ -274,7 +274,7 @@ export default [
                 description: 'Default years range relative to selected year',
                 type: 'Array',
                 values: '—',
-                default: '<code>[-100, 3]</code>'
+                default: '<code>[-100, 10]</code>'
             },
             {
                 name: '<code>defaultDatepickerNearbyMonthDays</code>',


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Fixed docs due to `defaultDatepickerYearsRange` value changed in https://github.com/buefy/buefy/commit/349189b32f3d34ae06c7eb47eb65f25cfa53ca57

