### PR TITLE
Adjusting links and spacings in Homepage

### DIFF
--- a/packages/docs/src/pages/Home.vue
+++ b/packages/docs/src/pages/Home.vue
@@ -26,14 +26,14 @@
                             ></strong
                         >
                     </h2>
-                    <div class="home-hero">
+                    <div class="home-hero my-6">
                         <pre
                             class="npm"
                         ><code><span class="is-unselectable">$ </span>npm install buefy</code></pre>
                     </div>
 
 
-                    <div class="buttons">
+                    <div class="buttons my-6">
                         <router-link
                             class="button is-medium home-hero"
                             to="/documentation/start"

--- a/packages/docs/src/pages/Home.vue
+++ b/packages/docs/src/pages/Home.vue
@@ -14,12 +14,14 @@
                         <strong>Lightweight</strong> UI components for
                         <strong
                             ><a href="https://vuejs.org/" target="_blank"
+                                class="has-text-light is-underlined"
                                 >Vue 3</a
                             ></strong
                         >
                         based on
                         <strong
                             ><a href="http://bulma.io/" target="_blank"
+                                class="has-text-light is-underlined"
                                 >Bulma</a
                             ></strong
                         >
@@ -39,7 +41,7 @@
                             Get started
                         </router-link>
                         <a
-                            class="button is-medium is-primary home-hero"
+                            class="button is-medium is-outlined home-hero"
                             href="https://github.com/buefy/buefy/releases"
                             target="_blank"
                         >
@@ -51,7 +53,7 @@
                         <p>
                             The Vue 2 version of Buefy is deprecated but will remain available as Version "0.x".
                         </p>
-                        <a href="https://v2.buefy.org" alt="Buefy Vue2 documentation website">Buefy Vue2</a>
+                        <a class="has-text-light is-underlined" href="https://v2.buefy.org" alt="Buefy Vue2 documentation website">Buefy Vue2</a>
                     </div>
 
 
@@ -322,7 +324,7 @@ export default defineComponent({
 .home-hero, .features {
     opacity: 0;
     transform: translateY(20px);
-    transition: all 0.6s ease-out;
+    transition: transform 0.6s ease-out;
 }
 
 .home-hero.reveal-animation, .features.reveal-animation {


### PR DESCRIPTION
These black Links always bothered me...

Before:

<img width="658" height="666" alt="image" src="https://github.com/user-attachments/assets/97cbaeb7-2e87-48ae-8dab-0c9b6f1843c7" />

After:

<img width="676" height="784" alt="image" src="https://github.com/user-attachments/assets/5b7cd70b-8c03-4fe6-9f02-05a1eb9b719a" />
