### PR TITLE
Fix Datepicker Missing Background Color 

### DIFF
--- a/packages/buefy/src/scss/components/_datepicker.scss
+++ b/packages/buefy/src/scss/components/_datepicker.scss
@@ -156,7 +156,7 @@ $datepicker-item-selected-background-color: cv.getVar("primary") !default;
                         border-top-right-radius: 0;
                     }
                     &.is-within-selected {
-                        background-color: cv.getRgbaVar("datepicker-item-selected-background-color", 0.5);
+                        background-color: rgb(from $datepicker-item-selected-background-color r g b / 0.5);
                         border-radius: 0;
                     }
                     &.is-last-selected {


### PR DESCRIPTION
…ct bg color

<!-- Thank you for helping Buefy! -->
Fixes #4263 

## Proposed Changes
Seems like rgba(var(myVariableName), 0.5) doesn't work. Looks like using the `rbg(from ` fixes this issue. My thought is that rgba doesn't like the an actual hex code as the parameter?
Source: https://stackoverflow.com/questions/72966406/how-can-i-automatically-convert-hex-to-rgb-in-css-using-bootstrap

## Before fix
<img width="1063" height="748" alt="image" src="https://github.com/user-attachments/assets/b8d483ed-8675-4e8e-80a1-c2486b6c8b7a" />


## After fix (taken from local version of docs)
<img width="1063" height="748" alt="image" src="https://github.com/user-attachments/assets/5dd2d00b-2eb6-44ff-9251-6a6a1a60ccdf" />
