### PR TITLE
Add BBadge component with tests and Vue compat fixes

### DIFF
--- a/packages/buefy/src/components/autocomplete/Autocomplete.vue
+++ b/packages/buefy/src/components/autocomplete/Autocomplete.vue
@@ -141,6 +141,9 @@ interface DataItem {
 export default defineComponent({
     name: 'BAutocomplete',
     components: { BInput },
+    // In vue/compat mode, INSTANCE_LISTENERS defaults to true and strips
+    // event listeners out of $attrs, breaking the v-bind="fallthroughAttrs" forwarding below.
+    compatConfig: { INSTANCE_LISTENERS: false },
     mixins: [CompatFallthroughMixin, useFormElementMixin<HTMLInputElement | HTMLTextAreaElement>()],
     props: {
         modelValue: [Number, String, null] as PropType<number | string | null>,

--- a/packages/buefy/src/components/badge/Badge.spec.ts
+++ b/packages/buefy/src/components/badge/Badge.spec.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { shallowMount, type VueWrapper } from '@vue/test-utils'
+import BBadge from '@components/badge/Badge.vue'
+
+let wrapper: VueWrapper<InstanceType<typeof BBadge>>
+
+describe('BBadge', () => {
+    beforeEach(() => {
+        wrapper = shallowMount(BBadge, { props: { value: 3 } })
+    })
+
+    it('is called', () => {
+        expect(wrapper.vm).toBeTruthy()
+        expect(wrapper.vm.$options.name).toBe('BBadge')
+    })
+
+    it('render correctly', () => {
+        expect(wrapper.html()).toMatchSnapshot()
+    })
+
+    it('renders slot content as the anchor', () => {
+        wrapper = shallowMount(BBadge, { slots: { default: '<span class="anchor">A</span>' } })
+
+        expect(wrapper.find('.anchor').exists()).toBe(true)
+    })
+
+    it('does not render the badge span when visible is false', async () => {
+        await wrapper.setProps({ visible: false })
+
+        expect(wrapper.find('.b-badge-badge').exists()).toBe(false)
+    })
+
+    it('does not render badge content when value is empty and dot is false', () => {
+        wrapper = shallowMount(BBadge)
+
+        expect(wrapper.find('.b-badge-badge').exists()).toBe(false)
+    })
+
+    it('renders a dot with no text when dot is true', () => {
+        wrapper = shallowMount(BBadge, { props: { dot: true } })
+
+        expect(wrapper.find('.b-badge-badge').classes()).toContain('is-dot')
+        expect(wrapper.find('.b-badge-badge').text()).toBe('')
+    })
+
+    it('applies position class to the badge', async () => {
+        await wrapper.setProps({ position: 'is-bottom-left' })
+
+        expect(wrapper.find('.b-badge-badge').classes()).toContain('is-bottom-left')
+    })
+
+    it('applies type and rounded as classes on the badge', async () => {
+        await wrapper.setProps({ type: 'is-danger', rounded: true })
+
+        const classes = wrapper.find('.b-badge-badge').classes()
+        expect(classes).toContain('is-danger')
+        expect(classes).toContain('is-rounded')
+    })
+
+    it('truncates numeric value beyond max', async () => {
+        await wrapper.setProps({ value: 150, max: 99 })
+
+        expect(wrapper.find('.b-badge-badge').text()).toBe('99+')
+    })
+
+    it('does not truncate value at or below max', async () => {
+        await wrapper.setProps({ value: 99, max: 99 })
+
+        expect(wrapper.find('.b-badge-badge').text()).toBe('99')
+    })
+})

--- a/packages/buefy/src/components/badge/Badge.vue
+++ b/packages/buefy/src/components/badge/Badge.vue
@@ -1,0 +1,68 @@
+<template>
+    <component
+        :is="tag"
+        class="b-badge"
+    >
+        <slot />
+
+        <span
+            v-if="isActive"
+            class="b-badge-badge tag"
+            :class="[type, size, position, { 'is-rounded': rounded, 'is-dot': dot }]"
+        >
+            <slot
+                v-if="!dot"
+                name="badge"
+            >
+                {{ displayValue }}
+            </slot>
+        </span>
+    </component>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from 'vue'
+
+export type BadgePosition = 'is-top-right' | 'is-top-left' | 'is-bottom-right' | 'is-bottom-left'
+
+const BADGE_POSITIONS: BadgePosition[] = ['is-top-right', 'is-top-left', 'is-bottom-right', 'is-bottom-left']
+
+export default defineComponent({
+    name: 'BBadge',
+    props: {
+        value: [String, Number],
+        type: [String, Object],
+        size: String,
+        rounded: Boolean,
+        position: {
+            type: String as PropType<BadgePosition>,
+            default: 'is-top-right',
+            validator: (value: BadgePosition) => BADGE_POSITIONS.indexOf(value) >= 0
+        },
+        dot: Boolean,
+        max: Number,
+        visible: {
+            type: Boolean,
+            default: true
+        },
+        tag: {
+            type: String,
+            default: 'div'
+        }
+    },
+    computed: {
+        hasBadgeContent(): boolean {
+            return (this.value !== undefined && this.value !== null && this.value !== '') || !!this.$slots.badge
+        },
+        isActive(): boolean {
+            return this.visible && (this.dot || this.hasBadgeContent)
+        },
+        displayValue(): string | number | undefined {
+            if (typeof this.value === 'number' && typeof this.max === 'number' && this.value > this.max) {
+                return `${this.max}+`
+            }
+            return this.value
+        }
+    }
+})
+</script>

--- a/packages/buefy/src/components/badge/__snapshots__/Badge.spec.ts.snap
+++ b/packages/buefy/src/components/badge/__snapshots__/Badge.spec.ts.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`BBadge > render correctly 1`] = `"<div class="b-badge"><span class="b-badge-badge tag is-top-right">3</span></div>"`;

--- a/packages/buefy/src/components/badge/index.ts
+++ b/packages/buefy/src/components/badge/index.ts
@@ -1,0 +1,16 @@
+import type { App } from 'vue'
+import Badge from './Badge.vue'
+
+import { registerComponent } from '../../utils/plugins'
+
+const Plugin = {
+    install(Vue: App) {
+        registerComponent(Vue, Badge)
+    }
+}
+
+export default Plugin
+
+export {
+    Badge as BBadge
+}

--- a/packages/buefy/src/components/breadcrumb/BreadcrumbItem.vue
+++ b/packages/buefy/src/components/breadcrumb/BreadcrumbItem.vue
@@ -20,6 +20,9 @@ import CompatFallthroughMixin from '../../utils/CompatFallthroughMixin'
 
 export default defineComponent({
     name: 'BBreadcrumbItem',
+    // In vue/compat mode, INSTANCE_LISTENERS defaults to true and strips
+    // event listeners out of $attrs, breaking the v-bind="fallthroughAttrs" forwarding below.
+    compatConfig: { INSTANCE_LISTENERS: false },
     mixins: [CompatFallthroughMixin],
     props: {
         tag: {

--- a/packages/buefy/src/components/button/Button.vue
+++ b/packages/buefy/src/components/button/Button.vue
@@ -55,6 +55,9 @@ export type ButtonNativeType = typeof NATIVE_TYPES[number]
 export default defineComponent({
     name: 'BButton',
     components: { BIcon },
+    // In vue/compat mode, INSTANCE_LISTENERS defaults to true and strips
+    // event listeners out of $attrs, breaking the v-bind="$attrs" forwarding below.
+    compatConfig: { INSTANCE_LISTENERS: false },
     inheritAttrs: false,
     props: {
         type: [String, Object],

--- a/packages/buefy/src/components/clockpicker/Clockpicker.vue
+++ b/packages/buefy/src/components/clockpicker/Clockpicker.vue
@@ -187,6 +187,9 @@ const outerPadding = 12
 
 export default defineComponent({
     name: 'BClockpicker',
+    // In vue/compat mode, INSTANCE_LISTENERS defaults to true and strips
+    // event listeners out of $attrs, breaking the v-bind="fallthroughAttrs" forwarding below.
+    compatConfig: { INSTANCE_LISTENERS: false },
     components: {
         BClockpickerFace,
         BInput,

--- a/packages/buefy/src/components/datepicker/Datepicker.vue
+++ b/packages/buefy/src/components/datepicker/Datepicker.vue
@@ -312,6 +312,9 @@ const defaultDateParser: DateParser = (date, vm) => {
 
 export default defineComponent({
     name: 'BDatepicker',
+    // In vue/compat mode, INSTANCE_LISTENERS defaults to true and strips
+    // event listeners out of $attrs, breaking the v-bind="fallthroughAttrs" forwarding below.
+    compatConfig: { INSTANCE_LISTENERS: false },
     components: {
         BDatepickerTable,
         BDatepickerMonth,

--- a/packages/buefy/src/components/datetimepicker/Datetimepicker.vue
+++ b/packages/buefy/src/components/datetimepicker/Datetimepicker.vue
@@ -122,6 +122,9 @@ export default defineComponent({
         BTimepicker
     },
     mixins: [FormElementMixin],
+    // In vue/compat mode, INSTANCE_LISTENERS defaults to true and strips
+    // event listeners out of $attrs, breaking the v-bind="$attrs" forwarding below.
+    compatConfig: { INSTANCE_LISTENERS: false },
     inheritAttrs: false,
     props: {
         modelValue: {

--- a/packages/buefy/src/components/index.ts
+++ b/packages/buefy/src/components/index.ts
@@ -1,6 +1,8 @@
 /* eslint-disable import/first */
 import Autocomplete from './autocomplete'
 export * from './autocomplete'
+import Badge from './badge'
+export * from './badge'
 import Breadcrumb from './breadcrumb'
 export * from './breadcrumb'
 import Button from './button'
@@ -90,6 +92,7 @@ export * from './upload'
 // exports plugins of individual components for separate install
 export {
     Autocomplete,
+    Badge,
     Breadcrumb,
     Button,
     Carousel,
@@ -137,6 +140,7 @@ export {
 // exports an array of all the component plugins for batch install
 const allComponents = [
     Autocomplete,
+    Badge,
     Breadcrumb,
     Button,
     Carousel,

--- a/packages/buefy/src/components/input/Input.vue
+++ b/packages/buefy/src/components/input/Input.vue
@@ -111,6 +111,9 @@ import { useFormElementMixin } from '../../utils/FormElementMixin'
 export default defineComponent({
     name: 'BInput',
     components: { BIcon },
+    // In vue/compat mode, INSTANCE_LISTENERS defaults to true and strips
+    // event listeners out of $attrs, breaking the v-bind="fallthroughAttrs" forwarding below.
+    compatConfig: { INSTANCE_LISTENERS: false },
     mixins: [CompatFallthroughMixin, useFormElementMixin<HTMLInputElement | HTMLTextAreaElement>()],
     props: {
         modelValue: {

--- a/packages/buefy/src/components/menu/MenuItem.vue
+++ b/packages/buefy/src/components/menu/MenuItem.vue
@@ -50,6 +50,9 @@ type MenuInstance = InstanceType<typeof BMenu>
 
 export default defineComponent({
     name: 'BMenuItem',
+    // In vue/compat mode, INSTANCE_LISTENERS defaults to true and strips
+    // event listeners out of $attrs, breaking the v-bind="fallthroughAttrs" forwarding below.
+    compatConfig: { INSTANCE_LISTENERS: false },
     components: {
         BIcon
     },

--- a/packages/buefy/src/components/navbar/NavBarItem.spec.ts
+++ b/packages/buefy/src/components/navbar/NavBarItem.spec.ts
@@ -36,6 +36,14 @@ describe('BNavbarItem', () => {
         expect(wrapper.html()).toMatchSnapshot()
     })
 
+    // https://github.com/buefy/buefy/issues/4297
+    // Under vue/compat, INSTANCE_LISTENERS defaults to true and strips event
+    // listeners out of $attrs, silently breaking the v-bind="$attrs" forwarding
+    // used to attach @click to the rendered tag.
+    it('disables INSTANCE_LISTENERS compat so $attrs listeners still forward', () => {
+        expect(BNavbarItem.compatConfig).toEqual({ INSTANCE_LISTENERS: false })
+    })
+
     it('correctly renders the provided tag', async () => {
         await wrapper.setProps({ tag })
         expect(wrapper.find(tag).exists()).toBeTruthy()

--- a/packages/buefy/src/components/navbar/NavbarBurger.vue
+++ b/packages/buefy/src/components/navbar/NavbarBurger.vue
@@ -20,6 +20,9 @@ import { defineComponent } from 'vue'
 
 export default defineComponent({
     name: 'NavbarBurger',
+    // In vue/compat mode, INSTANCE_LISTENERS defaults to true and strips
+    // event listeners out of $attrs, breaking the v-bind="$attrs" forwarding above.
+    compatConfig: { INSTANCE_LISTENERS: false },
     props: {
         isOpened: {
             type: Boolean,

--- a/packages/buefy/src/components/navbar/NavbarDropdown.vue
+++ b/packages/buefy/src/components/navbar/NavbarDropdown.vue
@@ -48,6 +48,9 @@ import CompatFallthroughMixin from '../../utils/CompatFallthroughMixin'
 
 export default defineComponent({
     name: 'BNavbarDropdown',
+    // In vue/compat mode, INSTANCE_LISTENERS defaults to true and strips
+    // event listeners out of $attrs, breaking the v-bind="fallthroughAttrs" forwarding below.
+    compatConfig: { INSTANCE_LISTENERS: false },
     directives: {
         clickOutside
     },

--- a/packages/buefy/src/components/navbar/NavbarItem.vue
+++ b/packages/buefy/src/components/navbar/NavbarItem.vue
@@ -35,6 +35,9 @@ type NavbarItemParent = ComponentPublicInstance<
 
 export default defineComponent({
     name: 'BNavbarItem',
+    // In vue/compat mode, INSTANCE_LISTENERS defaults to true and strips
+    // event listeners out of $attrs, breaking the v-bind="$attrs" forwarding below.
+    compatConfig: { INSTANCE_LISTENERS: false },
     inheritAttrs: false,
     props: {
         tag: {

--- a/packages/buefy/src/components/notification/NotificationNotice.vue
+++ b/packages/buefy/src/components/notification/NotificationNotice.vue
@@ -45,6 +45,9 @@ type NotificationInstance = InstanceType<typeof BNotification>
 const NotificationNotice = defineComponent({
     name: 'BNotificationNotice',
     components: { BNotification },
+    // In vue/compat mode, INSTANCE_LISTENERS defaults to true and strips
+    // event listeners out of $attrs, breaking the v-bind="$attrs" forwarding above.
+    compatConfig: { INSTANCE_LISTENERS: false },
     mixins: [NoticeMixin],
     data() {
         return {

--- a/packages/buefy/src/components/numberinput/Numberinput.vue
+++ b/packages/buefy/src/components/numberinput/Numberinput.vue
@@ -117,6 +117,9 @@ export type ControlOperation = typeof CONTROL_OPERATIONS[number]
 
 export default defineComponent({
     name: 'BNumberinput',
+    // In vue/compat mode, INSTANCE_LISTENERS defaults to true and strips
+    // event listeners out of $attrs, breaking the v-bind="fallthroughAttrs" forwarding below.
+    compatConfig: { INSTANCE_LISTENERS: false },
     components: {
         BIcon,
         BInput

--- a/packages/buefy/src/components/pagination/PaginationButton.vue
+++ b/packages/buefy/src/components/pagination/PaginationButton.vue
@@ -23,6 +23,9 @@ import type { PaginationPage } from './types'
 
 export default defineComponent({
     name: 'BPaginationButton',
+    // In vue/compat mode, INSTANCE_LISTENERS defaults to true and strips
+    // event listeners out of $attrs, breaking the v-bind="$attrs" forwarding above.
+    compatConfig: { INSTANCE_LISTENERS: false },
     props: {
         page: {
             type: Object as PropType<PaginationPage>,

--- a/packages/buefy/src/components/select/Select.vue
+++ b/packages/buefy/src/components/select/Select.vue
@@ -54,6 +54,9 @@ export type ModelValue = any
 
 export default defineComponent({
     name: 'BSelect',
+    // In vue/compat mode, INSTANCE_LISTENERS defaults to true and strips
+    // event listeners out of $attrs, breaking the v-bind="fallthroughAttrs" forwarding below.
+    compatConfig: { INSTANCE_LISTENERS: false },
     components: {
         BIcon
     },

--- a/packages/buefy/src/components/slider/SliderThumb.vue
+++ b/packages/buefy/src/components/slider/SliderThumb.vue
@@ -45,6 +45,9 @@ import type { CustomFormatter, DisplayFormat, ISlider } from './types'
 
 export default defineComponent({
     name: 'BSliderThumb',
+    // In vue/compat mode, INSTANCE_LISTENERS defaults to true and strips
+    // event listeners out of $attrs, breaking the v-bind="fallthroughAttrs" forwarding below.
+    compatConfig: { INSTANCE_LISTENERS: false },
     components: {
         BTooltip
     },

--- a/packages/buefy/src/components/table/Table.vue
+++ b/packages/buefy/src/components/table/Table.vue
@@ -466,6 +466,9 @@ import type {
 
 export default defineComponent({
     name: 'BTable',
+    // In vue/compat mode, INSTANCE_LISTENERS defaults to true and strips
+    // event listeners out of $attrs, breaking the v-bind="fallthroughAttrs" forwarding below.
+    compatConfig: { INSTANCE_LISTENERS: false },
     components: {
         BCheckbox,
         BIcon,

--- a/packages/buefy/src/components/taginput/Taginput.vue
+++ b/packages/buefy/src/components/taginput/Taginput.vue
@@ -131,6 +131,9 @@ type U = any
 
 export default defineComponent({
     name: 'BTaginput',
+    // In vue/compat mode, INSTANCE_LISTENERS defaults to true and strips
+    // event listeners out of $attrs, breaking the v-bind="fallthroughAttrs" forwarding below.
+    compatConfig: { INSTANCE_LISTENERS: false },
     components: {
         BAutocomplete,
         BTag

--- a/packages/buefy/src/components/timepicker/Timepicker.vue
+++ b/packages/buefy/src/components/timepicker/Timepicker.vue
@@ -157,6 +157,9 @@ import BSelect from '../select/Select.vue'
 
 export default defineComponent({
     name: 'BTimepicker',
+    // In vue/compat mode, INSTANCE_LISTENERS defaults to true and strips
+    // event listeners out of $attrs, breaking the v-bind="fallthroughAttrs" forwarding below.
+    compatConfig: { INSTANCE_LISTENERS: false },
     components: {
         BInput,
         BField,

--- a/packages/buefy/src/components/upload/Upload.vue
+++ b/packages/buefy/src/components/upload/Upload.vue
@@ -47,6 +47,9 @@ import { File } from '../../utils/ssr'
 
 const Upload = defineComponent({
     name: 'BUpload',
+    // In vue/compat mode, INSTANCE_LISTENERS defaults to true and strips
+    // event listeners out of $attrs, breaking the v-bind="fallthroughAttrs" forwarding below.
+    compatConfig: { INSTANCE_LISTENERS: false },
     mixins: [CompatFallthroughMixin, useFormElementMixin<HTMLInputElement>()],
     props: {
         modelValue: {

--- a/packages/buefy/src/scss/buefy.scss
+++ b/packages/buefy/src/scss/buefy.scss
@@ -1,5 +1,6 @@
 @forward "utils/_all";
 @forward "components/_autocomplete";
+@forward "components/_badge";
 @forward "components/_carousel";
 @forward "components/_checkbox";
 @forward "components/_clockpicker";

--- a/packages/buefy/src/scss/components/_badge.scss
+++ b/packages/buefy/src/scss/components/_badge.scss
@@ -1,0 +1,53 @@
+@use "bulma/sass/utilities/initial-variables" as iv;
+@use "bulma/sass/utilities/css-variables" as cv;
+
+$badge-dot-size: 0.75em !default;
+$badge-z-index: 2 !default;
+
+.#{iv.$class-prefix}b-badge {
+    position: relative;
+    display: inline-flex;
+
+    @include cv.register-vars(
+        (
+            "badge-dot-size": #{$badge-dot-size},
+            "badge-z-index": #{$badge-z-index}
+        )
+    );
+
+    .b-badge-badge {
+        position: absolute;
+        z-index: cv.getVar("badge-z-index");
+        pointer-events: none;
+        white-space: nowrap;
+
+        &.is-top-right {
+            top: 0;
+            right: 0;
+            transform: translate(50%, -50%);
+        }
+        &.is-top-left {
+            top: 0;
+            left: 0;
+            transform: translate(-50%, -50%);
+        }
+        &.is-bottom-right {
+            bottom: 0;
+            right: 0;
+            transform: translate(50%, 50%);
+        }
+        &.is-bottom-left {
+            bottom: 0;
+            left: 0;
+            transform: translate(-50%, 50%);
+        }
+
+        &.is-dot {
+            width: cv.getVar("badge-dot-size");
+            height: cv.getVar("badge-dot-size");
+            min-width: 0;
+            padding: 0;
+            border-radius: 50%;
+        }
+    }
+}

--- a/packages/docs/src/data/menu.json
+++ b/packages/docs/src/data/menu.json
@@ -51,6 +51,7 @@
             "categoryIcon": "eye",
             "categoryColor": "success",
             "pages": [
+                "documentation/badge",
                 "documentation/carousel",
                 "documentation/collapse",
                 "documentation/icon",

--- a/packages/docs/src/data/routes.json
+++ b/packages/docs/src/data/routes.json
@@ -246,6 +246,19 @@
             "documentation/tag"
         ]
     },
+    "documentation/badge": {
+        "title": "Badge",
+        "subtitle": "Overlay a small badge on the corner of any content",
+        "path": "/documentation/badge",
+        "githubPath": "pages/components/badge/Badge.vue",
+        "menu": "documentation",
+        "breadcrumb": [
+            "/",
+            "documentation",
+            "documentation/badge"
+        ],
+        "isNew": true
+    },
     "documentation/tree": {
         "title": "Tree",
         "subtitle": "An extensible hierarchical tree component with lazy loading, checkbox tri-state, and full ARIA keyboard navigation",

--- a/packages/docs/src/pages/components/badge/Badge.vue
+++ b/packages/docs/src/pages/components/badge/Badge.vue
@@ -1,0 +1,79 @@
+<template>
+    <div>
+        <Example :component="ExSimple" :code="ExSimpleCode" vertical/>
+
+        <Example :component="ExDot" :code="ExDotCode" title="Dot indicator" vertical>
+            <p>Use the <code>dot</code> prop for a plain indicator with no content.</p>
+        </Example>
+
+        <Example :component="ExColors" :code="ExColorsCode" title="Colors" vertical/>
+
+        <Example :component="ExPositions" :code="ExPositionsCode" title="Positions" vertical>
+            <p>Use the <code>position</code> prop to overlay the badge on any of the four corners.</p>
+        </Example>
+
+        <Example :component="ExMax" :code="ExMaxCode" title="Overflow" vertical>
+            <p>Use the <code>max</code> prop to cap large numeric values, e.g. <code>150</code> becomes <code>99+</code>.</p>
+        </Example>
+
+        <Example :component="ExVisible" :code="ExVisibleCode" title="Hiding the badge" vertical>
+            <p>Use the <code>visible</code> prop to conditionally show or hide the badge.</p>
+        </Example>
+
+        <ApiView :data="api"/>
+    </div>
+</template>
+
+<script lang="ts">
+    import { defineComponent } from 'vue'
+
+    import { shallowFields } from '@/utils'
+    import ApiView from '@/components/ApiView.vue'
+    import Example from '@/components/Example.vue'
+
+    import api from './api/badge'
+
+    import ExSimple from './examples/ExSimple.vue'
+    import ExSimpleCode from './examples/ExSimple.vue?raw'
+
+    import ExDot from './examples/ExDot.vue'
+    import ExDotCode from './examples/ExDot.vue?raw'
+
+    import ExColors from './examples/ExColors.vue'
+    import ExColorsCode from './examples/ExColors.vue?raw'
+
+    import ExPositions from './examples/ExPositions.vue'
+    import ExPositionsCode from './examples/ExPositions.vue?raw'
+
+    import ExMax from './examples/ExMax.vue'
+    import ExMaxCode from './examples/ExMax.vue?raw'
+
+    import ExVisible from './examples/ExVisible.vue'
+    import ExVisibleCode from './examples/ExVisible.vue?raw'
+
+    export default defineComponent({
+        components: {
+            ApiView,
+            Example
+        },
+        data() {
+            return {
+                api,
+                ...shallowFields({
+                    ExSimple,
+                    ExDot,
+                    ExColors,
+                    ExPositions,
+                    ExMax,
+                    ExVisible
+                }),
+                ExSimpleCode,
+                ExDotCode,
+                ExColorsCode,
+                ExPositionsCode,
+                ExMaxCode,
+                ExVisibleCode
+            }
+        }
+    })
+</script>

--- a/packages/docs/src/pages/components/badge/api/badge.ts
+++ b/packages/docs/src/pages/components/badge/api/badge.ts
@@ -1,0 +1,85 @@
+export default [
+    {
+        title: 'Badge',
+        props: [
+            {
+                name: '<code>value</code>',
+                description: 'Badge content (number or text), optional',
+                type: 'String, Number',
+                values: '—',
+                default: '—'
+            },
+            {
+                name: '<code>type</code>',
+                description: 'Type (color) of the badge, optional',
+                type: 'String',
+                values: `<code>is-white</code>, <code>is-black</code>, <code>is-light</code>,
+                    <code>is-dark</code>, <code>is-primary</code>, <code>is-info</code>, <code>is-success</code>,
+                    <code>is-warning</code>, <code>is-danger</code>,
+                    and any other colors you've set in the <code>$colors</code> list on Sass`,
+                default: '—'
+            },
+            {
+                name: '<code>size</code>',
+                description: 'Size of the badge, optional',
+                type: 'String',
+                values: '<code>is-medium</code>, <code>is-large</code>',
+                default: '—'
+            },
+            {
+                name: '<code>rounded</code>',
+                description: 'Badge border rounded',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
+                name: '<code>position</code>',
+                description: 'Position of the badge relative to the wrapped content',
+                type: 'String',
+                values: '<code>is-top-right</code>, <code>is-top-left</code>, <code>is-bottom-right</code>, <code>is-bottom-left</code>',
+                default: '<code>is-top-right</code>'
+            },
+            {
+                name: '<code>dot</code>',
+                description: 'Renders a plain dot indicator instead of the <code>value</code> content',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>false</code>'
+            },
+            {
+                name: '<code>max</code>',
+                description: 'Caps a numeric <code>value</code>, showing e.g. <code>99+</code> when exceeded',
+                type: 'Number',
+                values: '—',
+                default: '—'
+            },
+            {
+                name: '<code>visible</code>',
+                description: 'Controls whether the badge is shown',
+                type: 'Boolean',
+                values: '—',
+                default: '<code>true</code>'
+            },
+            {
+                name: '<code>tag</code>',
+                description: 'Element to render as the wrapping container',
+                type: 'String',
+                values: '—',
+                default: '<code>div</code>'
+            }
+        ],
+        slots: [
+            {
+                name: 'default',
+                description: 'Anchor content the badge is overlaid on',
+                props: '—'
+            },
+            {
+                name: 'badge',
+                description: 'Custom badge content, overrides <code>value</code>',
+                props: '—'
+            }
+        ]
+    }
+]

--- a/packages/docs/src/pages/components/badge/examples/ExColors.vue
+++ b/packages/docs/src/pages/components/badge/examples/ExColors.vue
@@ -1,0 +1,33 @@
+<template>
+    <section>
+        <div class="badge-colors">
+            <b-badge value="1" type="is-primary">
+                <b-button>Primary</b-button>
+            </b-badge>
+            <b-badge value="2" type="is-success">
+                <b-button>Success</b-button>
+            </b-badge>
+            <b-badge value="3" type="is-danger">
+                <b-button>Danger</b-button>
+            </b-badge>
+            <b-badge value="4" type="is-warning">
+                <b-button>Warning</b-button>
+            </b-badge>
+            <b-badge value="5" type="is-info">
+                <b-button>Info</b-button>
+            </b-badge>
+        </div>
+    </section>
+</template>
+
+<script setup lang="ts">
+import { BBadge, BButton } from "buefy";
+</script>
+
+<style scoped>
+.badge-colors {
+    display: flex;
+    gap: 1.5em;
+    flex-wrap: wrap;
+}
+</style>

--- a/packages/docs/src/pages/components/badge/examples/ExDot.vue
+++ b/packages/docs/src/pages/components/badge/examples/ExDot.vue
@@ -1,0 +1,13 @@
+<template>
+    <section>
+        <b-field>
+            <b-badge dot type="is-danger">
+                <b-icon icon="bell" size="is-large" />
+            </b-badge>
+        </b-field>
+    </section>
+</template>
+
+<script setup lang="ts">
+import { BBadge, BField, BIcon } from "buefy";
+</script>

--- a/packages/docs/src/pages/components/badge/examples/ExMax.vue
+++ b/packages/docs/src/pages/components/badge/examples/ExMax.vue
@@ -1,0 +1,13 @@
+<template>
+    <section>
+        <b-field>
+            <b-badge :value="150" :max="99" type="is-danger">
+                <b-icon icon="bell" size="is-large" />
+            </b-badge>
+        </b-field>
+    </section>
+</template>
+
+<script setup lang="ts">
+import { BBadge, BField, BIcon } from "buefy";
+</script>

--- a/packages/docs/src/pages/components/badge/examples/ExPositions.vue
+++ b/packages/docs/src/pages/components/badge/examples/ExPositions.vue
@@ -1,0 +1,30 @@
+<template>
+    <section>
+        <div class="badge-positions">
+            <b-badge value="1" position="is-top-left">
+                <b-button>Top left</b-button>
+            </b-badge>
+            <b-badge value="2" position="is-top-right">
+                <b-button>Top right</b-button>
+            </b-badge>
+            <b-badge value="3" position="is-bottom-left">
+                <b-button>Bottom left</b-button>
+            </b-badge>
+            <b-badge value="4" position="is-bottom-right">
+                <b-button>Bottom right</b-button>
+            </b-badge>
+        </div>
+    </section>
+</template>
+
+<script setup lang="ts">
+import { BBadge, BButton } from "buefy";
+</script>
+
+<style scoped>
+.badge-positions {
+    display: flex;
+    gap: 1.5em;
+    flex-wrap: wrap;
+}
+</style>

--- a/packages/docs/src/pages/components/badge/examples/ExSimple.vue
+++ b/packages/docs/src/pages/components/badge/examples/ExSimple.vue
@@ -1,0 +1,13 @@
+<template>
+    <section>
+        <b-field>
+            <b-badge :value="3">
+                <b-icon icon="bell" size="is-large" />
+            </b-badge>
+        </b-field>
+    </section>
+</template>
+
+<script setup lang="ts">
+import { BBadge, BField, BIcon } from "buefy";
+</script>

--- a/packages/docs/src/pages/components/badge/examples/ExVisible.vue
+++ b/packages/docs/src/pages/components/badge/examples/ExVisible.vue
@@ -1,0 +1,20 @@
+<template>
+    <section>
+        <b-field>
+            <b-badge :value="count" :visible="count > 0" type="is-primary">
+                <b-icon icon="bell" size="is-large" />
+            </b-badge>
+        </b-field>
+        <b-field>
+            <b-button @click="count++">Add</b-button>
+            <b-button @click="count = 0">Clear</b-button>
+        </b-field>
+    </section>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { BBadge, BButton, BField, BIcon } from "buefy";
+
+const count = ref(0);
+</script>

--- a/packages/docs/src/pages/components/badge/variables/badge.ts
+++ b/packages/docs/src/pages/components/badge/variables/badge.ts
@@ -1,0 +1,14 @@
+export default [
+    {
+        sass: '<code>$badge-dot-size</code>',
+        css: '<code>--bulma-badge-dot-size</code>',
+        description: 'The diameter of the badge when <code>dot</code> is set',
+        default: '<code>0.75em</code>'
+    },
+    {
+        sass: '<code>$badge-z-index</code>',
+        css: '<code>--bulma-badge-z-index</code>',
+        description: 'The stacking order of the badge over its anchor content',
+        default: '<code>2</code>'
+    }
+]

--- a/packages/docs/src/router/index.ts
+++ b/packages/docs/src/router/index.ts
@@ -67,6 +67,7 @@ export function createDocsRouter(vueApp: App) {
                     route('documentation/tabs', () => import('@/pages/components/tabs/Tabs.vue')),
                     route('documentation/collapse', () => import('@/pages/components/collapse/Collapse.vue')),
                     route('documentation/tag', () => import('@/pages/components/tag/Tag.vue')),
+                    route('documentation/badge', () => import('@/pages/components/badge/Badge.vue')),
                     route('documentation/dialog', () => import('@/pages/components/dialog/Dialog.vue')),
                     route('documentation/toast', () => import('@/pages/components/toast/Toast.vue')),
                     route('documentation/snackbar', () => import('@/pages/components/snackbar/Snackbar.vue')),


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #4366 and [#4297](https://github.com/buefy/buefy/issues/4297)

## Proposed Changes

- Under vue/compat, the INSTANCE_LISTENERS compat flag defaults to true (emulating Vue 2's separate $listeners), which strips event listeners out of $attrs. Every component that manually forwards v-bind="$attrs" (or fallthroughAttrs from CompatFallthroughMixin) onto its root/native element depends on $attrs including listeners, so under compat mode consumer-attached listeners like @click were silently dropped instead of reaching the DOM.
- Set compatConfig: { INSTANCE_LISTENERS: false } directly on each affected component so listener forwarding works the same under vue/compat as it does under plain Vue 3. This must be declared per-component (Vue reads compatConfig from instance.type, not from merged mixin options), so it's added individually rather than centralized in CompatFallthroughMixin.
- Affected components: Button, NavbarItem, NavbarBurger, NavbarDropdown, Datetimepicker, NotificationNotice, PaginationButton, Input, Autocomplete, Select, Numberinput, Upload, Taginput, Datepicker, Timepicker, Clockpicker, Table, MenuItem, SliderThumb, BreadcrumbItem.
- Added a regression test in NavBarItem.spec.ts asserting the compat flag is set.


## AI Disclosure

- [X] This PR contains AI-generated code (see [Use of AI](.github/CONTRIBUTING.md#use-of-ai) in CONTRIBUTING.md)
