### PR TITLE
Adjust tab aria to be screen reader friendly

### DIFF
--- a/packages/buefy/src/components/tabs/Tabs.vue
+++ b/packages/buefy/src/components/tabs/Tabs.vue
@@ -16,9 +16,7 @@
                     v-show="childItem.visible"
                     :class="[ childItem.headerClass, { 'is-active': childItem.isActive,
                                                        'is-disabled': childItem.disabled }]"
-                    role="tab"
-                    :aria-controls="`${childItem.uniqueValue}-content`"
-                    :aria-selected="`${childItem.isActive}`"
+                    role="presentation"
                 >
                     <b-slot-component
                         :ref="`tabLink${childItem.index}`"
@@ -28,6 +26,9 @@
                         tag="a"
                         :id="`${childItem.uniqueValue}-label`"
                         :tabindex="childItem.isActive ? 0 : -1"
+                        role="tab"
+                        :aria-controls="`${childItem.uniqueValue}-content`"
+                        :aria-selected="`${childItem.isActive}`"
                         @focus="currentFocus = childItem.index"
                         @click="childClick(childItem)"
                         @keydown="manageTabKeydown($event, childItem)"
@@ -37,6 +38,9 @@
                         v-else
                         :id="`${childItem.uniqueValue}-label`"
                         :tabindex="childItem.isActive ? 0 : -1"
+                        role="tab"
+                        :aria-controls="`${childItem.uniqueValue}-content`"
+                        :aria-selected="`${childItem.isActive}`"
                         @focus="currentFocus = childItem.index"
                         @click="childClick(childItem)"
                         @keydown="manageTabKeydown($event, childItem)"

--- a/packages/buefy/src/components/tabs/__snapshots__/Tabs.spec.ts.snap
+++ b/packages/buefy/src/components/tabs/__snapshots__/Tabs.spec.ts.snap
@@ -4,10 +4,10 @@ exports[`BTabs > render correctly 1`] = `
 "<div class="b-tabs">
   <nav class="tabs">
     <ul aria-orientation="horizontal" role="tablist">
-      <li class="is-active" role="tab" aria-controls="tab1-content" aria-selected="true"><a id="tab1-label" tabindex="0">
+      <li class="is-active" role="presentation"><a id="tab1-label" tabindex="0" role="tab" aria-controls="tab1-content" aria-selected="true">
           <!--v-if--><span></span>
         </a></li>
-      <li class="" role="tab" aria-controls="tab2-content" aria-selected="false" style="display: none;"><a id="tab2-label" tabindex="-1">
+      <li class="" role="presentation" style="display: none;"><a id="tab2-label" tabindex="-1" role="tab" aria-controls="tab2-content" aria-selected="false">
           <!--v-if--><span></span>
         </a></li>
     </ul>


### PR DESCRIPTION
As a screen reader user, I noticed accessibility issues with the tab lists and tab items in an app using Buefy. Screen readers treated the clickable anchor elements and the `<li>` elements with `role="tab"` as separate elements. As a result, selecting a tab required moving the screen reader cursor inside the list item and activating the anchor element.

Keyboard controls, such as arrow-key navigation, also did not work unless one of the anchor elements was focused. With some screen readers, this made it difficult to determine which tab was selected because the `aria-selected` attribute was located on the `<li>` element.

<!-- Thank you for helping Buefy! -->

## Proposed Changes

This PR proposes moving the `role="tab"`, `aria-controls`, and `aria-selected` attributes from the `<li>` element to the `<a>` elements in both branches of the component. It also adds `role="presentation"` to the `<li>` elements so that screen readers ignore their semantics and treat the clickable `<a>` elements as the tabs.

This is a partial reversal of #3686. That change correctly moved the `tablist` role to the `<ul>` element, resolving #3685, but it also moved the `aria-selected` attribute and the `tab` role to the `<li>` element. I am not sure why that part of the previous change was included, but the arrangement proposed in this PR is more screen-reader-friendly in every screen reader I tested.

## Testing and reference

I tested this change on a local version of the [tabs page in the documentation](https://buefy.org/documentation/tabs) using VoiceOver on macOS and NVDA, JAWS, and Narrator on Windows. Tab behavior improved in all the screen readers I tested. Keyboard controls worked correctly for navigating among and selecting tabs, and it was no longer needed to move the screen reader cursor inside a list item to activate its anchor element.

I verified with axe-core that this change does not regress #3685: the `aria-required-children` and `aria-required-parent` rules pass both before and after. The accessibility error reported in #3685 was resolved just by moving `role="tablist"` to the `<ul>` element, which this PR preserves.

A similar placement of roles can be seen at the top of the ARIA Authoring Practices Guide page about the `presentation` role: [https://www.w3.org/WAI/ARIA/apg/practices/hiding-semantics/#introduction](https://www.w3.org/WAI/ARIA/apg/practices/hiding-semantics/#introduction).
