### PR TITLE
Fixed issue where sorting icon would not show up in custom table headers

### DIFF
--- a/packages/buefy/src/components/table/Table.vue
+++ b/packages/buefy/src/components/table/Table.vue
@@ -121,46 +121,46 @@
                                 </template>
                                 <template v-else>
                                     {{ column.label }}
-                                    <template
-                                        v-if="sortMultiple &&
-                                            sortMultipleDataComputed &&
-                                            sortMultipleDataComputed.length > 0 &&
-                                            sortMultipleDataComputed.filter(i =>
-                                                i.field === column.field).length > 0"
-                                    >
-                                        <span class="multi-sort-icons">
-                                            <b-icon
-                                                :icon="sortIcon"
-                                                :pack="iconPack"
-                                                both
-                                                :size="sortIconSize"
-                                                :class="{
-                                                    'is-desc': sortMultipleDataComputed
-                                                        .filter(i => i.field === column.field)[0]
-                                                        .order === 'desc'}"
-                                            />
-                                            {{ findIndexOfSortData(column) }}
-                                            <button
-                                                class="delete is-small multi-sort-cancel-icon"
-                                                type="button"
-                                                @click.stop="removeSortingPriority(column)"
-                                            />
-                                        </span>
-                                    </template>
-
-                                    <b-icon
-                                        v-else
-                                        :icon="sortIcon"
-                                        :pack="iconPack"
-                                        both
-                                        :size="sortIconSize"
-                                        class="sort-icon"
-                                        :class="{
-                                            'is-desc': !isAsc,
-                                            'is-invisible': currentSortColumn !== column
-                                        }"
-                                    />
                                 </template>
+                                <template
+                                    v-if="sortMultiple &&
+                                        sortMultipleDataComputed &&
+                                        sortMultipleDataComputed.length > 0 &&
+                                        sortMultipleDataComputed.filter(i =>
+                                            i.field === column.field).length > 0"
+                                >
+                                    <span class="multi-sort-icons">
+                                        <b-icon
+                                            :icon="sortIcon"
+                                            :pack="iconPack"
+                                            both
+                                            :size="sortIconSize"
+                                            :class="{
+                                                'is-desc': sortMultipleDataComputed
+                                                    .filter(i => i.field === column.field)[0]
+                                                    .order === 'desc'}"
+                                        />
+                                        {{ findIndexOfSortData(column) }}
+                                        <button
+                                            class="delete is-small multi-sort-cancel-icon"
+                                            type="button"
+                                            @click.stop="removeSortingPriority(column)"
+                                        />
+                                    </span>
+                                </template>
+
+                                <b-icon
+                                    v-else
+                                    :icon="sortIcon"
+                                    :pack="iconPack"
+                                    both
+                                    :size="sortIconSize"
+                                    class="sort-icon"
+                                    :class="{
+                                        'is-desc': !isAsc,
+                                        'is-invisible': currentSortColumn !== column
+                                    }"
+                                />
                             </div>
                         </th>
                         <th


### PR DESCRIPTION
Fixes #2850.

The issue can still be reproduced with Buefy 3.0.4 in [this CodeSandbox](https://codesandbox.io/p/devbox/m82sdh).

## Proposed fix

Just changed the arrangement of the header slot so that the sort icon logic falls outside of the slot handling.

However, it could be argued that when the user creates a custom header using the `#header` slot, it's up to them to implement the icon too. Then, as [this comment](https://github.com/buefy/buefy/issues/2850#issuecomment-691100285) mentioned in the original issue (back in 2020, what a year that was):

> If the decision is made to not add the arrows back in, perhaps something could be added to the documentation showing how to add them back in manually inside the custom template, if that's even possible.

I think this solution would be messier, as we would have to pass a callback method or something as a prop to the slot, nevermind having to update the docs! (For legal reasons, this is a joke) Obviously, feel free to reject this PR if you do agree with the quote.