### PR TITLE
fix(input): match icon size to is-medium field

### DIFF
--- a/packages/buefy/src/utils/FormElementMixin.spec.ts
+++ b/packages/buefy/src/utils/FormElementMixin.spec.ts
@@ -38,9 +38,4 @@ describe('FormElementMixin', () => {
         expect(wrapper.emitted().blur).toBeTruthy()
         expect(wrapper.vm.checkHtml5Validity).toHaveBeenCalled()
     })
-
-    it('should scale the icon to match an is-medium size', async () => {
-        await wrapper.setProps({ size: 'is-medium' })
-        expect(wrapper.vm.iconSize).toBe('is-medium')
-    })
 })

--- a/packages/buefy/src/utils/FormElementMixin.spec.ts
+++ b/packages/buefy/src/utils/FormElementMixin.spec.ts
@@ -38,4 +38,9 @@ describe('FormElementMixin', () => {
         expect(wrapper.emitted().blur).toBeTruthy()
         expect(wrapper.vm.checkHtml5Validity).toHaveBeenCalled()
     })
+
+    it('should scale the icon to match an is-medium size', async () => {
+        await wrapper.setProps({ size: 'is-medium' })
+        expect(wrapper.vm.iconSize).toBe('is-medium')
+    })
 })

--- a/packages/buefy/src/utils/FormElementMixin.ts
+++ b/packages/buefy/src/utils/FormElementMixin.ts
@@ -111,7 +111,7 @@ const FormElementMixin = defineComponent({
          */
         iconSize() {
             switch (this.size) {
-                case 'is-small': return this.size
+                case 'is-small':
                 case 'is-medium': return this.size
                 case 'is-large': return this.newIconPack === 'mdi'
                     ? 'is-medium'

--- a/packages/buefy/src/utils/FormElementMixin.ts
+++ b/packages/buefy/src/utils/FormElementMixin.ts
@@ -112,7 +112,7 @@ const FormElementMixin = defineComponent({
         iconSize() {
             switch (this.size) {
                 case 'is-small': return this.size
-                case 'is-medium': return
+                case 'is-medium': return this.size
                 case 'is-large': return this.newIconPack === 'mdi'
                     ? 'is-medium'
                     : ''


### PR DESCRIPTION
Fixes #4348

## Proposed Changes

- The `iconSize` computed had an empty `return` for `is-medium`, so the icon fell back to the default 24px and didn't grow with the field.
- `is-small` and `is-medium` both return `this.size` (shared fall-through), so a medium field gets the matching icon size (e.g. `mdi-36px`).