### PR TITLE
Feat (dropdown): add listbox/option ARIA roles for accessibility (#4295)

### DIFF
--- a/packages/buefy/src/components/dropdown/Dropdown.spec.ts
+++ b/packages/buefy/src/components/dropdown/Dropdown.spec.ts
@@ -35,6 +35,16 @@ describe('BDropdown', () => {
         expect(position.validator && position.validator('is-bottom-left')).toBeTruthy()
     })
 
+    it('accepts listbox as ariaRole for accessibility', () => {
+        const ariaRole = wrapper.vm.$options.props.ariaRole
+
+        expect(ariaRole.type).toBe(String)
+        expect(ariaRole.validator && ariaRole.validator('listbox')).toBeTruthy()
+        expect(ariaRole.validator && ariaRole.validator('menu')).toBeTruthy()
+        expect(ariaRole.validator && ariaRole.validator('list')).toBeTruthy()
+        expect(ariaRole.validator && ariaRole.validator('invalid')).toBeFalsy()
+    })
+
     it('react accordingly when changing v-model', async () => {
         const value = 'value'
         await wrapper.setProps({ modelValue: value })

--- a/packages/buefy/src/components/dropdown/Dropdown.vue
+++ b/packages/buefy/src/components/dropdown/Dropdown.vue
@@ -124,6 +124,7 @@ export default defineComponent({
                 return [
                     'menu',
                     'list',
+                    'listbox',
                     'dialog'
                 ].indexOf(value as string) > -1
             },

--- a/packages/buefy/src/components/dropdown/DropdownItem.spec.ts
+++ b/packages/buefy/src/components/dropdown/DropdownItem.spec.ts
@@ -75,4 +75,10 @@ describe('BDropdownItem', () => {
         expect(parent.selectItem).toHaveBeenCalled()
         expect(wrapper.emitted().click).toBeTruthy()
     })
+
+    it('applies option role for listbox/option accessibility', async () => {
+        await wrapper.setProps({ ariaRole: 'option' })
+        expect(wrapper.vm.ariaRoleItem).toBe('option')
+        expect(wrapper.find('.dropdown-item').attributes('role')).toBe('option')
+    })
 })

--- a/packages/buefy/src/components/dropdown/DropdownItem.spec.ts
+++ b/packages/buefy/src/components/dropdown/DropdownItem.spec.ts
@@ -77,8 +77,13 @@ describe('BDropdownItem', () => {
     })
 
     it('applies option role for listbox/option accessibility', async () => {
-        await wrapper.setProps({ ariaRole: 'option' })
+        await wrapper.setProps({ ariaRole: 'option', value: dropdownSelected })
         expect(wrapper.vm.ariaRoleItem).toBe('option')
         expect(wrapper.find('.dropdown-item').attributes('role')).toBe('option')
+        expect(wrapper.find('.dropdown-item').attributes('aria-selected')).toBe('true')
+
+        await wrapper.setProps({ value: 'other-value' })
+        expect(wrapper.find('.dropdown-item').attributes('role')).toBe('option')
+        expect(['false', undefined]).toContain(wrapper.find('.dropdown-item').attributes('aria-selected'))
     })
 })

--- a/packages/buefy/src/components/dropdown/DropdownItem.vue
+++ b/packages/buefy/src/components/dropdown/DropdownItem.vue
@@ -78,7 +78,7 @@ export default defineComponent({
             }
         },
         ariaRoleItem() {
-            return this.ariaRole === 'menuitem' || this.ariaRole === 'listitem' ? this.ariaRole : undefined
+            return this.ariaRole === 'menuitem' || this.ariaRole === 'listitem' || this.ariaRole === 'option' ? this.ariaRole : undefined
         },
         isClickable() {
             return !(this.parent as DropdownInstance).disabled &&


### PR DESCRIPTION
Fixes #4295

Adds support for the `listbox` / `option` ARIA role pair on the Dropdown component so it can be used as a semantically correct list of selectable options and improves accessibility (e.g. for screen readers).

## Proposed Changes
- **BDropdown:** `ariaRole` prop now accepts `'listbox'` in addition to `'menu'`, `'list'`, and `'dialog'`.
- **BDropdownItem:** `ariaRole` prop now accepts `'option'` in addition to `'menuitem'` and `'listitem'`, and the item renders with `role="option"` when `aria-role="option"` is set.

### Usage
Use `aria-role="listbox"` on the dropdown and `aria-role="option"` on each item when the dropdown represents a list of selectable options (e.g. custom select-like UIs):

```vue
<b-dropdown aria-role="listbox" v-model="selected">
  <template #trigger>
    <b-button>{{ selected ?? 'Choose' }}</b-button>
  </template>
  <b-dropdown-item aria-role="option" value="a">Option A</b-dropdown-item>
  <b-dropdown-item aria-role="option" value="b">Option B</b-dropdown-item>
</b-dropdown>
```

### Testing
- New unit tests for the `ariaRole` validator (including `listbox`) in `Dropdown.spec.ts`.
- New unit test for the `option` role on `BDropdownItem` in `DropdownItem.spec.ts`.
- All existing dropdown tests pass.

### References
- [ARIA listbox role (MDN)](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/listbox_role)
- [ARIA option role (MDN)](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/option_role)

