### PR TITLE
Delay unmount so Modal's leave transition and 150ms timeout can run.

### DIFF
--- a/packages/buefy/src/components/modal/index.ts
+++ b/packages/buefy/src/components/modal/index.ts
@@ -69,7 +69,10 @@ class ModalProgrammatic {
                         ...propsData,
                         programmatic: true,
                         onClose: () => {
-                            vueInstance.unmount()
+                            // Delay unmount so Modal's leave transition and 150ms timeout can run.
+                            setTimeout(() => {
+                                vueInstance.unmount()
+                            }, 160)
                         },
                         // intentionally overrides propsData.onCancel
                         // to prevent propsData.onCancel from receiving a "cancel" event


### PR DESCRIPTION
## Proposed Changes

Programmatically opened modals are being removed from the DOM before they can fire callbacks. I added a timeout to the onClose event to allow time for the callbacks and close animation.
