### PR TITLE
Fix minor errors in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,7 +11,7 @@
 * Include **screenshots** or animated GIFs in your pull request whenever needed (if visual changes)
 * It's OK to have multiple small commits as you work on the PR - we will let GitHub automatically squash it before merging
 * Make sure all the unit tests pass by running `npm test` both in the library and documentation
-* Make sure your code style is consistent by running `npm run lint:fix` both in the libary and documentation
+* Make sure your code style is consistent by running `npm run lint:fix` both in the library and documentation
 * **DO NOT** commit the ``lib`` and ``dist`` folder, use it only for testing on your end
 * If adding new feature:
     * Provide convincing reason to add this feature. Ideally you should open a suggestion issue first and have it greenlighted before working on it

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -115,10 +115,10 @@ npm install
 
 ## Buefy core library
 
-The core source files of Buefy are in the [`packages/buefy-next`](../packages/buefy-next/) folder.
+The core source files of Buefy are in the [`packages/buefy`](../packages/buefy/) folder.
 
 ```bash
-cd packages/buefy-next
+cd packages/buefy
 ```
 
 ### Checking types


### PR DESCRIPTION
This PR fixes two problems in [CONTRIBUTING.md](https://github.com/buefy/buefy/blob/dev/.github/CONTRIBUTING.md). 
<!-- Thank you for helping Buefy! -->

<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

First, the location of "The core source files" in `CONTRIBUTING.md` was still listed as `/packages/buefy-next`, but after the migration back to the main Buefy project that path is just `/packages/buefy`. This PR updates this reference and the command following it to cd into the directory.

The PR also fixes a minor spelling error on line 14 of the file, "libary -> library".