### PR TITLE
remove Object.keys() call in favor of checking first index

### DIFF
--- a/packages/buefy/src/components/table/Table.vue
+++ b/packages/buefy/src/components/table/Table.vue
@@ -991,7 +991,7 @@ export default defineComponent({
                     if (this.sortMultiple &&
                         this.sortMultipleDataLocal && this.sortMultipleDataLocal.length > 0) {
                         this.doSortMultiColumn()
-                    } else if (Object.keys(this.currentSortColumn).length > 0) {
+                    } else if (this.currentSortColumn[0]) {
                         this.doSortSingleColumn(this.currentSortColumn)
                     }
                 }


### PR DESCRIPTION
## Proposed Changes

On a BTable, after sorting a column and then filtering it, a warning appears in the browser console:

[Vue warn]: Avoid app logic that relies on enumerating keys on a component instance. The keys will be empty in production mode to avoid performance overhead.

I believe I've tracked it down to this line. 