### PR TITLE
fixed #4188 : clockpicker not closing and removed "autoSwitch"

### DIFF
--- a/packages/buefy/src/components/clockpicker/Clockpicker.vue
+++ b/packages/buefy/src/components/clockpicker/Clockpicker.vue
@@ -276,9 +276,19 @@ export default defineComponent({
                 this.isSelectingHour = !this.isSelectingHour
             } else {
                 // Minutes selected, let's close the clockpicker
+                this.toggle(false)
+            }
+        },
+        /*
+         * Toggle clockpicker
+         */
+        toggle(active: boolean) {
+            if (this.$refs.dropdown) {
                 const dropdown = this.$refs.dropdown as BDropdownInstance
-                if (dropdown && dropdown.isActive) {
-                    dropdown.toggle()
+                dropdown.isActive = active ?? !dropdown.isActive
+                if (dropdown.isActive) {
+                    // When opening the clockpicker, we always select the hour first
+                    this.isSelectingHour = true
                 }
             }
         },

--- a/packages/buefy/src/components/clockpicker/Clockpicker.vue
+++ b/packages/buefy/src/components/clockpicker/Clockpicker.vue
@@ -202,10 +202,6 @@ export default defineComponent({
             type: Number,
             default: 5
         },
-        autoSwitch: {
-            type: Boolean,
-            default: true
-        },
         type: {
             type: String,
             default: 'is-primary'
@@ -276,8 +272,13 @@ export default defineComponent({
             }
         },
         onClockChange() {
-            if (this.autoSwitch && this.isSelectingHour) {
+            if (this.isSelectingHour) {
                 this.isSelectingHour = !this.isSelectingHour
+            } else {
+                const dropdown = this.$refs.dropdown as BDropdownInstance
+                if (dropdown && dropdown.isActive) {
+                    dropdown.toggle(false)
+                }
             }
         },
         onMeridienClick(value: string) {

--- a/packages/buefy/src/components/clockpicker/Clockpicker.vue
+++ b/packages/buefy/src/components/clockpicker/Clockpicker.vue
@@ -275,9 +275,10 @@ export default defineComponent({
             if (this.isSelectingHour) {
                 this.isSelectingHour = !this.isSelectingHour
             } else {
+                // Minutes selected, let's close the clockpicker
                 const dropdown = this.$refs.dropdown as BDropdownInstance
                 if (dropdown && dropdown.isActive) {
-                    dropdown.toggle(false)
+                    dropdown.toggle()
                 }
             }
         },


### PR DESCRIPTION
The "autoSwitch" option was never documented and of doubtful usefulness.

