### PR TITLE
Fix hasAddons with dynamic slot children test

### DIFF
--- a/packages/buefy/src/components/field/Field.spec.ts
+++ b/packages/buefy/src/components/field/Field.spec.ts
@@ -281,7 +281,7 @@ describe('BField', () => {
                 { global: { components } }
             )
             expect(wrapper.findComponent(BField).vm.hasAddons()).toBe(true)
-            expect(wrapper.find('.field').classes()).toContain('has-addons')
+            expect(wrapper.find('.field-body .field').classes()).toContain('has-addons')
         })
     })
 


### PR DESCRIPTION
I noticed that one of the library's unit tests was failing even with a clean working tree and no changes, specifically, the `hasAddons with dynamic slot children` test. This test appears to have been introduced in commit b15a8c4a, and since then, every commit and PR has failed a CI check.

## Proposed Changes

As far as I could tell, the `hasAddons()` logic is correct, but the second assertion matches the outer `.field` container rather than the inner field inside `.field-body`, where `has-addons` is applied:

```diff
- expect(wrapper.find('.field').classes()).toContain('has-addons')
+ expect(wrapper.find('.field-body .field').classes()).toContain('has-addons')
```

The test's first assertion (`wrapper.findComponent(BField).vm.hasAddons()` is `true`) did not need to change and continues to cover the logic. There are no component behavior changes.

## Testing

After running `npm -w buefy run unit`, the previously failing test now passes, and the rest of the suite remains green, with all 721 tests passing.