### PR TITLE
Fix dropdown style for links 

### DIFF
--- a/packages/buefy/src/scss/components/_dropdown.scss
+++ b/packages/buefy/src/scss/components/_dropdown.scss
@@ -4,6 +4,7 @@
 @use "bulma/sass/utilities/initial-variables" as iv;
 @use "bulma/sass/utilities/derived-variables.scss" as dv;
 @use "bulma/sass/utilities/mixins" as mixins;
+@use "bulma/sass/components/dropdown" as dropdown;
 
 $dropdown-mobile-breakpoint: calc(iv.$desktop - 1px) !default;
 $dropdown-background-color: rgba(dv.$scheme-invert, 0.86) !default;


### PR DESCRIPTION
Fixes #
- N/A

## Proposed Changes
Import Bulma's dropdown component styles in `_dropdown.scss` to ensure `.dropdown-item` styles are properly applied to Buefy dropdowns.


| Before | After |
| :------- | :------: |
| <img width="219" height="366" alt="Screenshot 2025-12-09 at 4 30 55 PM" src="https://github.com/user-attachments/assets/3d80722a-15bf-4c97-b2e3-1622e9f79992" />  | <img width="247" height="424" alt="Screenshot 2025-12-09 at 4 31 14 PM" src="https://github.com/user-attachments/assets/5f8d1dcb-fab5-4e69-a06b-663aaae3cb3c" /> |
 

**CSS from bulma that was not being include on line 56:**
<img width="318" height="135" alt="Screenshot 2025-12-09 at 4 31 50 PM" src="https://github.com/user-attachments/assets/8c20d52b-3b07-4cb7-8bb5-1fb6a36a0359" />

