### PR TITLE
Extend Buefy CSS with Built Versions

### DIFF
--- a/packages/buefy/README.md
+++ b/packages/buefy/README.md
@@ -58,7 +58,7 @@ Bundle
 ```javascript
 import { createApp } from "vue";
 import Buefy from "buefy";
-import "buefy/dist/buefy.css";
+import "buefy/dist/css/buefy.css";
 
 const app = createApp();
 
@@ -70,7 +70,7 @@ or Individual Components
 ```javascript
 import { createApp } from "vue";
 import { Field, Input } from "buefy";
-import "buefy/dist/buefy.css";
+import "buefy/dist/css/buefy.css";
 
 const app = createApp();
 

--- a/packages/buefy/package.json
+++ b/packages/buefy/package.json
@@ -49,7 +49,11 @@
     "build": "rimraf dist && npm run build:js && npm run build:scss && npm run build:dts",
     "build:js": "rollup -c && rollup -c --environment MINIFY",
     "build:dts": "rimraf temp-dts && vue-tsc -b tsconfig.types.json --force && api-extractor run --local && node build/augment-dts.mjs",
-    "build:scss": "node ./build/banner.js < src/scss/buefy-build.scss | sass --load-path=../../node_modules --load-path=node_modules src/scss/buefy-build.scss dist/buefy.css && cleancss -o dist/buefy.min.css dist/buefy.css",
+    "build:scss": "npm run build:scss-buefy && npm run build:scss-buefy-bulma && npm run build:scss-no-reset",
+    "build:scss-buefy": "sass --load-path=../../node_modules --load-path=node_modules src/scss/buefy.scss dist/css/buefy.css && node ./build/banner.js < dist/css/buefy.css > dist/css/buefy.banner.css && mv dist/css/buefy.banner.css dist/css/buefy.css && cleancss -o dist/css/buefy.min.css dist/css/buefy.css",
+    "build:scss-buefy-bulma": "sass --load-path=../../node_modules --load-path=node_modules src/scss/versions/buefy-bulma-bundle.scss dist/css/versions/buefy-bulma-bundle.css && node ./build/banner.js < dist/css/versions/buefy-bulma-bundle.css > dist/css/buefy.banner.css && mv dist/css/buefy.banner.css dist/css/versions/buefy-bulma-bundle.css && cleancss -o dist/css/versions/buefy-bulma-bundle.min.css dist/css/versions/buefy-bulma-bundle.css",
+    "build:scss-no-reset": "sass --load-path=../../node_modules --load-path=node_modules src/scss/versions/buefy-no-reset.scss dist/css/versions/buefy-no-reset.css && node ./build/banner.js < dist/css/versions/buefy-no-reset.css > dist/css/buefy.banner.css && mv dist/css/buefy.banner.css dist/css/versions/buefy-no-reset.css && cleancss -o dist/css/versions/buefy-no-reset.min.css dist/css/versions/buefy-no-reset.css",
+
     "vetur": "node -r esm build/vetur.js"
   },
   "dependencies": {

--- a/packages/buefy/package.json
+++ b/packages/buefy/package.json
@@ -49,9 +49,9 @@
     "build": "rimraf dist && npm run build:js && npm run build:scss && npm run build:dts",
     "build:js": "rollup -c && rollup -c --environment MINIFY",
     "build:dts": "rimraf temp-dts && vue-tsc -b tsconfig.types.json --force && api-extractor run --local && node build/augment-dts.mjs",
-    "build:scss": "npm run build:scss-buefy && npm run build:scss-buefy-bulma && npm run build:scss-no-reset",
-    "build:scss-buefy": "sass --load-path=../../node_modules --load-path=node_modules src/scss/buefy.scss dist/css/buefy.css && node ./build/banner.js < dist/css/buefy.css > dist/css/buefy.banner.css && mv dist/css/buefy.banner.css dist/css/buefy.css && cleancss -o dist/css/buefy.min.css dist/css/buefy.css",
-    "build:scss-buefy-bulma": "sass --load-path=../../node_modules --load-path=node_modules src/scss/versions/buefy-bulma-bundle.scss dist/css/versions/buefy-bulma-bundle.css && node ./build/banner.js < dist/css/versions/buefy-bulma-bundle.css > dist/css/buefy.banner.css && mv dist/css/buefy.banner.css dist/css/versions/buefy-bulma-bundle.css && cleancss -o dist/css/versions/buefy-bulma-bundle.min.css dist/css/versions/buefy-bulma-bundle.css",
+    "build:scss": "npm run build:scss-buefy && npm run build:scss-buefy-standalone && npm run build:scss-no-reset",
+    "build:scss-buefy": "sass --load-path=../../node_modules --load-path=node_modules src/scss/versions/buefy-bulma-bundle.scss dist/css/buefy.css && node ./build/banner.js < dist/css/buefy.css > dist/css/buefy.banner.css && mv dist/css/buefy.banner.css dist/css/buefy.css && cleancss -o dist/css/buefy.min.css dist/css/buefy.css",
+    "build:scss-buefy-standalone": "sass --load-path=../../node_modules --load-path=node_modules src/scss/buefy.scss dist/css/versions/buefy-standalone.css && node ./build/banner.js < dist/css/versions/buefy-standalone.css > dist/css/buefy.banner.css && mv dist/css/buefy.banner.css dist/css/versions/buefy-standalone.css && cleancss -o dist/css/versions/buefy-standalone.min.css dist/css/versions/buefy-standalone.css",
     "build:scss-no-reset": "sass --load-path=../../node_modules --load-path=node_modules src/scss/versions/buefy-no-reset.scss dist/css/versions/buefy-no-reset.css && node ./build/banner.js < dist/css/versions/buefy-no-reset.css > dist/css/buefy.banner.css && mv dist/css/buefy.banner.css dist/css/versions/buefy-no-reset.css && cleancss -o dist/css/versions/buefy-no-reset.min.css dist/css/versions/buefy-no-reset.css",
 
     "vetur": "node -r esm build/vetur.js"

--- a/packages/buefy/src/scss/versions/buefy-bulma-bundle.scss
+++ b/packages/buefy/src/scss/versions/buefy-bulma-bundle.scss
@@ -1,3 +1,3 @@
 @charset "utf-8";
 @use "bulma/bulma";
-@use "buefy";
+@use "../buefy";

--- a/packages/buefy/src/scss/versions/buefy-no-reset.scss
+++ b/packages/buefy/src/scss/versions/buefy-no-reset.scss
@@ -1,0 +1,16 @@
+@charset "utf-8";
+
+/* Custom Bulma Imports Without Minirest */
+@forward "bulma/sass/utilities";
+@forward "bulma/sass/themes";
+@forward "bulma/sass/base/generic";
+@forward "bulma/sass/base/animations";
+@forward "bulma/sass/elements";
+@forward "bulma/sass/form";
+@forward "bulma/sass/components";
+@forward "bulma/sass/grid";
+@forward "bulma/sass/layout";
+@forward "bulma/sass/base/skeleton";
+@forward "bulma/sass/helpers";
+
+@use "../buefy";

--- a/packages/docs/src/pages/installation/Sass.vue
+++ b/packages/docs/src/pages/installation/Sass.vue
@@ -2,7 +2,7 @@
     <div>
         <div class="content">
             <p>
-                Customize Buefy with <strong>Sass</strong> by overriding Bulma variables before importing the framework. 
+                Customize Buefy with <strong>Sass</strong> by overriding Bulma variables before importing the framework.
                 This guide covers both modern Sass (with <code>@use</code>) and legacy Sass (with <code>@import</code>) approaches.
             </p>
         </div>
@@ -61,7 +61,7 @@
                 <b-message type="is-warning">
                     <div class="content">
                         <p>
-                            <b>Note:</b> The <code>@import</code> directive is deprecated and will be removed in Dart Sass 2.0. 
+                            <b>Note:</b> The <code>@import</code> directive is deprecated and will be removed in Dart Sass 2.0.
                             Consider migrating to <code>@use</code> for new projects.
                         </p>
                     </div>
@@ -78,10 +78,10 @@
                 <p class="content">
                     Configure your build tool to use Dart Sass:
                 </p>
-                
+
                 <h5 class="title is-5">Vite Configuration</h5>
                 <CodeView :code="preformat(viteConfig)" lang="javascript" expanded />
-                
+
                 <h5 class="title is-5 mt-5">Webpack Configuration</h5>
                 <CodeView :code="preformat(webpackConfig)" lang="javascript" expanded />
             </div>
@@ -100,8 +100,8 @@
                 <b-message type="is-success">
                     <div class="content">
                         <p>
-                            <b>Important:</b> When using Sass customization, do not import 
-                            <code>buefy/dist/buefy.css</code> as your custom Sass will generate 
+                            <b>Important:</b> When using Sass customization, do not import
+                            <code>buefy/dist/css/buefy.css</code> as your custom Sass will generate
                             the CSS with your customizations.
                         </p>
                     </div>
@@ -120,16 +120,16 @@
                 <li><strong>Spacing:</strong> <code>$radius</code>, <code>$radius-small</code>, <code>$radius-large</code>, <code>$radius-rounded</code></li>
                 <li><strong>Buefy specific:</strong> <code>$speed-slow</code>, <code>$speed-slower</code></li>
             </ul>
-            
+
             <h4 class="title is-4">Learn More</h4>
             <p>
-                For a complete list of Bulma variables, visit the 
+                For a complete list of Bulma variables, visit the
                 <a href="https://bulma.io/documentation/customize/list-of-sass-variables/" target="_blank" rel="noopener">
                     Bulma Sass customization documentation
                 </a>.
             </p>
             <p>
-                For CSS Variables approach (no compilation required), see the 
+                For CSS Variables approach (no compilation required), see the
                 <router-link to="/documentation/css-variables">CSS Variables section</router-link>.
             </p>
         </div>
@@ -144,13 +144,13 @@ import { BMessage } from "buefy";
 import CodeView from "@/components/CodeView.vue";
 import { preformat } from "@/utils";
 
-import { 
-    importing, 
-    sass, 
-    sassLegacy, 
-    packageJsonSetup, 
-    viteConfig, 
-    webpackConfig 
+import {
+    importing,
+    sass,
+    sassLegacy,
+    packageJsonSetup,
+    viteConfig,
+    webpackConfig
 } from "./usage/customization";
 
 export default defineComponent({

--- a/packages/docs/src/pages/installation/usage/start.ts
+++ b/packages/docs/src/pages/installation/usage/start.ts
@@ -6,7 +6,7 @@
 export const importingBundle = `
 import Vue from 'vue'
 import Buefy from 'buefy'
-import 'buefy/dist/buefy.css'
+import 'buefy/dist/css/buefy.css'
 
 Vue.use(Buefy)
 `
@@ -14,7 +14,7 @@ Vue.use(Buefy)
 export const importingComponentsAsVuePlugins = `
 import Vue from 'vue'
 import { Table, Input } from 'buefy'
-import 'buefy/dist/buefy.css'
+import 'buefy/dist/css/buefy.css'
 
 Vue.use(Table)
 Vue.use(Input)
@@ -23,7 +23,7 @@ Vue.use(Input)
 export const importingSSR = `
 import Vue from 'vue'
 import Buefy from 'buefy'
-import 'buefy/dist/buefy.css'
+import 'buefy/dist/css/buefy.css'
 
 Vue.use(Buefy) `
 


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #4230
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Adds multiple versioned CSS builds for Buefy:
  - `buefy.css` (with Bulma)
  - `buefy-standalone.css` (this will allow you to choose any built version of bulma or even integrate a separate css framework)
  - `buefy-no-reset.css` (with Bulma, excluding minireset)
- Moves default Buefy output to `dist/css/buefy.css`
- Places custom builds under `dist/css/versions` for modular clarity and legacy-proof structure