### PR TITLE
Add function to table component for conditionally rendering checkboxes when table is checkable.

### DIFF
--- a/docs/pages/components/table/api/table.js
+++ b/docs/pages/components/table/api/table.js
@@ -342,6 +342,13 @@ export default [
                 default: 'true'
             },
             {
+                name: '<code>is-row-checkbox-visible</code>',
+                description: 'Custom method to verify if a row\'s checkbox is visible, works when is <code>checkable</code>. ',
+                type: 'Function (row: Object)',
+                values: '—',
+                default: 'true'
+            },
+            {
                 name: '<code>is-row-selectable</code>',
                 description: 'Custom method to verify if a row is selectable, works when is <code>selected</code>. ',
                 type: 'Function (row: Object)',

--- a/docs/pages/components/table/examples/ExCheckable.vue
+++ b/docs/pages/components/table/examples/ExCheckable.vue
@@ -29,6 +29,7 @@
                     :columns="columns"
                     :checked-rows.sync="checkedRows"
                     :is-row-checkable="(row) => row.id !== 3 && row.id !== 4"
+                    :is-row-checkbox-visible="(row) => row.id < 5"
                     checkable
                     :checkbox-position="checkboxPosition"
                     :checkbox-type="checkboxType">

--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -281,6 +281,7 @@
                                 :class="['checkbox-cell', { 'is-sticky': stickyCheckbox } ]"
                                 v-if="checkable && checkboxPosition === 'left'">
                                 <b-checkbox
+                                    v-if="isRowCheckboxVisible(row)"
                                     autocomplete="off"
                                     :value="isRowChecked(row)"
                                     :type="checkboxType"
@@ -495,6 +496,10 @@ export default {
         focusable: Boolean,
         customIsChecked: Function,
         isRowCheckable: {
+            type: Function,
+            default: () => true
+        },
+        isRowCheckboxVisible: {
             type: Function,
             default: () => true
         },


### PR DESCRIPTION
## Intention

There are some use cases where presenting a disabled checkbox in a `checked` table doesn't make sense from a UX perspective. For example, some rows may never be able to be checked, so displaying a disabled checkbox sends the wrong message to the user.

## Proposed Changes

- Add new function to the table component called `is-row-checkbox-visible` that allows you to conditionally render checkboxes for rows when the table is `checkable`. 
- Update table API documentation.
- Update checkable table example code (`ExCheckable.vue`).

## Impact

No breaking changes to existing usage. The function defaults to `true` in order to preserve existing functionality. 

## Screenshots

Screenshot 1: Checkable Table Example.
![image](https://github.com/user-attachments/assets/6a6cf8c5-6d62-4cc9-a4d1-cfa1f270b5c8)

Screenshot 2: Checkable Table Example Code.
![image](https://github.com/user-attachments/assets/b7544462-1c6f-455b-b4d6-eb64e794ac08)

Screenshot 3: Table API documentation changes.
![image](https://github.com/user-attachments/assets/5ce446cb-5236-4e5a-831e-66d2fa2e46f7)
