### PR TITLE
Augment 'vue' instead of '@vue/runtime-core' to register $buefy

### DIFF
--- a/packages/buefy/src/utils/vue-augmentation.ts
+++ b/packages/buefy/src/utils/vue-augmentation.ts
@@ -17,7 +17,7 @@ import ConfigComponent from './ConfigComponent'
 
 // Augments the global property with `$buefy`.
 // https://vuejs.org/guide/typescript/options-api.html#augmenting-global-properties
-declare module '@vue/runtime-core' {
+declare module 'vue' {
     /* @public */
     interface ComponentCustomProperties {
         /* Global Buefy API. */


### PR DESCRIPTION
This follows the Vue documentation:

https://vuejs.org/guide/typescript/options-api.html#augmenting-global-properties

Fixes #4232 - see issue for details.
