### PR TITLE
Fix: Snackbar programmatic API ignores defaultNoticeQueue config

### DIFF
--- a/packages/buefy/src/components/snackbar/Snackbar.spec.ts
+++ b/packages/buefy/src/components/snackbar/Snackbar.spec.ts
@@ -1,9 +1,13 @@
+import { transformVNodeArgs } from 'vue'
 import { shallowMount } from '@vue/test-utils'
 import type { VueWrapper } from '@vue/test-utils'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import BSnackbar from '@components/snackbar/Snackbar.vue'
+import { SnackbarProgrammatic } from '@components/snackbar'
+import config, { setOptions } from '@utils/config'
 
 let wrapper: VueWrapper<InstanceType<typeof BSnackbar>>
+const realInsertAdjacentElement = HTMLElement.prototype.insertAdjacentElement
 
 describe('BSnackbar', () => {
     HTMLElement.prototype.insertAdjacentElement = vi.fn()
@@ -31,5 +35,53 @@ describe('BSnackbar', () => {
         await wrapper.vm.$nextTick()
         expect(wrapper.vm.onAction).toHaveBeenCalled()
         expect(wrapper.vm.close).toHaveBeenCalled()
+    })
+
+    describe('programmatically opened', () => {
+        const savedNoticeQueue = config.defaultNoticeQueue
+
+        beforeEach(() => {
+            transformVNodeArgs(undefined)
+            HTMLElement.prototype.insertAdjacentElement = realInsertAdjacentElement
+        })
+
+        afterEach(() => {
+            HTMLElement.prototype.insertAdjacentElement = vi.fn()
+            setOptions(Object.assign(config, { defaultNoticeQueue: savedNoticeQueue }))
+            document.querySelectorAll('.notices').forEach((el) => el.remove())
+        })
+
+        it('should not dismiss existing snackbar when queue is disabled globally', () => {
+            setOptions(Object.assign(config, { defaultNoticeQueue: false }))
+
+            new SnackbarProgrammatic().open({ message: 'first', indefinite: true })
+            const parent = document.querySelector('body > .notices.is-bottom')!
+            expect(parent.childElementCount).toBe(1)
+
+            new SnackbarProgrammatic().open({ message: 'second', indefinite: true })
+            expect(parent.childElementCount).toBe(2)
+        })
+
+        it('should dismiss existing snackbar when queue is enabled', () => {
+            setOptions(Object.assign(config, { defaultNoticeQueue: true }))
+
+            new SnackbarProgrammatic().open({ message: 'first', indefinite: true })
+            const parent = document.querySelector('body > .notices.is-bottom')!
+            expect(parent.childElementCount).toBe(1)
+
+            new SnackbarProgrammatic().open({ message: 'second', indefinite: true })
+            expect(parent.childElementCount).toBe(1)
+        })
+
+        it('explicit queue param should override the global config', () => {
+            setOptions(Object.assign(config, { defaultNoticeQueue: false }))
+
+            new SnackbarProgrammatic().open({ message: 'first', indefinite: true })
+            const parent = document.querySelector('body > .notices.is-bottom')!
+            expect(parent.childElementCount).toBe(1)
+
+            new SnackbarProgrammatic().open({ message: 'second', indefinite: true, queue: true })
+            expect(parent.childElementCount).toBe(1)
+        })
     })
 })

--- a/packages/buefy/src/components/snackbar/index.ts
+++ b/packages/buefy/src/components/snackbar/index.ts
@@ -51,7 +51,7 @@ class SnackbarProgrammatic {
         const propsData: SnackbarProps = {
             type: 'is-success',
             position: config.defaultSnackbarPosition || 'is-bottom-right',
-            queue: true,
+            queue: config.defaultNoticeQueue,
             message,
             ...restParams
         }


### PR DESCRIPTION
## Proposed Changes

`SnackbarProgrammatic.open()` hardcodes `queue: true` in its default props, which means the `defaultNoticeQueue` constructor option has no effect on programmatically opened snackbars.

Both `ToastProgrammatic` and `NotificationProgrammatic` correctly omit `queue` from their defaults, allowing `NoticeMixin.shouldQueue()` to fall back to `config.defaultNoticeQueue`. Snackbar was the only notice type that ignored this global setting.

This replaces the hardcoded `true` with `config.defaultNoticeQueue` so that:
- `defaultNoticeQueue: false` disables queuing globally (including snackbars)
- Users can still override per-call via `this.$buefy.snackbar.open({ queue: true })` since `...restParams` spreads after the default

### Before
```js
// snackbar/index.ts
const propsData: SnackbarProps = {
    type: 'is-success',
    position: config.defaultSnackbarPosition || 'is-bottom-right',
    queue: true, // ← ignores defaultNoticeQueue
    message,
    ...restParams
}
```

### After
```js
const propsData: SnackbarProps = {
    type: 'is-success',
    position: config.defaultSnackbarPosition || 'is-bottom-right',
    queue: config.defaultNoticeQueue, // ← respects global config
    message,
    ...restParams
}
```

All existing tests pass (`664 passed`), lint is clean.