### PR TITLE
Fixed fallthrough attr issue in Datetimepicker

### DIFF
--- a/packages/buefy/src/components/datetimepicker/Datetimepicker.vue
+++ b/packages/buefy/src/components/datetimepicker/Datetimepicker.vue
@@ -3,7 +3,7 @@
         v-if="!isMobile || inline"
         ref="datepicker"
         v-model="computedValue"
-        v-bind="datepicker"
+        v-bind="{...datepicker, ...$attrs}"
         :rounded="rounded"
         :open-on-focus="openOnFocus"
         :position="position"


### PR DESCRIPTION
Fixes #4039.

The issue can still be reproduced with Buefy 3.0.4 in  [this codesandbox](https://codesandbox.io/p/devbox/cqfwx8).

## Proposed fix

I just propagated the `$attrs` to the `<b-datepicker>` inside `DateTimePicker`, giving priority to the `datepicker` prop over `$attrs`. I figured the `datepicker` prop is used in cases where the user might need more fine grained control over the `<b-datepicker>`, and thus it should prevail over fallthrough attributes that they might have less control over. If you disagree on this, we can change it :)

I already voiced my concerns in #4272 regarding how the fallback attributes are implemented, through `CompatFallthroughMixin`. I'm not here to discuss that, because it looks like a heavy discussion.

But while the matter is unresolved, I figured that `DateTimePicker` should at least behave consistently when compared with the other components. As can be seen in the codesandbox linked above, `id` usually stays on the top most element of the template, whereas the `name` usually falls down to the `<input>`. The change in this PR brings that behavior to `DateTimePicker`.