### PR TITLE
Added a mention to the required "field" prop in Table docs

### DIFF
--- a/packages/docs/src/components/home/HomeFaq.vue
+++ b/packages/docs/src/components/home/HomeFaq.vue
@@ -12,7 +12,7 @@
                     animation="slide"
                     :model-value="openItems[index]"
                     :aria-id="'faq-item-' + index"
-                    @update:modelValue="openItems[index] = $event"
+                    @update:model-value="openItems[index] = $event"
                 >
                     <template #trigger="props">
                         <div
@@ -47,8 +47,8 @@ export default defineComponent({
     data() {
         return {
             faq,
-            openItems: faq.map(() => false) as boolean[],
+            openItems: faq.map(() => false) as boolean[]
         }
-    },
+    }
 })
 </script>

--- a/packages/docs/src/data/homeFaq.ts
+++ b/packages/docs/src/data/homeFaq.ts
@@ -1,14 +1,14 @@
 export default [
     {
         question: 'Does Buefy support Vue 2?',
-        answer: 'No. Buefy 3.x targets Vue 3 exclusively. If you need Vue 2 support, use Buefy 0.9.x (legacy, unmaintained).',
+        answer: 'No. Buefy 3.x targets Vue 3 exclusively. If you need Vue 2 support, use Buefy 0.9.x (legacy, unmaintained).'
     },
     {
         question: 'How do I install Buefy?',
-        answer: 'Install via your package manager (npm install buefy, yarn add buefy, etc.), then register the plugin in your Vue app:\n\nimport { createApp } from "vue"\nimport Buefy from "buefy"\nimport "buefy/dist/buefy.css"\ncreateApp(App).use(Buefy).mount("#app")\n\nIndividual components can also be imported tree-shakably directly from "buefy".',
+        answer: 'Install via your package manager (npm install buefy, yarn add buefy, etc.), then register the plugin in your Vue app:\n\nimport { createApp } from "vue"\nimport Buefy from "buefy"\nimport "buefy/dist/buefy.css"\ncreateApp(App).use(Buefy).mount("#app")\n\nIndividual components can also be imported tree-shakably directly from "buefy".'
     },
     {
         question: 'How do I customize Buefy\'s styles?',
-        answer: 'Buefy is built on Bulma CSS variables. Override variables in your SCSS before importing Buefy\'s stylesheet, or use CSS custom properties at runtime. See the Customization page in the docs for a full variable reference.',
-    },
+        answer: 'Buefy is built on Bulma CSS variables. Override variables in your SCSS before importing Buefy\'s stylesheet, or use CSS custom properties at runtime. See the Customization page in the docs for a full variable reference.'
+    }
 ]

--- a/packages/docs/src/pages/components/table/Table.vue
+++ b/packages/docs/src/pages/components/table/Table.vue
@@ -70,7 +70,8 @@
         >
             <p>
                 You can add search filtering to rows by using the
-                <code>searchable</code> prop.
+                <code>searchable</code> prop, and specifying a <code>field</code>
+                name.
             </p>
             <b-message type="is-warning">
                 This feature is not available on mobile when


### PR DESCRIPTION
The `field` prop of the `BTable` component is required for both searching and sorting ([proof](https://codesandbox.io/p/devbox/9f6q7h)). The prop is mentioned in the _Sortable_ section of the documentation, but not in the _Searchable_ section. This PR adds the missing mention.