### PR TITLE
Bump Version to v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Buefy Changelog
 
-## [1.0.0](https://github.com/buefy/buefy/pull/4077) unreleased
+## [1.0.1](https://github.com/buefy/buefy/pull/4077)
 
 ### Breaking changes
 
@@ -19,9 +19,16 @@
 * Clarified developer release installation instructions and naming conventions in the README.
 
 ### Others
-* Version bump: package.json version set to 1.0.0.
+* Version bump: package.json version set to 1.0.1.
 * jsconfig updated to reference new source directory.
 * Large updates to package-lock.json and workflow YAML files to match new structure.
+
+
+## [1.0.0](https://www.npmjs.com/package/buefy/v/1.0.0) depricated
+This version was published more than 8 years before the intended release of Buefy 1.0 and does **not** represent the official, stable `v1`. It was released prematurely and lacks the features, structure, and design decisions that define the true `Buefy v1.0.0`
+
+Please upgrade to `v1.0.1` or newer to access the latest architecture, complete documentation, and active support.
+
 
 ## Buefy-next 0.2.1 unreleased
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "root",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "homepage": "https://buefy.org",
   "description": "Lightweight UI components for Vue.js (v3) based on Bulma",
   "license": "MIT",

--- a/packages/buefy/package.json
+++ b/packages/buefy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buefy",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Lightweight UI components for Vue.js (v3) based on Bulma",
   "keywords": [
     "vuejs",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "author": "Rafael Beraldo <rafael.pimpa@gmail.com>",
   "maintainers": [


### PR DESCRIPTION
### What's Changed

- 🔖 Bumped version from `v1.0.0` to `v1.0.1` to mark the first *official* stable release of Buefy.
  - The previous `v1.0.0` was published over 8 years ago and did not reflect the current codebase or roadmap.
  - This new version establishes a modern baseline for 1.x going forward, with proper configuration, documentation, and active maintenance.