### PR TITLE
auto -> is-auto for more consistency + docs

### DIFF
--- a/packages/docs/src/pages/components/tooltip/api/tooltip.ts
+++ b/packages/docs/src/pages/components/tooltip/api/tooltip.ts
@@ -41,10 +41,10 @@ export default [
             },
             {
                 name: '<code>position</code>',
-                description: 'Tooltip position in relation to the element',
+                description: 'Tooltip position in relation to the element. By default, it places itself away from the nearest window border.',
                 type: 'String',
-                values: '<code>is-top</code>, <code>is-bottom</code>, <code>is-left</code>, <code>is-right</code>',
-                default: '<code>is-top</code>'
+                values: '<code>is-auto</code>, <code>is-top</code>, <code>is-bottom</code>, <code>is-left</code>, <code>is-right</code>',
+                default: '<code>is-auto</code>'
             },
             {
                 name: '<code>always</code>',

--- a/packages/docs/src/pages/components/tooltip/examples/ExSimple.vue
+++ b/packages/docs/src/pages/components/tooltip/examples/ExSimple.vue
@@ -1,11 +1,15 @@
 <template>
     <section class="b-tooltips">
+        <b-tooltip label="Tooltip auto">
+            <b-button label="Auto positioning (default)" type="is-dark" />
+        </b-tooltip>
+
         <b-tooltip label="Tooltip right" position="is-right">
             <b-button label="Right" type="is-dark" />
         </b-tooltip>
 
-        <b-tooltip label="Tooltip top">
-            <b-button label="Top (default)" type="is-dark" />
+        <b-tooltip label="Tooltip top" position="is-top">
+            <b-button label="Top" type="is-dark" />
         </b-tooltip>
 
         <b-tooltip label="Tooltip bottom" position="is-bottom">


### PR DESCRIPTION
With fixed tooltip positioning, tooltips are often partially hidden when scrolling near a window border. This small PR adds an auo-positioning (and sets it as default) to place the tooltip way from the nearest border.