### PR TITLE
Added ref to clockpicker face in the Clockpicker Component

### DIFF
--- a/packages/buefy/src/components/clockpicker/Clockpicker.vue
+++ b/packages/buefy/src/components/clockpicker/Clockpicker.vue
@@ -121,6 +121,7 @@
                             </div>
                         </div>
                         <b-clockpicker-face
+                            ref="clockpickerFace"
                             :picker-size="faceSize"
                             :min="minFaceValue"
                             :max="maxFaceValue"


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->


## Proposed Changes

This change makes it possible to access the clockpickerface and use its variables such as isDragging.

This is useful when closing and switching current values through the dragging info of the clockpicker face.
