### PR TITLE
Fix: Restore Autocomplete Arrow Key Hover Styles

### DIFF
--- a/packages/buefy/src/scss/components/_autocomplete.scss
+++ b/packages/buefy/src/scss/components/_autocomplete.scss
@@ -1,6 +1,12 @@
 @use "bulma/sass/utilities/css-variables" as cv;
 @use "bulma/sass/utilities/initial-variables" as iv;
+@use "bulma/sass/utilities/derived-variables" as dv;
 @use "bulma/sass/utilities/controls" as controls;
+
+@include cv.register-vars((
+  "bulma-dropdown-item-hover-background-l-delta": dv.$dropdown-item-hover-background-l-delta,
+  "bulma-dropdown-item-hover-border-l-delta": dv.$dropdown-item-hover-border-l-delta
+));
 
 $dropdown-content-max-height: 200px !default;
 

--- a/packages/buefy/src/scss/components/_autocomplete.scss
+++ b/packages/buefy/src/scss/components/_autocomplete.scss
@@ -31,8 +31,8 @@ $dropdown-content-max-height: 200px !default;
         overflow: hidden;
         text-overflow: ellipsis;
         &.is-hovered {
-            background: $dropdown-item-hover-background-color;
-            color: $dropdown-item-hover-color;
+            background: cv.getVar("dropdown-item-hover-background-color");
+            color: cv.getVar("dropdown-item-hover-color");
         }
         &.is-disabled {
             opacity: 0.5;

--- a/packages/buefy/src/scss/components/_autocomplete.scss
+++ b/packages/buefy/src/scss/components/_autocomplete.scss
@@ -30,6 +30,10 @@ $dropdown-content-max-height: 200px !default;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        &.is-hovered {
+            background: $dropdown-item-hover-background-color;
+            color: $dropdown-item-hover-color;
+        }
         &.is-disabled {
             opacity: 0.5;
             cursor: not-allowed;

--- a/packages/buefy/src/scss/components/_autocomplete.scss
+++ b/packages/buefy/src/scss/components/_autocomplete.scss
@@ -31,8 +31,8 @@ $dropdown-content-max-height: 200px !default;
         overflow: hidden;
         text-overflow: ellipsis;
         &.is-hovered {
-            background: cv.getVar("dropdown-item-hover-background-color");
-            color: cv.getVar("dropdown-item-hover-color");
+            $bulma-dropdown-item-background-l-delta: cv.getVar("bulma-dropdown-item-hover-background-l-delta");
+            $bulma-dropdown-item-border-l-delta: cv.getVar("bulma-dropdown-item-hover-border-l-delta");
         }
         &.is-disabled {
             opacity: 0.5;

--- a/packages/buefy/src/scss/components/_autocomplete.scss
+++ b/packages/buefy/src/scss/components/_autocomplete.scss
@@ -1,12 +1,7 @@
 @use "bulma/sass/utilities/css-variables" as cv;
 @use "bulma/sass/utilities/initial-variables" as iv;
-@use "bulma/sass/utilities/derived-variables" as dv;
 @use "bulma/sass/utilities/controls" as controls;
 
-@include cv.register-vars((
-  "bulma-dropdown-item-hover-background-l-delta": dv.$dropdown-item-hover-background-l-delta,
-  "bulma-dropdown-item-hover-border-l-delta": dv.$dropdown-item-hover-border-l-delta
-));
 
 $dropdown-content-max-height: 200px !default;
 
@@ -37,8 +32,8 @@ $dropdown-content-max-height: 200px !default;
         overflow: hidden;
         text-overflow: ellipsis;
         &.is-hovered {
-            $bulma-dropdown-item-background-l-delta: cv.getVar("bulma-dropdown-item-hover-background-l-delta");
-            $bulma-dropdown-item-border-l-delta: cv.getVar("bulma-dropdown-item-hover-border-l-delta");
+            --bulma-dropdown-item-background-l-delta: var(--bulma-dropdown-item-hover-background-l-delta);
+            --bulma-dropdown-item-border-l-delta: var(--bulma-dropdown-item-hover-border-l-delta);
         }
         &.is-disabled {
             opacity: 0.5;


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #4207
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Restores the .is-hovered styles for autocomplete dropdown items when navigating via arrow keys.